### PR TITLE
Refactor HS2 code to encapsulate client, session, and operation handles

### DIFF
--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -757,9 +757,11 @@ class ThriftRPC(object):
         return self._get_operation(resp.operationHandle)
 
     def _log_request(self, kind, request):
-        log.debug('{0}: req={1!s}'.format(kind, request))
+        # pylint: disable=logging-format-interpolation
+        log.debug('%s: req={1!s}'.format(kind, request))
 
     def _log_response(self, kind, response):
+        # pylint: disable=logging-format-interpolation
         log.debug('{0}: resp={1!s}'.format(kind, response))
 
 
@@ -801,6 +803,7 @@ class HS2Session(ThriftRPC):
 
     def __init__(self, service, handle, config, hs2_protocol_version,
                  retries=3):
+        # pylint: disable=protected-access
         self.service = service
         self.handle = handle
         self.config = config

--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -758,7 +758,7 @@ class ThriftRPC(object):
 
     def _log_request(self, kind, request):
         # pylint: disable=logging-format-interpolation
-        log.debug('%s: req={1!s}'.format(kind, request))
+        log.debug('{0}: req={1!s}'.format(kind, request))
 
     def _log_response(self, kind, response):
         # pylint: disable=logging-format-interpolation

--- a/impala/interface.py
+++ b/impala/interface.py
@@ -44,7 +44,7 @@ class Connection(object):
         # PEP 249
         raise NotImplementedError
 
-    def cursor(self, user=None, configuration=None):
+    def cursor(self, user=None, configuration=None, convert_types=True):
         # PEP 249
         raise NotImplementedError
 

--- a/impala/interface.py
+++ b/impala/interface.py
@@ -44,7 +44,7 @@ class Connection(object):
         # PEP 249
         raise NotImplementedError
 
-    def cursor(self, session_handle=None, user=None, configuration=None):
+    def cursor(self, user=None, configuration=None):
         # PEP 249
         raise NotImplementedError
 


### PR DESCRIPTION
Created wrapper classes for each of the thrift handle types to simplify code and reduce the need for parameter wrangling. 

In particular, there is now:

- 1 RPC code path
- 1 logging code path

I will also address #151 here. There will be a companion Ibis PR