### PR TITLE
Fix SQLAlchemy connector to work with Hive

### DIFF
--- a/impala/sqlalchemy.py
+++ b/impala/sqlalchemy.py
@@ -132,7 +132,6 @@ class ImpalaDialect(DefaultDialect):
         return impala.dbapi
 
     def initialize(self, connection):
-        self.server_version_info = self._get_server_version_info(connection)
         self.default_schema_name = connection.connection.default_db
 
     def _get_server_version_info(self, connection):


### PR DESCRIPTION
Removed default execution of `select version()`, this causes a failure in Hive as the `version()` function does not exist in Hive.

I have tested and verified that this change fixes SQLAlchemy connection for Hive.