### PR TITLE
Change async to run_async for Python 3.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ coverage.xml
 
 udf-scratch/
 .idea/
+
+/venv/

--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -342,7 +342,7 @@ class HiveServer2Cursor(Cursor):
 
             op = self.session.execute(self._last_operation_string,
                                       configuration,
-                                      async=True)
+                                      run_async=True)
             self._last_operation = op
 
         self._execute_async(op)
@@ -1024,11 +1024,11 @@ class HS2Session(ThriftRPC):
         req = TCloseSessionReq(sessionHandle=self.handle)
         self._rpc('CloseSession', req)
 
-    def execute(self, statement, configuration=None, async=False):
+    def execute(self, statement, configuration=None, run_async=False):
         req = TExecuteStatementReq(sessionHandle=self.handle,
                                    statement=statement,
                                    confOverlay=configuration,
-                                   runAsync=async)
+                                   runAsync=run_async)
         return self._operation('ExecuteStatement', req)
 
     def get_databases(self, schema='.*'):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-bitarray==0.8.3
 ply==3.11
 six==1.11.0
 thrift==0.11.0
-thriftpy==0.3.9
+thriftpy2==0.3.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+bitarray==0.8.3
+ply==3.11
+six==1.11.0
+thrift==0.11.0
+thriftpy==0.3.9


### PR DESCRIPTION
`async` is now a [reserved keyword in Python 3.7](https://docs.python.org/3/whatsnew/3.7.html#changes-in-python-behavior), causing syntax errors in `hiveserver2.py`.

The syntax errors are restricted to argument names, which were changed from `async` to `run_async`. Camel-cased `runAsync` on line 1032 was kept to avoid issues with Thrift generated code.