### PR TITLE
Return detailed Error Messages from query failures

### DIFF
--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -312,12 +312,17 @@ class HiveServer2Cursor(Cursor):
     def _wait_to_finish(self):
         loop_start = time.time()
         while True:
-            operation_state = self._last_operation.get_status()
+            req = TGetOperationStatusReq(operationHandle=self._last_operation.handle)
+            resp = self._last_operation._rpc('GetOperationStatus', req)
+            operation_state = TOperationState._VALUES_TO_NAMES[resp.operationState]
 
             log.debug('_wait_to_finish: waited %s seconds so far',
                       time.time() - loop_start)
             if self._op_state_is_error(operation_state):
-                raise OperationalError("Operation is in ERROR_STATE")
+                if resp.errorMessage:
+                    raise OperationalError(resp.errorMessage)
+                else:
+                    raise OperationalError("Operation is in ERROR_STATE")
             if not self._op_state_is_executing(operation_state):
                 break
             time.sleep(self._get_sleep_interval(loop_start))


### PR DESCRIPTION
Allow the usage of the errorMessage field from the GetOperationStatus command in an exception on impala 2.7+ where IMPALA-1633 has been implemented. This will fix issue #200.

Below commit would provide this functionality for existing impala versions but has the side effect of  invalidating the query handle and breaking subsequent calls to get_log which users may rely on for extra information after a query failure.
https://github.com/schaffino/impyla/commit/cea034545611127945114e8d57d1bc122e8db1ba