### PR TITLE
Add 'NULL' to _TTypeId_to_TColumnValue_getters (fixes #256)

### DIFF
--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -685,6 +685,7 @@ _TTypeId_to_TColumnValue_getters = {
     'ARRAY': operator.attrgetter('stringVal'),
     'STRUCT': operator.attrgetter('stringVal'),
     'UNIONTYPE': operator.attrgetter('stringVal'),
+    'NULL': operator.attrgetter('stringVal'),
     'DATE': operator.attrgetter('stringVal')
 }
 


### PR DESCRIPTION
This patch fixes #256, an issue causing `KeyError` when a result column has `NULL_TYPE`.

Based on https://github.com/cloudera/impyla/blob/94a8eff9cda0cdb16b180c7079961449c8385997/impala/thrift/TCLIService.thrift#L375, it looks like Hive's `NULL_TYPE` gets mapped to TStringColumn, so I added an entry to fetch `stringVal` attribute from the column. I believe this is the rationale for a similar change in #162 to avoid `KeyError` for complex types (which also map to `stringVal`).