### PR TITLE
Pulling sasl dependency as part of building Impyla

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ PY3 = sys.version_info[0] == 3
 
 # Apache Thrift does not yet support Python 3 (see THRIFT-1857).  We use
 # thriftpy as a stopgap replacement
-reqs = ['six', 'thrift_sasl', 'bitarray']
+reqs = ['six', 'thrift_sasl', 'bitarray', 'sasl']
 packages = find_packages(exclude=['impala._thrift_gen',
                                   'impala._thrift_gen.*'])
 if PY2:


### PR DESCRIPTION
This will pull down sasl as one of the dependencies for Impyla. That way users don't have to do extra steps to satisfy this dependency.


Successfully built Impyla with Systest:

```
Processing dependencies for setuptools
Finished processing dependencies for setuptools
if /Users/vamsee/Cloudera/OtherProjects/cmf/systest/target/env/bin/python -c "$PIP_VERSION_GREATER_THAN" 1.4; then \
		/Users/vamsee/Cloudera/OtherProjects/cmf/systest/target/env/bin/python /Users/vamsee/Cloudera/OtherProjects/cmf/systest/target/env/bin/pip install \
			--no-index --process-dependency-links \
			-e git://github.com/vamseeyarla/impyla.git@342f16c64346fbc953315eb7304e3d72a2f3b624#egg=impyla-1.0; \
	else \
		/Users/vamsee/Cloudera/OtherProjects/cmf/systest/target/env/bin/python /Users/vamsee/Cloudera/OtherProjects/cmf/systest/target/env/bin/pip install \
			-e git://github.com/vamseeyarla/impyla.git@342f16c64346fbc953315eb7304e3d72a2f3b624#egg=impyla-1.0; \
	fi; \
	touch /Users/vamsee/Cloudera/OtherProjects/cmf/systest/target/impyla.stamp
Obtaining impyla from git+git://github.com/vamseeyarla/impyla.git@342f16c64346fbc953315eb7304e3d72a2f3b624#egg=impyla-1.0
  Cloning git://github.com/vamseeyarla/impyla.git (to 342f16c64346fbc953315eb7304e3d72a2f3b624) to ./target/env/src/impyla
  Could not find a tag or branch '342f16c64346fbc953315eb7304e3d72a2f3b624', assuming commit.
  Running setup.py egg_info for package impyla
    /System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'install_package_data'
      warnings.warn(msg)
    
Requirement already satisfied (use --upgrade to upgrade): six in ./target/env/lib/python2.7/site-packages (from impyla)
Downloading/unpacking thrift-sasl (from impyla)
  Downloading thrift_sasl-0.1.0.tar.gz
  Running setup.py egg_info for package thrift-sasl
    
Downloading/unpacking bitarray (from impyla)
  Downloading bitarray-0.8.1.tar.gz (46kB): 46kB downloaded
  Running setup.py egg_info for package bitarray
    
Downloading/unpacking sasl (from impyla)
  Downloading sasl-0.1.3.tar.gz
  Running setup.py egg_info for package sasl
    
Requirement already satisfied (use --upgrade to upgrade): thrift in ./target/env/lib/python2.7/site-packages/thrift-0.8.0-py2.7-macosx-10.10-intel.egg (from impyla)
Installing collected packages: impyla, thrift-sasl, bitarray, sasl
  Running setup.py develop for impyla
    /System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'install_package_data'
      warnings.warn(msg)
    
    Creating /Users/vamsee/Cloudera/OtherProjects/cmf/systest/target/env/lib/python2.7/site-packages/impyla.egg-link (link to .)
    Adding impyla 0.11.0.dev0 to easy-install.pth file
    Installing register-impala-udfs.py script to /Users/vamsee/Cloudera/OtherProjects/cmf/systest/target/env/bin
    
    Installed /Users/vamsee/Cloudera/OtherProjects/cmf/systest/target/env/src/impyla
  Running setup.py install for thrift-sasl
    
  Running setup.py install for bitarray
    building 'bitarray._bitarray' extension
    cc -fno-strict-aliasing -fno-common -dynamic -arch x86_64 -arch i386 -g -Os -pipe -fno-common -fno-strict-aliasing -fwrapv -DENABLE_DTRACE -DMACOSX -DNDEBUG -Wall -Wstrict-prototypes -Wshorten-64-to-32 -DNDEBUG -g -fwrapv -Os -Wall -Wstrict-prototypes -DENABLE_DTRACE -arch x86_64 -arch i386 -pipe -I/System/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7 -c bitarray/_bitarray.c -o build/temp.macosx-10.10-intel-2.7/bitarray/_bitarray.o
    bitarray/_bitarray.c:533:21: warning: implicit conversion loses integer precision: 'long' to 'int' [-Wshorten-64-to-32]
        setbit(self, i, vi);
        ~~~~~~          ^~
    bitarray/_bitarray.c:976:25: warning: implicit conversion loses integer precision: 'long' to 'int' [-Wshorten-64-to-32]
        i = findfirst(self, vi, start, stop);
            ~~~~~~~~~       ^~
    bitarray/_bitarray.c:1806:25: warning: implicit conversion loses integer precision: 'long' to 'int' [-Wshorten-64-to-32]
        i = findfirst(self, vi, 0, -1);
            ~~~~~~~~~       ^~
    3 warnings generated.
    cc -bundle -undefined dynamic_lookup -arch x86_64 -arch i386 -Wl,-F. build/temp.macosx-10.10-intel-2.7/bitarray/_bitarray.o -o build/lib.macosx-10.10-intel-2.7/bitarray/_bitarray.so
    
  Running setup.py install for sasl
    
    building '_saslwrapper' extension
    cc -fno-strict-aliasing -fno-common -dynamic -arch x86_64 -arch i386 -g -Os -pipe -fno-common -fno-strict-aliasing -fwrapv -DENABLE_DTRACE -DMACOSX -DNDEBUG -Wall -Wstrict-prototypes -Wshorten-64-to-32 -DNDEBUG -g -fwrapv -Os -Wall -Wstrict-prototypes -DENABLE_DTRACE -arch x86_64 -arch i386 -pipe -Isasl -I/System/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7 -c sasl/saslwrapper.cpp -o build/temp.macosx-10.10-intel-2.7/sasl/saslwrapper.o
    sasl/saslwrapper.cpp:227:60: warning: implicit conversion loses integer precision: 'size_type' (aka 'unsigned long') to 'unsigned int' [-Wshorten-64-to-32]
            result = sasl_client_step(conn, challenge.c_str(), challenge.size(), &prompt, &resp, &len);
                     ~~~~~~~~~~~~~~~~                          ^~~~~~~~~~~~~~~~
    sasl/saslwrapper.cpp:244:55: warning: implicit conversion loses integer precision: 'size_type' (aka 'unsigned long') to 'unsigned int' [-Wshorten-64-to-32]
        int result = sasl_encode(conn, clearText.c_str(), clearText.size(), &output, &outlen);
                     ~~~~~~~~~~~                          ^~~~~~~~~~~~~~~~
    sasl/saslwrapper.cpp:256:26: warning: implicit conversion loses integer precision: 'size_type' (aka 'unsigned long') to 'unsigned int' [-Wshorten-64-to-32]
        unsigned int inLen = cipherText.size();
                     ~~~~~   ^~~~~~~~~~~~~~~~~
    sasl/saslwrapper.cpp:341:11: warning: unused variable 'input' [-Wunused-variable]
        char* input;
              ^
    sasl/saslwrapper.cpp:356:19: warning: implicit conversion loses integer precision: 'size_type' (aka 'unsigned long') to 'unsigned int' [-Wshorten-64-to-32]
        prompt->len = output.length();
                    ~ ^~~~~~~~~~~~~~~
    5 warnings generated.
    sasl/saslwrapper.cpp:341:11: warning: unused variable 'input' [-Wunused-variable]
        char* input;
              ^
    1 warning generated.
    cc -fno-strict-aliasing -fno-common -dynamic -arch x86_64 -arch i386 -g -Os -pipe -fno-common -fno-strict-aliasing -fwrapv -DENABLE_DTRACE -DMACOSX -DNDEBUG -Wall -Wstrict-prototypes -Wshorten-64-to-32 -DNDEBUG -g -fwrapv -Os -Wall -Wstrict-prototypes -DENABLE_DTRACE -arch x86_64 -arch i386 -pipe -Isasl -I/System/Library/Frameworks/Python.framework/Versions/2.7/include/python2.7 -c sasl/saslwrapper_wrap.cxx -o build/temp.macosx-10.10-intel-2.7/sasl/saslwrapper_wrap.o
    sasl/saslwrapper_wrap.cxx:2062:11: warning: explicitly assigning value of variable of type 'int' to itself [-Wself-assign]
                        res = SWIG_AddCast(res);
                        ~~~ ^              ~~~
    sasl/saslwrapper_wrap.cxx:2065:11: warning: explicitly assigning value of variable of type 'int' to itself [-Wself-assign]
                        res = SWIG_AddCast(res);
                        ~~~ ^              ~~~
    sasl/saslwrapper_wrap.cxx:4579:14: warning: explicitly assigning value of variable of type 'void *' to itself [-Wself-assign]
      clientdata = clientdata;
      ~~~~~~~~~~ ^ ~~~~~~~~~~
    3 warnings generated.
    sasl/saslwrapper_wrap.cxx:2062:11: warning: explicitly assigning value of variable of type 'int' to itself [-Wself-assign]
                        res = SWIG_AddCast(res);
                        ~~~ ^              ~~~
    sasl/saslwrapper_wrap.cxx:2065:11: warning: explicitly assigning value of variable of type 'int' to itself [-Wself-assign]
                        res = SWIG_AddCast(res);
                        ~~~ ^              ~~~
    sasl/saslwrapper_wrap.cxx:4579:14: warning: explicitly assigning value of variable of type 'void *' to itself [-Wself-assign]
      clientdata = clientdata;
      ~~~~~~~~~~ ^ ~~~~~~~~~~
    3 warnings generated.
    c++ -bundle -undefined dynamic_lookup -arch x86_64 -arch i386 -Wl,-F. build/temp.macosx-10.10-intel-2.7/sasl/saslwrapper.o build/temp.macosx-10.10-intel-2.7/sasl/saslwrapper_wrap.o -lsasl2 -o build/lib.macosx-10.10-intel-2.7/_saslwrapper.so
Successfully installed impyla thrift-sasl bitarray sasl
```