### PR TITLE
BUG: ensure replaced strings are not included in subsequent find/replaces

### DIFF
--- a/impala/interface.py
+++ b/impala/interface.py
@@ -188,9 +188,14 @@ def _replace_numeric_markers(operation, string_parameters):
     def replace_markers(marker, op, parameters):
         param_count = len(parameters)
         marker_index = 0
-        while op.find(marker) > -1:
+        start_offset = 0
+        while True:
+            found_offset = op.find(marker, start_offset)
+            if not found_offset > -1:
+                break
             if marker_index < param_count:
-                op = op.replace(marker, parameters[marker_index], 1)
+                op = op[:found_offset]+op[found_offset:].replace(marker, parameters[marker_index], 1)
+                start_offset = found_offset + len(parameters[marker_index])
                 marker_index += 1
             else:
                 raise ProgrammingError("Incorrect number of bindings "

--- a/impala/tests/test_query_parameters.py
+++ b/impala/tests/test_query_parameters.py
@@ -257,3 +257,8 @@ def test_bad_argument_type():
         _bind_parameters("select * from test", 1)
     with raises(ProgrammingError):
         _bind_parameters("select * from test", "a")
+
+def test_marker_replacement():
+    dt("select * from test where x = '%s'",
+       "select * from test where x = %s",
+       [r'%s'])


### PR DESCRIPTION
Otherwise have fun trying to insert a string that has '%s' or '?' in it.

Closes #208 