### PR TITLE
Pinned thrift_sasl to 0.2.1 until #268 is resolved

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Required:
 For Hive and/or Kerberos support:
 
 ```
-pip install thrift_sasl
+pip install thrift_sasl==0.2.1
 pip install sasl
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ if PY2:
 elif PY3:
     packages = find_packages(exclude=['impala._thrift_gen',
                                       'impala._thrift_gen.*'])
-    reqs.append('thrift_sasl<=0.2.1')
     reqs.append('thriftpy>=0.3.5')
 
 

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ if PY2:
 elif PY3:
     packages = find_packages(exclude=['impala._thrift_gen',
                                       'impala._thrift_gen.*'])
-    reqs.append('thriftpy>=0.3.5,<=0.2.1')
+    reqs.append('thrift_sasl<=0.2.1')
+    reqs.append('thriftpy>=0.3.5')
 
 
 import versioneer  # noqa

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ if PY2:
 elif PY3:
     packages = find_packages(exclude=['impala._thrift_gen',
                                       'impala._thrift_gen.*'])
-    reqs.append('thriftpy>=0.3.5')
+    reqs.append('thriftpy>=0.3.5,<=0.2.1')
 
 
 import versioneer  # noqa


### PR DESCRIPTION
thrift_sasl was updated and now throws an error:

`AttributeError: 'TSSLSocket' object has no attribute 'isOpen'`

Pinning is a short term fix until the issue #268 is formally resolved.