### PR TITLE
Call close_operation() during cursor.close()

### DIFF
--- a/impala/beeswax.py
+++ b/impala/beeswax.py
@@ -133,7 +133,12 @@ class BeeswaxCursor(Cursor):
 
     def close(self):
         # PEP 249
-        pass
+        # If an operation is active and isn't closed before the session is
+        # closed, then the server will cancel the operation upon closing
+        # the session. Cancellation could be problematic for some DDL
+        # operations. This avoids requiring the user to call the non-PEP 249
+        # close_operation().
+        self.close_operation()
 
     def cancel_operation(self):
         if self._last_operation_active:

--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -167,6 +167,13 @@ class HiveServer2Cursor(Cursor):
 
     def close(self):
         # PEP 249
+        # If an operation is active and isn't closed before the session is
+        # closed, then the server will cancel the operation upon closing
+        # the session. Cancellation could be problematic for some DDL
+        # operations. This avoids requiring the user to call the non-PEP 249
+        # close_operation().
+        self.close_operation()
+
         log.info('Closing HiveServer2Cursor')
         close_session(self.service, self.session_handle)
 


### PR DESCRIPTION
If the operation isn't closed, the server will cancel the operation
which could abort a DDL op.