### PR TITLE
Add support for configuring authentication mechanisms (required for H…

### DIFF
--- a/impala/_rpc/beeswax.py
+++ b/impala/_rpc/beeswax.py
@@ -21,8 +21,9 @@ from six.moves import map
 from six.moves import range
 
 from impala.error import RPCError, QueryStateError, DisconnectedError
+from impala._rpc import thrift_util
 from impala._thrift_api.beeswax import (
-    TSocket, TBufferedTransport, TTransportException, TBinaryProtocol,
+    TTransportException, TBinaryProtocol,
     TApplicationException, BeeswaxService, ImpalaService, TStatus, TStatusCode,
     TExecStats, ThriftClient)
 
@@ -169,28 +170,16 @@ def build_summary_table(summary, idx, is_fragment_root, indent_level, output):
     return idx
 
 
-def _get_socket(host, port, use_ssl, ca_cert):
-    # based on the Impala shell impl
-    if use_ssl:
-        from thrift.transport.TSSLSocket import TSSLSocket
-        if ca_cert is None:
-            return TSSLSocket(host, port, validate=False)
-        else:
-            return TSSLSocket(host, port, validate=True, ca_certs=ca_cert)
-    else:
-        return TSocket(host, port)
-
-
 def connect_to_impala(host, port, timeout=45, use_ssl=False, ca_cert=None,
-                      use_ldap=False, ldap_user=None, ldap_password=None,
-                      use_kerberos=False, kerberos_service_name='impala'):
-    sock = _get_socket(host, port, use_ssl, ca_cert)
+                      username=None, password=None, kerberos_service_name='impala',
+                      auth_mechanism=None):
+    sock = thrift_util.get_socket(host, port, use_ssl, ca_cert)
     if six.PY2:
         sock.setTimeout(timeout * 1000.)
     elif six.PY3:
         sock.set_timeout(timeout * 1000.)
-    transport = _get_transport(sock, host, use_ldap, ldap_user, ldap_password,
-                               use_kerberos, kerberos_service_name)
+    transport = thrift_util.get_transport(sock, host, kerberos_service_name, auth_mechanism,
+        username, password)
     transport.open()
     protocol = TBinaryProtocol(transport)
     if six.PY2:
