### PR TITLE
ImpalaContext and BigDataFrame cleanups

### DIFF
--- a/impala/context.py
+++ b/impala/context.py
@@ -72,10 +72,7 @@ class ImpalaContext(object):
         # drop the temp dir in HDFS
         try:
             from requests.exceptions import ConnectionError
-            from pywebhdfs.webhdfs import PyWebHdfsClient
-            hdfs_client = PyWebHdfsClient(
-                host=self._nn_host, port=self._webhdfs_port,
-                user_name=self._hdfs_user)
+            hdfs_client = self.hdfs_client()
             hdfs_client.delete_file_dir(self._temp_dir.lstrip('/'),
                                         recursive=True)
         except ImportError:
@@ -88,3 +85,9 @@ class ImpalaContext(object):
             sys.stderr.write("Could not connect via pywebhdfs. "
                              "You must delete the temporary directory "
                              "manually: %s" % self._temp_dir)
+
+    def hdfs_client(self):
+        from pywebhdfs.webhdfs import PyWebHdfsClient
+        return PyWebHdfsClient(
+            host=self._nn_host, port=self._webhdfs_port,
+            user_name=self._hdfs_user)

--- a/impala/tests/conftest.py
+++ b/impala/tests/conftest.py
@@ -126,9 +126,8 @@ def hdfs_client(ic):
     pywebhdfs = importorskip('pywebhdfs')
     if ic._nn_host is None:
         skip("NAMENODE_HOST not set; skipping...")
-    from pywebhdfs.webhdfs import PyWebHdfsClient
-    hdfs_client = PyWebHdfsClient(host=ic._nn_host, port=ic._webhdfs_port,
-                                  user_name=ic._hdfs_user)
+
+    hdfs_client = ic.hdfs_client()
     return hdfs_client
 
 

--- a/impala/tests/test_bdf.py
+++ b/impala/tests/test_bdf.py
@@ -70,9 +70,7 @@ def test_from_pandas_in_query(ic):
 def test_from_pandas_webhdfs(ic):
     df1 = pd.DataFrame({'a': (1, 2, 5), 'b': ('foo', 'bar', 'pasta')})
     path = os.path.join(ic._temp_dir, 'test_pandas_webhdfs_dir')
-    bdf = from_pandas(ic, df1, method='webhdfs', path=path,
-                      hdfs_host=ic._nn_host, webhdfs_port=ic._webhdfs_port,
-                      hdfs_user=ic._hdfs_user)
+    bdf = from_pandas(ic, df1, method='webhdfs', path=path)
     df2 = bdf.collect()
     assert tuple(df2.columns) == ('a', 'b')
     assert df2.shape == df1.shape

--- a/impala/udf/__init__.py
+++ b/impala/udf/__init__.py
@@ -81,7 +81,6 @@ udf_to_impala_type = {'BooleanVal': 'BOOLEAN',
                       'TimestampVal': 'TIMESTAMP'}
 
 try:
-    from pywebhdfs.webhdfs import PyWebHdfsClient
 
     def ship_udf(ic, function, hdfs_path=None, udf_name=None, database=None,
                  overwrite=False):
@@ -95,8 +94,7 @@ try:
                      for arg in function.signature.args[1:]]
 
         # ship the IR to the cluster
-        hdfs_client = PyWebHdfsClient(host=ic._nn_host, port=ic._webhdfs_port,
-                                      user_name=ic._hdfs_user)
+        hdfs_client = ic.hdfs_client()
         if hdfs_path is None:
             hdfs_path = os.path.join(ic._temp_dir, udf_name + '.ll')
         if not hdfs_path.endswith('.ll'):


### PR DESCRIPTION
Added utility method to ImpalaContext to get the webdfs client.

Added a store_managed method to a BigDataFrame.  Previously it was not possibly to use store to create a managed table from a big dataframe, since path was a required argument.