### PR TITLE
Pin Python thrift at <= 0.9.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ PY3 = sys.version_info[0] == 3
 reqs = ['six', 'bitarray']
 if PY2:
     packages = find_packages()
-    reqs.append('thrift')
+    reqs.append('thrift<=0.9.3')
 elif PY3:
     packages = find_packages(exclude=['impala._thrift_gen',
                                       'impala._thrift_gen.*'])


### PR DESCRIPTION
[thrift 0.10.0](https://pypi.python.org/pypi/thrift/0.10.0) package has a breaking change, closes https://github.com/cloudera/impyla/issues/235.

Currently installing `impyla` will require user to manually downgrade thrift to 0.9.3. This PR prohibits thrift 0.10.0 from being installed. 