@@ -207,32 +196,6 @@ def connect_to_impala(host, port, timeout=45, use_ssl=False, ca_cert=None,
 def ping(service):
     result = service.PingImpalaService()
     return result.version
-
-
-def _get_transport(sock, host, use_ldap, ldap_user, ldap_password,
-                   use_kerberos, kerberos_service_name):
-    # based on the Impala shell impl
-    if not use_ldap and not use_kerberos:
-        return TBufferedTransport(sock)
-    
-    import sasl
-    from impala.thrift_sasl import TSaslClientTransport
-
-    def sasl_factory():
-        sasl_client = sasl.Client()
-        sasl_client.setAttr("host", host)
-        if use_ldap:
-            sasl_client.setAttr("username", ldap_user)
-            sasl_client.setAttr("password", ldap_password)
-        else:
-            sasl_client.setAttr("service", kerberos_service_name)
-        sasl_client.init()
-        return sasl_client
-
-    if use_kerberos:
-        return TSaslClientTransport(sasl_factory, "GSSAPI", sock)
-    else:
-        return TSaslClientTransport(sasl_factory, "PLAIN", sock)
 
 
 def close_service(service):

--- a/impala/_rpc/hiveserver2.py
+++ b/impala/_rpc/hiveserver2.py
@@ -35,8 +35,9 @@ from decimal import Decimal
 from six.moves import range
 
 from impala.error import HiveServer2Error
+from impala._rpc import thrift_util
 from impala._thrift_api.hiveserver2 import (
-    TSocket, TBufferedTransport, TTransportException, TBinaryProtocol,
+    TTransportException, TBinaryProtocol,
     TOpenSessionReq, TFetchResultsReq, TCloseSessionReq, TExecuteStatementReq,
     TGetInfoReq, TGetInfoType, TTypeId, TFetchOrientation,
     TGetResultSetMetadataReq, TStatusCode, TGetColumnsReq, TGetSchemasReq,
@@ -145,54 +146,16 @@ def retry(func):
     return wrapper
 
 
-def _get_socket(host, port, use_ssl, ca_cert):
-    # based on the Impala shell impl
-    if use_ssl:
-        from thrift.transport.TSSLSocket import TSSLSocket
-        if ca_cert is None:
-            return TSSLSocket(host, port, validate=False)
-        else:
-            return TSSLSocket(host, port, validate=True, ca_certs=ca_cert)
-    else:
-        return TSocket(host, port)
-
-
-def _get_transport(sock, host, use_ldap, ldap_user, ldap_password,
-                   use_kerberos, kerberos_service_name):
-    # based on the Impala shell impl
-    if not use_ldap and not use_kerberos:
-        return TBufferedTransport(sock)
-
-    import sasl
-    from impala.thrift_sasl import TSaslClientTransport
-
-    def sasl_factory():
-        sasl_client = sasl.Client()
-        sasl_client.setAttr("host", host)
-        if use_ldap:
-            sasl_client.setAttr("username", ldap_user)
-            sasl_client.setAttr("password", ldap_password)
-        else:
-            sasl_client.setAttr("service", kerberos_service_name)
-        sasl_client.init()
-        return sasl_client
-
-    if use_kerberos:
-        return TSaslClientTransport(sasl_factory, "GSSAPI", sock)
-    else:
-        return TSaslClientTransport(sasl_factory, "PLAIN", sock)
-
-
 def connect_to_impala(host, port, timeout=45, use_ssl=False, ca_cert=None,
-                      use_ldap=False, ldap_user=None, ldap_password=None,
-                      use_kerberos=False, kerberos_service_name='impala'):
-    sock = _get_socket(host, port, use_ssl, ca_cert)
+                      username=None, password=None, kerberos_service_name='impala',
+                      auth_mechanism=None):
+    sock = thrift_util.get_socket(host, port, use_ssl, ca_cert)
     if six.PY2:
         sock.setTimeout(timeout * 1000.)
     elif six.PY3:
         sock.set_timeout(timeout * 1000.)
-    transport = _get_transport(sock, host, use_ldap, ldap_user, ldap_password,
-                               use_kerberos, kerberos_service_name)
+    transport = thrift_util.get_transport(sock, host, kerberos_service_name, auth_mechanism,
+        username, password)
     transport.open()
     protocol = TBinaryProtocol(transport)
     if six.PY2:

--- a/impala/_rpc/thrift_util.py
+++ b/impala/_rpc/thrift_util.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+# Copyright (c) 2012 Cloudera, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Thrift utility functions
+
+from thrift.transport.TSocket import TSocket
+from thrift.transport.TTransport import TBufferedTransport
+import getpass
+import sasl
+
+def get_socket(host, port, use_ssl, ca_cert):
+    # based on the Impala shell impl
+    if use_ssl:
+        from thrift.transport.TSSLSocket import TSSLSocket
+        if ca_cert is None:
+            return TSSLSocket(host, port, validate=False)
+        else:
+            return TSSLSocket(host, port, validate=True, ca_certs=ca_cert)
+    else:
+        return TSocket(host, port)
+
+
+def get_transport(socket, host, kerberos_service_name, auth_mechanism="NOSASL",
+                  user=None, password=None):
+    """Creates a new Thrift Transport using the specified auth_mechanism.
+    Supported auth_mechanisms are:
+    - None or NOSASL - returns simple buffered transport (default)
+    - PLAIN  - returns a SASL transport with the PLAIN mechanism
+    - GSSAPI - returns a SASL transport with the GSSAPI mechanism
+    """
+    if not auth_mechanism or auth_mechanism.upper() == "NOSASL":
+        return TBufferedTransport(socket)
+
+    # Set defaults for PLAIN SASL / LDAP connections.
+    if auth_mechanism.upper() in ['LDAP', 'PLAIN']:
+        if user is None: user = getpass.getuser()
+        if password is None:
+            if auth_mechanism.upper() == 'LDAP':
+                password = ''
+            else:
+                # PLAIN always requires a password for HS2.
+                password = 'password'
+
+    # Initializes a sasl client
+    import sasl
+    from impala.thrift_sasl import TSaslClientTransport
+    def sasl_factory():
+        sasl_client = sasl.Client()
+        sasl_client.setAttr("host", host)
+        sasl_client.setAttr("service", kerberos_service_name)
+        if auth_mechanism.upper() in ["PLAIN", "LDAP"]:
+            sasl_client.setAttr("username", user)
+            sasl_client.setAttr("password", password)
+        sasl_client.init()
+        return sasl_client
+    return TSaslClientTransport(sasl_factory, auth_mechanism.upper(), socket)

--- a/impala/dbapi/__init__.py
+++ b/impala/dbapi/__init__.py
@@ -33,21 +33,42 @@ apilevel = '2.0'
 threadsafety = 1  # Threads may share the module, but not connections
 paramstyle = 'pyformat'
 
-
 def connect(host='localhost', port=21050, protocol='hiveserver2',
             database=None, timeout=45, use_ssl=False, ca_cert=None,
             use_ldap=False, ldap_user=None, ldap_password=None,
-            use_kerberos=False, kerberos_service_name='impala'):
+            use_kerberos=False, kerberos_service_name='impala',
+            auth_mechanism=None):
+
+    # Supported authentication mechanisms
+    auth_mechanisms = ['NOSASL', 'PLAIN', 'GSSAPI', 'LDAP']
+    if use_kerberos:
+        if auth_mechanism and auth_mechanism.upper() != 'GSSAPI':
+            raise ValueError("Kerberos requires authentication mechanism 'GSSAPI'")
+        else:
+            auth_mechanism = 'GSSAPI'
+
+    if use_ldap:
+        if auth_mechanism and auth_mechanism.upper() != 'LDAP':
+            raise ValueError("LDAP requires authentication mechanism 'LDAP'")
+        else:
+            auth_mechanism = 'LDAP'
+
+    # If not specified, authentication mechanism defaults to NOSASL
+    if not auth_mechanism: auth_mechanism = 'NOSASL'
+
+    if auth_mechanism.upper() not in auth_mechanisms:
+        raise NotSupportedError('Unsupported authentication mechanism: %s' % mechanism)
+
     # PEP 249
     if protocol.lower() == 'beeswax':
         service = connect_to_beeswax(
-            host, port, timeout, use_ssl, ca_cert, use_ldap, ldap_user,
-            ldap_password, use_kerberos, kerberos_service_name)
+            host, port, timeout, use_ssl, ca_cert, ldap_user,
+            ldap_password, kerberos_service_name, auth_mechanism)
         return BeeswaxConnection(service, default_db=database)
     elif protocol.lower() == 'hiveserver2':
         service = connect_to_hiveserver2(
-            host, port, timeout, use_ssl, ca_cert, use_ldap, ldap_user,
-            ldap_password, use_kerberos, kerberos_service_name)
+            host, port, timeout, use_ssl, ca_cert, ldap_user,
+            ldap_password, kerberos_service_name, auth_mechanism)
         return HiveServer2Connection(service, default_db=database)
     else:
         raise NotSupportedError(


### PR DESCRIPTION
…ive)

Hive's default transport is PLAIN SASL where Impala does not use SASL. Impala and Impyla
support supported PLAIN SASL, but only for LDAP connections. This change updates Impyla
to allow the authentication mechanism to be specified as part of the connect() call.

For example, connections to Hive can be made using:
conn = connect(host='host', port=10000, auth_mechanism='PLAIN')

The valid values for auth_mechanism are:
- LDAP - Uses plain SASL, but there are some differences in how passwords are handled.
- PLAIN - Authenticate using plain SASL
- GSSAPI - Authenticate using SASL with GSSAPI (Kerberos)
- NOSASL - Don't use sasl.

auth_mechanism is optional and if it is not specifieid the default stays will be the same
as it is today - NOSASL. Support for the use_kerberos / use_ldap flags also is allowed
in which case the mechanism will be set to the appropriate value.

As part of this change there was a bunch of duplication between Beeswax and HS2 so this
fixes that problem by putting the common code in a thrift_util module.