### PR TITLE
Update to require thriftpy>=0.3.5, bump version to 0.13.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ Required:
 
 For Hive and/or Kerberos support:
 
-* `thrift_sasl`
-
-* `python-sasl` (for Python 3.x support, requires
-  [cloudera/python-sasl@cython][python-sasl-cython] branch)
+```
+pip install thrift_sasl
+pip install sasl
+```
 
 Optional:
 

--- a/jenkins/run-dbapi.sh
+++ b/jenkins/run-dbapi.sh
@@ -91,7 +91,7 @@ which python
 if [ $IMPYLA_TEST_AUTH_MECH != "NOSASL" ]; then
     # Hive and Kerberos all need sasl installed
     sudo yum install -y cyrus-sasl-devel
-    pip install git+https://github.com/laserson/python-sasl.git@cython
+    pip install sasl
 fi
 
 if [ $IMPYLA_TEST_AUTH_MECH = "GSSAPI" -o $IMPYLA_TEST_AUTH_MECH = "LDAP" ]; then

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ PY3 = sys.version_info[0] == 3
 
 # Apache Thrift does not yet support Python 3 (see THRIFT-1857).  We use
 # thriftpy as a stopgap replacement
-reqs = ['six', 'thrift_sasl', 'bitarray']
+reqs = ['six', 'thrift_sasl', 'bitarray', 'sasl>=0.2.1']
 if PY2:
     packages = find_packages()
     reqs.append('thrift')

--- a/setup.py
+++ b/setup.py
@@ -39,12 +39,12 @@ if PY2:
 elif PY3:
     packages = find_packages(exclude=['impala._thrift_gen',
                                       'impala._thrift_gen.*'])
-    reqs.append('thriftpy')
+    reqs.append('thriftpy>=0.3.5')
 
 
 setup(
     name='impyla',
-    version='0.14.0.dev0',
+    version='0.13.2',
     description='Python client for the Impala distributed query engine',
     long_description=readme(),
     author='Uri Laserson',


### PR DESCRIPTION
Should close #173. Will merge and make release when I get a passing Jenkins build. 