### PR TITLE
BUG: sqlalchemy connection string parsing and ldap auth

### DIFF
--- a/impala/_thrift_api.py
+++ b/impala/_thrift_api.py
@@ -134,6 +134,7 @@ def get_transport(socket, host, kerberos_service_name, auth_mechanism='NOSASL',
 
     # Set defaults for PLAIN SASL / LDAP connections.
     if auth_mechanism in ['LDAP', 'PLAIN']:
+        auth_mechanism = 'PLAIN'
         if user is None:
             user = getpass.getuser()
             log.debug('get_transport: user=%s', user)

--- a/impala/_thrift_api.py
+++ b/impala/_thrift_api.py
@@ -134,7 +134,6 @@ def get_transport(socket, host, kerberos_service_name, auth_mechanism='NOSASL',
 
     # Set defaults for PLAIN SASL / LDAP connections.
     if auth_mechanism in ['LDAP', 'PLAIN']:
-        auth_mechanism = 'PLAIN'
         if user is None:
             user = getpass.getuser()
             log.debug('get_transport: user=%s', user)
@@ -145,7 +144,7 @@ def get_transport(socket, host, kerberos_service_name, auth_mechanism='NOSASL',
                 # PLAIN always requires a password for HS2.
                 password = 'password'
             log.debug('get_transport: password=%s', password)
-
+        auth_mechanism = 'PLAIN'  # sasl doesn't know mechanism LDAP
     # Initializes a sasl client
     from thrift_sasl import TSaslClientTransport
     try:
@@ -165,6 +164,7 @@ def get_transport(socket, host, kerberos_service_name, auth_mechanism='NOSASL',
         from impala.sasl_compat import PureSASLClient
 
         def sasl_factory():
-            return PureSASLClient(host, username=user, password=password, service=kerberos_service_name)
+            return PureSASLClient(host, username=user, password=password,
+                                  service=kerberos_service_name)
 
     return TSaslClientTransport(sasl_factory, auth_mechanism, socket)

--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -740,7 +740,7 @@ def connect(host, port, timeout=None, use_ssl=False, ca_cert=None,
             user=None, password=None, kerberos_service_name='impala',
             auth_mechanism=None):
     log.debug('Connecting to HiveServer2 %s:%s with %s authentication '
-             'mechanism', host, port, auth_mechanism)
+              'mechanism', host, port, auth_mechanism)
     sock = get_socket(host, port, use_ssl, ca_cert)
     if timeout is not None:
         timeout = timeout * 1000.  # TSocket expects millis

--- a/impala/sqlalchemy.py
+++ b/impala/sqlalchemy.py
@@ -131,6 +131,17 @@ class ImpalaDialect(DefaultDialect):
         import impala.dbapi
         return impala.dbapi
 
+    def create_connect_args(self, url):
+        kwargs = {
+            'host': url.host,
+            'port': url.port,
+            'user': url.username,
+            'password': url.password,
+            'database': url.database,
+        }
+        kwargs.update(url.query)
+        return ([], kwargs)
+
     def initialize(self, connection):
         self.default_schema_name = connection.connection.default_db
 


### PR DESCRIPTION
A couple bug fixes.

* Fig bug in sqlalchemy parsing of username in connection string. sqlalchemy passes `username` but `connect` take `user`. ie
```
from sqlalchemy import create_engine
con_string = 'impala://<username>:<password>@hostname:port/database'
engine = create_engine(con_string)
```
* Fix bug in `_thrift_api.get_transport`. SASL doesn't recognize `LDAP` mechanism. If `auth_mechanism = 'LDAP'`, change to `'PLAIN'` after username and password checking.