### PR TITLE
[IMPYLA-128] Eliminate default socket timeout

### DIFF
--- a/impala/beeswax.py
+++ b/impala/beeswax.py
@@ -452,14 +452,16 @@ def build_summary_table(summary, idx, is_fragment_root, indent_level, output):
     return idx
 
 
-def connect(host, port, timeout=45, use_ssl=False, ca_cert=None,
+def connect(host, port, timeout=None, use_ssl=False, ca_cert=None,
             user=None, password=None, kerberos_service_name='impala',
             auth_mechanism=None):
     sock = get_socket(host, port, use_ssl, ca_cert)
+    if timeout is not None:
+        timeout = timeout * 1000.  # TSocket expects millis
     if six.PY2:
-        sock.setTimeout(timeout * 1000.)
+        sock.setTimeout(timeout)
     elif six.PY3:
-        sock.set_timeout(timeout * 1000.)
+        sock.set_timeout(timeout)
     transport = get_transport(sock, host, kerberos_service_name,
                               auth_mechanism, user, password)
     transport.open()

--- a/impala/dbapi.py
+++ b/impala/dbapi.py
@@ -40,7 +40,7 @@ paramstyle = 'pyformat'
 
 
 def connect(host='localhost', port=21050, protocol=None,
-            database=None, timeout=45, use_ssl=False, ca_cert=None,
+            database=None, timeout=None, use_ssl=False, ca_cert=None,
             auth_mechanism='NOSASL', user=None, password=None,
             kerberos_service_name='impala', use_ldap=None, ldap_user=None,
             ldap_password=None, use_kerberos=None):

--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -571,16 +571,18 @@ def retry(func):
     return wrapper
 
 
-def connect(host, port, timeout=45, use_ssl=False, ca_cert=None,
+def connect(host, port, timeout=None, use_ssl=False, ca_cert=None,
             user=None, password=None, kerberos_service_name='impala',
             auth_mechanism=None):
     log.info('Connecting to HiveServer2 %s:%s with %s authentication '
              'mechanism', host, port, auth_mechanism)
     sock = get_socket(host, port, use_ssl, ca_cert)
+    if timeout is not None:
+        timeout = timeout * 1000.  # TSocket expects millis
     if six.PY2:
-        sock.setTimeout(timeout * 1000.)
+        sock.setTimeout(timeout)
     elif six.PY3:
-        sock.set_timeout(timeout * 1000.)
+        sock.set_timeout(timeout)
     transport = get_transport(sock, host, kerberos_service_name,
                               auth_mechanism, user, password)
     transport.open()


### PR DESCRIPTION
Socket has no timeout now by default.

Fixes #128.