### PR TITLE
Add decimal precision and scale to HS2 cursor description

### DIFF
--- a/impala/_rpc/hiveserver2.py
+++ b/impala/_rpc/hiveserver2.py
@@ -245,9 +245,17 @@ def get_result_schema(service, operation_handle):
     schema = []
     for column in resp.schema.columns:
         name = column.columnName
-        type_ = TTypeId._VALUES_TO_NAMES[
-            column.typeDesc.types[0].primitiveEntry.type].split('_')[0]
-        schema.append((name, type_))
+        entry = column.typeDesc.types[0].primitiveEntry
+        type_ = TTypeId._VALUES_TO_NAMES[entry.type].split('_')[0]
+        if type_ == 'DECIMAL':
+            qualifiers = entry.typeQualifiers.qualifiers
+            precision = qualifiers['precision'].i32Value
+            scale = qualifiers['scale'].i32Value
+            schema.append((name, type_, None, None,
+                           precision, scale, None))
+        else:
+            schema.append((name, type_, None, None, None, None, None))
+
 
     return schema
 

--- a/impala/dbapi/hiveserver2.py
+++ b/impala/dbapi/hiveserver2.py
@@ -158,10 +158,9 @@ class HiveServer2Cursor(Cursor):
         self._last_operation_active = True
         self._wait_to_finish()  # make execute synchronous
         if self.has_result_set:
-            schema = rpc.get_result_schema(
-                self.service, self._last_operation_handle)
-            self._description = [tup + (None, None, None, None, None)
-                                 for tup in schema]
+            schema = rpc.get_result_schema(self.service,
+                                           self._last_operation_handle)
+            self._description = schema
 
     def _reset_state(self):
         self._buffer = []


### PR DESCRIPTION
Not being a Thrift expert, there might be a less hackish way to get at the precision/scale values in the RPC request. 