### PR TITLE
BUG: Fix nulls bug introduced in #221

### DIFF
--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -805,6 +805,7 @@ class Column(object):
         self.values = values
         self.nulls = nulls
         self.rows_left = len(self.values)
+        self.num_rows = self.rows_left
 
     def __len__(self):
         return self.rows_left
@@ -815,11 +816,13 @@ class Column(object):
 
     def pop(self):
         if self.rows_left < 1:
-            raise StopIteration 
-        isnull = self.nulls[-self.rows_left]
-        value = self.values[-self.rows_left]
+            raise StopIteration
+        pos = self.num_rows-self.rows_left
         self.rows_left -= 1
-        return None if isnull else value
+        if self.nulls[pos]:
+           return None
+        value = self.values[pos]
+        return value
 
 
 class CBatch(Batch):

--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -21,6 +21,7 @@ import datetime
 import socket
 import operator
 import re
+import sys
 from six.moves import range
 from bitarray import bitarray
 
@@ -167,7 +168,14 @@ class HiveServer2Cursor(Cursor):
         self._closed = False
 
     def __del__(self):
-        self.close()
+        try:
+           self.close_operation()
+        except Exception:
+            pass
+        try:
+           self.session.close()
+        except Exception:
+            pass
 
     @property
     def description(self):
@@ -222,12 +230,29 @@ class HiveServer2Cursor(Cursor):
         # the session. Cancellation could be problematic for some DDL
         # operations. This avoids requiring the user to call the non-PEP 249
         # close_operation().
-        self.close_operation()
+        exc_info = None
+        try:
+            self.close_operation()
+        except Exception:
+            exc_info = sys.exc_info()
 
         log.debug('Closing HiveServer2Cursor')
+        try:
+            self.session.close()
+        except Exception:
+            # If we encountered an error when closing the session
+            # then print operation close exception to logs and 
+            # raise the session close exception
+            if exc_info:
+                log.error('Failure encountered closing last operation.',
+                                                        exc_info=exc_info)
+            raise
 
-        self.session.close()
         self._closed = True
+        # If there was an error when closing last operation then
+        # raise exception
+        if exc_info:
+            raise exc_info[1], None, exc_info[2]
 
     def cancel_operation(self):
         if self._last_operation_active:

--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -252,7 +252,7 @@ class HiveServer2Cursor(Cursor):
         # If there was an error when closing last operation then
         # raise exception
         if exc_info:
-            raise exc_info[1], None, exc_info[2]
+            six.reraise(*exc_info)
 
     def cancel_operation(self):
         if self._last_operation_active:


### PR DESCRIPTION
*   Previous changes for #221 introduced a bug with NULLS when using hive due too NULL bitarray having more values than rows to be fetched and using negative indexing. Changed to index from front to avoid the issue.

*   Close in __del__ for cursor was outputting error messages in some situations where a query handle had been invalidated. Converted to best effort, ignoring any exceptions. Not sure if having a __del__ method is advisable recommend, though it is a good fallback. Explicit closing should be done as necessary. We could add context manager functionality to the cursor for easier use.

* When operation handles are invalid (timeouts, query killed through UI), session would not get closed due to thrown exception.