### PR TITLE
add support for optional krb_host parameter in connection

### DIFF
--- a/impala/dbapi.py
+++ b/impala/dbapi.py
@@ -41,7 +41,7 @@ def connect(host='localhost', port=21050, database=None, timeout=None,
             use_ssl=False, ca_cert=None, auth_mechanism='NOSASL', user=None,
             password=None, kerberos_service_name='impala', use_ldap=None,
             ldap_user=None, ldap_password=None, use_kerberos=None,
-            protocol=None):
+            protocol=None, krb_host=None):
     """Get a connection to HiveServer2 (HS2).
 
     These options are largely compatible with the impala-shell command line
@@ -144,7 +144,7 @@ def connect(host='localhost', port=21050, database=None, timeout=None,
                           timeout=timeout, use_ssl=use_ssl,
                           ca_cert=ca_cert, user=user, password=password,
                           kerberos_service_name=kerberos_service_name,
-                          auth_mechanism=auth_mechanism)
+                          auth_mechanism=auth_mechanism, krb_host=krb_host)
     return hs2.HiveServer2Connection(service, default_db=database)
 
 

--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -738,10 +738,16 @@ def threaded(func):
 
 def connect(host, port, timeout=None, use_ssl=False, ca_cert=None,
             user=None, password=None, kerberos_service_name='impala',
-            auth_mechanism=None):
+            auth_mechanism=None, krb_host=None):
     log.debug('Connecting to HiveServer2 %s:%s with %s authentication '
              'mechanism', host, port, auth_mechanism)
     sock = get_socket(host, port, use_ssl, ca_cert)
+    
+    if krb_host:
+        kerberos_host = krb_host
+    else:
+        kerberos_host = host
+    
     if timeout is not None:
         timeout = timeout * 1000.  # TSocket expects millis
     if six.PY2:
@@ -753,7 +759,7 @@ def connect(host, port, timeout=None, use_ssl=False, ca_cert=None,
         except AttributeError:
             sock.socket_timeout = timeout
             sock.connect_timeout = timeout
-    transport = get_transport(sock, host, kerberos_service_name,
+    transport = get_transport(sock, kerberos_host, kerberos_service_name,
                               auth_mechanism, user, password)
     transport.open()
     protocol = TBinaryProtocol(transport)


### PR DESCRIPTION
If host is registered under a different name in kerberos, we need to differentiate these two names (much like in pyhs2).