### PR TITLE
Fix KeyError when fetching DATE type.

### DIFF
--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -566,6 +566,7 @@ _TTypeId_to_TColumnValue_getters = {
     'ARRAY': operator.attrgetter('stringVal'),
     'STRUCT': operator.attrgetter('stringVal'),
     'UNIONTYPE': operator.attrgetter('stringVal'),
+    'DATE': operator.attrgetter('stringVal')
 }
 
 _pre_columnar_protocols = [


### PR DESCRIPTION
Analogically to https://github.com/cloudera/impyla/pull/162
It's preferable to get string representation of DATE type rather than KeyError.