### PR TITLE
Forces thriftpy be 0.3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ if PY2:
 elif PY3:
     packages = find_packages(exclude=['impala._thrift_gen',
                                       'impala._thrift_gen.*'])
-    reqs.append('thriftpy>=0.3.5')
+    reqs.append('thriftpy==0.3.5')
 
 
 setup(


### PR DESCRIPTION
Because impyla crashes when thriftpy version is greater than 0.3.5.
```
    from impala.dbapi import connect
  File "/usr/local/lib/python3.4/dist-packages/impala/dbapi.py", line 28, in <module>
    import impala.hiveserver2 as hs2
  File "/usr/local/lib/python3.4/dist-packages/impala/hiveserver2.py", line 32, in <module>
    from impala._thrift_api import (
  File "/usr/local/lib/python3.4/dist-packages/impala/_thrift_api.py", line 60, in <module>
    from thriftpy import load
ImportError: cannot import name 'load'
```