### PR TITLE
connection error in SQLalchemy due to version string regex mismatch

### DIFF
--- a/impala/sqlalchemy.py
+++ b/impala/sqlalchemy.py
@@ -118,7 +118,7 @@ class ImpalaDialect(DefaultDialect):
     def _get_server_version_info(self, connection):
         raw = connection.execute('select version()').scalar()
         v = raw.split()[2]
-        m = re.match('(\d{1,3})\.(\d{1,3})\.(\d{1,3}).*', v)
+        m = re.match('.*?(\d{1,3})\.(\d{1,3})\.(\d{1,3}).*', v)
         return tuple([int(x) for x in m.group(1, 2, 3) if x is not None])
 
     def has_table(self, connection, table_name, schema=None):


### PR DESCRIPTION
version string regex in [`sqlalchemy._get_server_version_info`](https://github.com/cloudera/impyla/blob/master/impala/sqlalchemy.py#L121) did not fully capture Impala version string (e.g. 'cdh5-1.3.0'). CDH version prefix was not covered.

Please note: this is just a minimal fix. I think there should be some exception handling since the version extraction as is seems to be quite brittle.
