### PR TITLE
Make setup.py compatible with older versions of setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,9 +36,7 @@ reqs = ['six', 'thrift_sasl', 'bitarray']
 packages = find_packages(exclude=['impala._thrift_gen',
                                   'impala._thrift_gen.*'])
 if PY2:
-    apache_thrift_pkgs = find_packages(include=['impala._thrift_gen',
-                                                'impala._thrift_gen.*'])
-    packages.extend(apache_thrift_pkgs)
+    packages = find_packages()  # This time including apache thrift packages
     reqs.append('thrift')
 elif PY3:
     reqs.append('thriftpy')


### PR DESCRIPTION
This patch makes it possible to install `impyla` with older versions of `setuptools` (versions which didn't have `include` keyword in `find_packages` method). Installation logic remains unchanged.

Although a relatively new version of `setuptools` (`3.4.4`) is explicitly installed in the beginning of `setup.py`, on systems where `setuptools` is installed via `.deb` package, the latter will be used, since it's higher in the system hierarchy (and it can be pretty old).