### PR TITLE
feat: add lastrowid to HiveServer2Cursor (PEP249)

### DIFF
--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -193,6 +193,11 @@ class HiveServer2Cursor(Cursor):
         return self._rowcount
 
     @property
+    def lastrowid(self):
+        # PEP 249
+        return None
+
+    @property
     def query_string(self):
         return self._last_operation_string
 

--- a/impala/interface.py
+++ b/impala/interface.py
@@ -91,6 +91,9 @@ class Cursor(object):
     def rowcount(self):
         raise NotImplementedError
 
+    def lastrowid(self):
+        raise NotImplementedError
+
     def query_string(self):
         raise NotImplementedError
 


### PR DESCRIPTION
I would like to add `lastrowid` to HiveServer2Cursor to make it PEP249 compliant, and to improve compatibility with SQLAlchemy (#141).
 
>  If the operation does not set a rowid or if the database does not support rowids, this attribute should be set to None. (https://www.python.org/dev/peps/pep-0249/#lastrowid)