### PR TITLE
Fixed leftover in flight queries caused by sqlalchemy.get_columns()

### DIFF
--- a/impala/sqlalchemy.py
+++ b/impala/sqlalchemy.py
@@ -24,14 +24,18 @@ from sqlalchemy.types import (BOOLEAN, SMALLINT, BIGINT, TIMESTAMP, FLOAT,
 
 registry.register('impala', 'impala.sqlalchemy', 'ImpalaDialect')
 
+
 class TINYINT(Integer):
     __visit_name__ = 'TINYINT'
+
 
 class INT(Integer):
     __visit_name__ = 'INT'
 
+
 class DOUBLE(Float):
     __visit_name__ = 'DOUBLE'
+
 
 class STRING(String):
     __visit_name__ = 'STRING'
@@ -48,6 +52,7 @@ _impala_type_to_sqlalchemy_type = {
         'STRING': STRING,
         'DECIMAL': DECIMAL}
 
+
 class ImpalaDialect(DefaultDialect):
     name = 'impala'
     driver = 'impala'
@@ -61,34 +66,34 @@ class ImpalaDialect(DefaultDialect):
     supports_native_enum = False
     supports_default_values = False
     returns_unicode_strings = True
-    
+
     @classmethod
     def dbapi(self):
         import impala.dbapi
         return impala.dbapi
-    
+
     def initialize(self, connection):
         self.server_version_info = self._get_server_version_info(connection)
         self.default_schema_name = connection.connection.default_db
-    
+
     def _get_server_version_info(self, connection):
         raw = connection.execute('select version()').scalar()
         v = raw.split()[2]
         m = re.match('(\d{1,3})\.(\d{1,3})\.(\d{1,3}).*', v)
         return tuple([int(x) for x in m.group(1, 2, 3) if x is not None])
-    
+
     def has_table(self, connection, table_name, schema=None):
         tables = self.get_table_names(connection, schema)
         if table_name in tables:
             return True
         return False
-    
+
     def get_table_names(self, connection, schema=None, **kw):
         query = 'SHOW TABLES'
         if schema is not None:
             query += ' IN %s' % schema
         return [tup[0] for tup in connection.execute(query).fetchall()]
-    
+
     def get_columns(self, connection, table_name, schema=None, **kwargs):
         name = table_name
         if schema is not None:
@@ -96,6 +101,8 @@ class ImpalaDialect(DefaultDialect):
         query = 'SELECT * FROM %s LIMIT 0' % name
         cursor = connection.execute(query)
         schema = cursor.cursor.description
+        # We need to fetch the empty results otherwise these queries remain in flight
+        cursor.fetchall()
         column_info = []
         for col in schema:
             column_info.append({
@@ -104,20 +111,20 @@ class ImpalaDialect(DefaultDialect):
                 'nullable': True,
                 'autoincrement': False})
         return column_info
-    
+
     def get_pk_constraint(self, connection, table_name, schema=None, **kw):
         # no primary keys in impala
         return {'constrained_columns': [], 'name': None}
-    
+
     def get_foreign_keys(self, connection, table_name, schema=None, **kw):
         # no foreign keys in impala
         return []
-    
+
     def get_indexes(self, connection, table_name, schema=None, **kw):
         # no indexes in impala
         # TODO(laserson): handle partitions, like in PyHive
         return []
-    
+
     def do_rollback(self, dbapi_connection):
         # no transactions in impala
         pass


### PR DESCRIPTION
We need to call fetchall even when we have 0 rows
