### PR TITLE
Logging function get_log() works for Hive

### DIFF
--- a/impala/_thrift_api.py
+++ b/impala/_thrift_api.py
@@ -37,6 +37,7 @@ if six.PY2:
     from thrift.transport.TSocket import TSocket
     from thrift.transport.TTransport import (
         TBufferedTransport, TTransportException)
+    from thrift.Thrift import TApplicationException
     from thrift.protocol.TBinaryProtocol import (
         TBinaryProtocolAccelerated as TBinaryProtocol)
 
@@ -58,7 +59,7 @@ if six.PY2:
 if six.PY3:
     # import thriftpy code
     from thriftpy import load
-    from thriftpy.thrift import TClient
+    from thriftpy.thrift import TClient, TApplicationException
     # TODO: reenable cython
     # from thriftpy.protocol import TBinaryProtocol
     from thriftpy.protocol.binary import TBinaryProtocol  # noqa
@@ -105,7 +106,7 @@ def get_socket(host, port, use_ssl, ca_cert):
                 return TSSLSocket(host, port, validate=False)
             else:
                 return TSSLSocket(host, port, validate=True, ca_certs=ca_cert)
-        else:    
+        else:
             from thriftpy.transport.sslsocket import TSSLSocket
             if ca_cert is None:
                 return TSSLSocket(host, port, validate=False)

--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -1018,7 +1018,7 @@ class Operation(ThriftRPC):
             resp = self._rpc('FetchResults', req)
             schema = [('Log', 'STRING', None, None, None, None, None)]
             log = self._wrap_results(resp.results, schema, convert_types=True)
-            log = '\n'.join([l[0] for l in log])
+            log = '\n'.join(l[0] for l in log)
         return log
 
     def cancel(self):

--- a/impala/thrift/TCLIService.thrift
+++ b/impala/thrift/TCLIService.thrift
@@ -1056,7 +1056,8 @@ struct TFetchResultsReq {
   // the rowset.
   3: required i64 maxRows
 
-  // Specify the fetchType for retrieval of logs use 1
+  // The type of a fetch results request.
+  // 0 represents Query output. 1 represents Log. 
   4: optional i16 fetchType
 }
 

--- a/impala/thrift/TCLIService.thrift
+++ b/impala/thrift/TCLIService.thrift
@@ -1057,7 +1057,7 @@ struct TFetchResultsReq {
   3: required i64 maxRows
 
   // Specify the fetchType for retrieval of logs use 1
-  4: optional i32 fetchType
+  4: optional i16 fetchType
 }
 
 struct TFetchResultsResp {

--- a/impala/thrift/TCLIService.thrift
+++ b/impala/thrift/TCLIService.thrift
@@ -1055,6 +1055,9 @@ struct TFetchResultsReq {
   // Max number of rows that should be returned in
   // the rowset.
   3: required i64 maxRows
+
+  // Specify the fetchType for retrieval of logs use 1
+  4: optional i32 fetchType
 }
 
 struct TFetchResultsResp {


### PR DESCRIPTION
Right now if you connect with impyla to Hive and issue the ``get_log()`` method on a cursor, you get:

> thriftpy.thrift.TApplicationException: Invalid method name: 'GetLog'

This is due to the fact that Hive uses another API for the retrieval of logs as answered in this [stackoverflow question](http://stackoverflow.com/questions/32530086/how-realtime-capture-logs-of-query-from-hiveserver2-with-python-client). 
This PR solves the issue by implementing and calling the necessary Hive log API when you run ``get_log()`` and solves the issues #160 and #161 as well as the remaining bits of #200 (scroll down).

