### PR TITLE
Bump Thrift for Python 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Required:
 
 * `six`, `bit_array`
 
-* `thrift` (on Python 2.x) or `thriftpy` (on Python 3.x)
+* `thrift`
 
 For Hive and/or Kerberos support:
 

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,6 @@
 
 from __future__ import absolute_import
 
-import sys
-
 import ez_setup
 ez_setup.use_setuptools()
 
@@ -26,24 +24,7 @@ def readme():
     with open('README.md', 'r') as ip:
         return ip.read()
 
-
-PY2 = sys.version_info[0] == 2
-PY3 = sys.version_info[0] == 3
-
-# Apache Thrift does not yet support Python 3 (see THRIFT-1857).  We use
-# thriftpy as a stopgap replacement
-reqs = ['six', 'bitarray']
-if PY2:
-    packages = find_packages()
-    reqs.append('thrift<=0.9.3')
-elif PY3:
-    packages = find_packages(exclude=['impala._thrift_gen',
-                                      'impala._thrift_gen.*'])
-    reqs.append('thriftpy>=0.3.5')
-
-
 import versioneer  # noqa
-
 
 setup(
     name='impyla',
@@ -56,10 +37,10 @@ setup(
     author='Uri Laserson',
     author_email='laserson@cloudera.com',
     url='https://github.com/cloudera/impyla',
-    packages=packages,
+    packages=find_packages(),
     install_package_data=True,
     package_data={'impala.thrift': ['*.thrift']},
-    install_requires=reqs,
+    install_requires=['six', 'bitarray', 'thrift>=0.9.3'],
     keywords=('cloudera impala python hadoop sql hdfs mpp spark pydata '
               'pandas distributed db api pep 249 hive hiveserver2 hs2'),
     license='Apache License, Version 2.0',


### PR DESCRIPTION
Hi all,

Can we bump the version for Python 2? We're using Thrift 0.11 and having some issues with the different versions thrift. Also we can use the thrift library for Python 3: https://issues.apache.org/jira/browse/THRIFT-2096

Cheers, Fokko