### PR TITLE
Add support for configuring authentication mechanisms (required for H…

### DIFF
--- a/impala/_rpc/beeswax.py
+++ b/impala/_rpc/beeswax.py
@@ -21,8 +21,9 @@ from six.moves import map
 from six.moves import range
 
 from impala.error import RPCError, QueryStateError, DisconnectedError
+from impala._thrift_api import (
+    get_socket, get_transport, TTransportException, TBinaryProtocol)
 from impala._thrift_api.beeswax import (
-    TSocket, TBufferedTransport, TTransportException, TBinaryProtocol,
     TApplicationException, BeeswaxService, ImpalaService, TStatus, TStatusCode,
     TExecStats, ThriftClient)
 
@@ -169,28 +170,16 @@ def build_summary_table(summary, idx, is_fragment_root, indent_level, output):
     return idx
 
 
-def _get_socket(host, port, use_ssl, ca_cert):
-    # based on the Impala shell impl
-    if use_ssl:
-        from thrift.transport.TSSLSocket import TSSLSocket
-        if ca_cert is None:
-            return TSSLSocket(host, port, validate=False)
-        else:
-            return TSSLSocket(host, port, validate=True, ca_certs=ca_cert)
-    else:
-        return TSocket(host, port)
-
-
 def connect_to_impala(host, port, timeout=45, use_ssl=False, ca_cert=None,
-                      use_ldap=False, ldap_user=None, ldap_password=None,
-                      use_kerberos=False, kerberos_service_name='impala'):
-    sock = _get_socket(host, port, use_ssl, ca_cert)
+                      user=None, password=None, kerberos_service_name='impala',
+                      auth_mechanism=None):
+    sock = get_socket(host, port, use_ssl, ca_cert)
     if six.PY2:
         sock.setTimeout(timeout * 1000.)
     elif six.PY3:
         sock.set_timeout(timeout * 1000.)
-    transport = _get_transport(sock, host, use_ldap, ldap_user, ldap_password,
-                               use_kerberos, kerberos_service_name)
+    transport = get_transport(sock, host, kerberos_service_name, auth_mechanism,
+                              user, password)
     transport.open()
     protocol = TBinaryProtocol(transport)
     if six.PY2:
