### PR TITLE
Changed to use TBinaryProtocolAccelerated

### DIFF
--- a/impala/_rpc/beeswax.py
+++ b/impala/_rpc/beeswax.py
@@ -20,7 +20,7 @@ from impala._thrift_gen.ExecStats.ttypes import TExecStats
 
 from thrift.transport.TSocket import TSocket
 from thrift.transport.TTransport import TBufferedTransport, TTransportException
-from thrift.protocol.TBinaryProtocol import TBinaryProtocol
+from thrift.protocol.TBinaryProtocol import TBinaryProtocolAccelerated as TBinaryProtocol
 from thrift.Thrift import TApplicationException
 
 

--- a/impala/_rpc/hiveserver2.py
+++ b/impala/_rpc/hiveserver2.py
@@ -32,7 +32,7 @@ from decimal import Decimal
 
 from thrift.transport.TSocket import TSocket
 from thrift.transport.TTransport import TBufferedTransport, TTransportException
-from thrift.protocol.TBinaryProtocol import TBinaryProtocol
+from thrift.protocol.TBinaryProtocol import TBinaryProtocolAccelerated as TBinaryProtocol
 
 from impala.error import HiveServer2Error
 from impala._thrift_gen.TCLIService.ttypes import (TOpenSessionReq,


### PR DESCRIPTION
If we switch to the TBinaryProtocolAccelerated we should be capable of deserializing the thrift messages from hiveserver2 / beeswas faster.

In the current implementation of the python thrift libraries if the C module that provides the speedup is not available this will be identical to before.
