### PR TITLE
fix keyerror when fetching complex types data

### DIFF
--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -501,6 +501,10 @@ _TTypeId_to_TColumnValue_getters = {
     'BINARY': operator.attrgetter('binaryVal'),
     'VARCHAR': operator.attrgetter('stringVal'),
     'CHAR': operator.attrgetter('stringVal'),
+    'MAP': operator.attrgetter('stringVal'),
+    'ARRAY': operator.attrgetter('stringVal'),
+    'STRUCT': operator.attrgetter('stringVal'),
+    'UNIONTYPE': operator.attrgetter('stringVal'),
 }
 
 _pre_columnar_protocols = [


### PR DESCRIPTION
When fetching the complex types data, this method will raise KeyError Exception.
```python
tcols = [_TTypeId_to_TColumnValue_getters[schema[i][1]](col)
                 for (i, col) in enumerate(resp.results.columns)]
```