### PR TITLE
Pass async arg so that we're actually async

### DIFF
--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -218,7 +218,8 @@ class HiveServer2Cursor(Cursor):
                 self._last_operation_string = operation
 
             op = self.session.execute(self._last_operation_string,
-                                      configuration)
+                                      configuration,
+                                      async=True)
             self._last_operation = op
 
         self._execute_async(op)


### PR DESCRIPTION
This will fix #157, but as noted in the ticket the two methods I was trying to call fail regardless of whether the query is being executed async or not.