@@ -207,32 +196,6 @@ def connect_to_impala(host, port, timeout=45, use_ssl=False, ca_cert=None,
 def ping(service):
     result = service.PingImpalaService()
     return result.version
-
-
-def _get_transport(sock, host, use_ldap, ldap_user, ldap_password,
-                   use_kerberos, kerberos_service_name):
-    # based on the Impala shell impl
-    if not use_ldap and not use_kerberos:
-        return TBufferedTransport(sock)
-    
-    import sasl
-    from thrift_sasl import TSaslClientTransport
-
-    def sasl_factory():
-        sasl_client = sasl.Client()
-        sasl_client.setAttr("host", host)
-        if use_ldap:
-            sasl_client.setAttr("username", ldap_user)
-            sasl_client.setAttr("password", ldap_password)
-        else:
-            sasl_client.setAttr("service", kerberos_service_name)
-        sasl_client.init()
-        return sasl_client
-
-    if use_kerberos:
-        return TSaslClientTransport(sasl_factory, "GSSAPI", sock)
-    else:
-        return TSaslClientTransport(sasl_factory, "PLAIN", sock)
 
 
 def close_service(service):

--- a/impala/_thrift_api/__init__.py
+++ b/impala/_thrift_api/__init__.py
@@ -15,3 +15,81 @@
 # This package is here to clean up references to thrift, because we're using
 # thriftpy for Py3 at the moment.  This should all be temporary, as Apache
 # Thrift gains Py3 compatibility.
+
+import os
+import sys
+import six
+import getpass
+
+
+if six.PY2:
+    # import Apache Thrift code
+    from thrift.transport.TSocket import TSocket
+    from thrift.transport.TTransport import (
+        TBufferedTransport, TTransportException)
+    from thrift.protocol.TBinaryProtocol import (
+        TBinaryProtocolAccelerated as TBinaryProtocol)
+
+
+if six.PY3:
+    # import thriftpy code
+    # TODO: reenable cython
+    # from thriftpy.protocol import TBinaryProtocol
+    from thriftpy import load
+    from thriftpy.protocol.binary import TBinaryProtocol
+    from thriftpy.transport import TSocket, TTransportException
+    # TODO: reenable cython
+    # from thriftpy.transport import TBufferedTransport
+    from thriftpy.transport.buffered import TBufferedTransport
+    thrift_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)),
+                              'thrift')
+
+
+def get_socket(host, port, use_ssl, ca_cert):
+    # based on the Impala shell impl
+    if use_ssl:
+        from thrift.transport.TSSLSocket import TSSLSocket
+        if ca_cert is None:
+            return TSSLSocket(host, port, validate=False)
+        else:
+            return TSSLSocket(host, port, validate=True, ca_certs=ca_cert)
+    else:
+        return TSocket(host, port)
+
+
+def get_transport(socket, host, kerberos_service_name, auth_mechanism='NOSASL',
+                  user=None, password=None):
+    """
+    Creates a new Thrift Transport using the specified auth_mechanism.
+    Supported auth_mechanisms are:
+    - None or 'NOSASL' - returns simple buffered transport (default)
+    - 'PLAIN'  - returns a SASL transport with the PLAIN mechanism
+    - 'GSSAPI' - returns a SASL transport with the GSSAPI mechanism
+    """
+    if auth_mechanism == 'NOSASL':
+        return TBufferedTransport(socket)
+
+    # Set defaults for PLAIN SASL / LDAP connections.
+    if auth_mechanism in ['LDAP', 'PLAIN']:
+        if user is None:
+            user = getpass.getuser()
+        if password is None:
+            if auth_mechanism == 'LDAP':
+                password = ''
+            else:
+                # PLAIN always requires a password for HS2.
+                password = 'password'
+
+    # Initializes a sasl client
+    import sasl
+    from thrift_sasl import TSaslClientTransport
+    def sasl_factory():
+        sasl_client = sasl.Client()
+        sasl_client.setAttr('host', host)
+        sasl_client.setAttr('service', kerberos_service_name)
+        if auth_mechanism.upper() in ['PLAIN', 'LDAP']:
+            sasl_client.setAttr('username', user)
+            sasl_client.setAttr('password', password)
+        sasl_client.init()
+        return sasl_client
+    return TSaslClientTransport(sasl_factory, auth_mechanism, socket)

--- a/impala/_thrift_api/beeswax.py
+++ b/impala/_thrift_api/beeswax.py
@@ -19,10 +19,6 @@ import six
 
 if six.PY2:
     # import Apache Thrift code
-    from thrift.transport.TSocket import TSocket
-    from thrift.transport.TTransport import TBufferedTransport, TTransportException
-    from thrift.protocol.TBinaryProtocol import (
-        TBinaryProtocolAccelerated as TBinaryProtocol)
     from thrift.Thrift import TApplicationException
 
     # import beeswax codegen objects
@@ -38,17 +34,9 @@ if six.PY3:
     # import thriftpy code
     from thriftpy import load
     from thriftpy.thrift import TClient, TApplicationException
-    # TODO: reenable cython
-    # from thriftpy.protocol import TBinaryProtocol
-    from thriftpy.protocol.binary import TBinaryProtocol
-    from thriftpy.transport import TSocket, TTransportException
-    # TODO: reenable cython
-    # from thriftpy.transport import TBufferedTransport
-    from thriftpy.transport.buffered import TBufferedTransport
 
     # dynamically load the beeswax modules
