### PR TITLE
issue-326 - potential fix for a socket leak in HiveServer2Cursor

### DIFF
--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -168,7 +168,7 @@ class HiveServer2Cursor(Cursor):
         self._closed = False
 
     def __del__(self):
-        if self._closed == True:
+        if self._closed:
             return
         try:
            self.close_operation()

--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -168,6 +168,8 @@ class HiveServer2Cursor(Cursor):
         self._closed = False
 
     def __del__(self):
+        if self._closed == True:
+            return
         try:
            self.close_operation()
         except Exception:

--- a/impala/tests/test_dbapi_connect.py
+++ b/impala/tests/test_dbapi_connect.py
@@ -87,13 +87,13 @@ class ImpalaConnectionTests(unittest.TestCase):
         self._execute_queries(self.connection)
 
 class ImpalaSocketTests(unittest.TestCase):
-    
+
     def run_a_query(self):
         with connect(ENV.host, ENV.port) as connection:
             with connection.cursor() as cursor:
                 cursor.execute('select 1 as a_number')
                 return cursor.fetchall()
-    
+
     def test_socket_leak(self):
         with SocketTracker() as sockets:
             # there should be no open sockets prior to running query


### PR DESCRIPTION
A potential fix for #326 along with a test that demonstrates the problem.  

`SocketTracker`, the class that keeps track of opened/closed sockets for the duration of the test seems hacky, but I can't think of a better way to do this.