-    thrift_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)),
-                              'thrift')
+    from impala._thrift_api import thrift_dir
     ExecStats = load(os.path.join(thrift_dir, 'ExecStats.thrift'),
                      include_dirs=[thrift_dir])
     Status = load(os.path.join(thrift_dir, 'Status.thrift'),

--- a/impala/_thrift_api/hiveserver2.py
+++ b/impala/_thrift_api/hiveserver2.py
@@ -18,13 +18,6 @@ import six
 
 
 if six.PY2:
-    # import Apache Thrift code
-    from thrift.transport.TSocket import TSocket
-    from thrift.transport.TTransport import (
-        TBufferedTransport, TTransportException)
-    from thrift.protocol.TBinaryProtocol import (
-        TBinaryProtocolAccelerated as TBinaryProtocol)
-
     # import HS2 codegen objects
     from impala._thrift_gen.TCLIService.ttypes import (
         TOpenSessionReq, TFetchResultsReq, TCloseSessionReq,
@@ -44,17 +37,9 @@ if six.PY3:
     # import thriftpy code
     from thriftpy import load
     from thriftpy.thrift import TClient
-    # TODO: reenable cython
-    # from thriftpy.protocol import TBinaryProtocol
-    from thriftpy.protocol.binary import TBinaryProtocol
-    from thriftpy.transport import TSocket, TTransportException
-    # TODO: reenable cython
-    # from thriftpy.transport import TBufferedTransport
-    from thriftpy.transport.buffered import TBufferedTransport
 
     # dynamically load the HS2 modules
-    thrift_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)),
-                              'thrift')
+    from impala._thrift_api import thrift_dir
     ExecStats = load(os.path.join(thrift_dir, 'ExecStats.thrift'),
                      include_dirs=[thrift_dir])
     TCLIService = load(os.path.join(thrift_dir, 'TCLIService.thrift'),
@@ -66,7 +51,6 @@ if six.PY3:
     sys.modules[ImpalaService.__name__] = ImpalaService
 
     # import the HS2 objects
-    from ExecStats import TExecStats
     from TCLIService import (
         TOpenSessionReq, TFetchResultsReq, TCloseSessionReq,
         TExecuteStatementReq, TGetInfoReq, TGetInfoType, TTypeId,
@@ -76,4 +60,5 @@ if six.PY3:
         TCloseOperationReq, TGetLogReq, TProtocolVersion)
     from ImpalaService import (
         TGetRuntimeProfileReq, TGetExecSummaryReq, ImpalaHiveServer2Service)
+    from ExecStats import TExecStats
     ThriftClient = TClient

--- a/impala/util.py
+++ b/impala/util.py
@@ -109,3 +109,11 @@ def warn_deprecate_ibis(functionality='This'):
            "in a future release; please see the Ibis project instead: "
            "http://ibis-project.org/".format(functionality))
     warnings.warn(msg, Warning)
+
+
+def warn_deprecate(functionality='This', alternative=None):
+    msg = ("{0} functionality in impyla is now deprecated and will be removed "
+           "in a future release".format(functionality))
+    if alternative:
+        msg += "; Please use {0} instead.".format(alternative)
+    warnings.warn(msg, Warning)


### PR DESCRIPTION
…ive)

Hive's default transport is PLAIN SASL where Impala does not use SASL. Impala and Impyla
support supported PLAIN SASL, but only for LDAP connections. This change updates Impyla
to allow the authentication mechanism to be specified as part of the connect() call.

For example, connections to Hive can be made using:
conn = connect(host='host', port=10000, auth_mechanism='PLAIN')

The valid values for auth_mechanism are:
- LDAP - Uses plain SASL, but there are some differences in how passwords are handled.
- PLAIN - Authenticate using plain SASL
- GSSAPI - Authenticate using SASL with GSSAPI (Kerberos)
- NOSASL - Don't use sasl.

auth_mechanism is optional and if it is not specifieid the default stays will be the same
as it is today - NOSASL. Support for the use_kerberos / use_ldap flags also is allowed
in which case the mechanism will be set to the appropriate value.

As part of this change there was a bunch of duplication between Beeswax and HS2 so this
fixes that problem by putting the common code in a thrift_util module.