### PR TITLE
Selectively install thriftpy2 requirement based on python version

### DIFF
--- a/impala/_thrift_api.py
+++ b/impala/_thrift_api.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # This package is here to clean up references to thrift, because we're using
-# thriftpy for Py3 at the moment.  This should all be temporary, as Apache
+# thriftpy2 for Py3 at the moment.  This should all be temporary, as Apache
 # Thrift gains Py3 compatibility.
 
 # pylint: disable=wrong-import-position
@@ -58,16 +58,16 @@ if six.PY2:
 
 
 if six.PY3:
-    # import thriftpy code
-    from thriftpy import load
-    from thriftpy.thrift import TClient, TApplicationException
+    # import thriftpy2 code
+    from thriftpy2 import load
+    from thriftpy2.thrift import TClient, TApplicationException
     # TODO: reenable cython
-    # from thriftpy.protocol import TBinaryProtocol
-    from thriftpy.protocol.binary import TBinaryProtocol  # noqa
-    from thriftpy.transport import TSocket, TTransportException  # noqa
+    # from thriftpy2.protocol import TBinaryProtocol
+    from thriftpy2.protocol.binary import TBinaryProtocol  # noqa
+    from thriftpy2.transport import TSocket, TTransportException  # noqa
     # TODO: reenable cython
-    # from thriftpy.transport import TBufferedTransport
-    from thriftpy.transport.buffered import TBufferedTransport  # noqa
+    # from thriftpy2.transport import TBufferedTransport
+    from thriftpy2.transport.buffered import TBufferedTransport  # noqa
     thrift_dir = os.path.join(os.path.dirname(__file__), 'thrift')
 
     # dynamically load the HS2 modules
@@ -112,7 +112,7 @@ def get_socket(host, port, use_ssl, ca_cert):
             else:
                 return TSSLSocket(host, port, validate=True, ca_certs=ca_cert)
         else:
-            from thriftpy.transport.sslsocket import TSSLSocket
+            from thriftpy2.transport.sslsocket import TSSLSocket
             if ca_cert is None:
                 return TSSLSocket(host, port, validate=False)
             else:

--- a/jenkins/run-dbapi.sh
+++ b/jenkins/run-dbapi.sh
@@ -79,7 +79,7 @@ conda info -a
 CONDA_ENV_NAME=pyenv-impyla-dbapi-test
 conda create -y -q -n $CONDA_ENV_NAME python=$PYTHON_VERSION pip
 source activate $CONDA_ENV_NAME
-pip install thriftpy sqlalchemy
+pip install thriftpy2 sqlalchemy
 pip install unittest2 pytest-cov
 
 # build impyla

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,9 @@ setup(
     install_package_data=True,
     package_data={'impala.thrift': ['*.thrift']},
     install_requires=['six', 'bitarray', 'thrift>=0.9.3'],
+    extras_require={
+        ":python_version>='3.0'": ["thriftpy2==0.4.0"],
+    },
     keywords=('cloudera impala python hadoop sql hdfs mpp spark pydata '
               'pandas distributed db api pep 249 hive hiveserver2 hs2'),
     license='Apache License, Version 2.0',


### PR DESCRIPTION
This patch addresses both #329 and #326.

Tested by setting up two different virtualenvs, and confimring that
the expected requirements were installed, and that the connect function
could be imported from impala.dbapi.

**Python 2**
```
[dknupp@mbp ~/Documents/code]$ virtualenv /tmp/python2_venv
New python executable in /tmp/python2_venv/bin/python
Installing setuptools, pip, wheel...
done.
[dknupp@mbp ~/Documents/code]$ source /tmp/python2_venv/bin/activate
(python2_venv) [dknupp@mbp ~/Documents/code]$ python --version
Python 2.7.10
(python2_venv) [dknupp@mbp ~/Documents/code]$ pip list
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
Package    Version
---------- -------
pip        19.0.3
setuptools 40.8.0
wheel      0.33.1
(python2_venv) [dknupp@mbp ~/Documents/code]$ pip install -e impyla/
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
Obtaining file:///Users/dknupp/Documents/code/impyla
Collecting six (from impyla==0.14.2.1+8.gc010d59)
  Using cached https://files.pythonhosted.org/packages/73/fb/00a976f728d0d1fecfe898238ce23f502a721c0ac0ecfedb80e0d88c64e9/six-1.12.0-py2.py3-none-any.whl
Collecting bitarray (from impyla==0.14.2.1+8.gc010d59)
Collecting thrift>=0.9.3 (from impyla==0.14.2.1+8.gc010d59)
Installing collected packages: six, bitarray, thrift, impyla
  Running setup.py develop for impyla
Successfully installed bitarray-0.8.3 impyla six-1.12.0 thrift-0.11.0
(python2_venv) [dknupp@mbp ~/Documents/code]$ pip list
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7.
Package    Version             Location
---------- ------------------- -----------------------------------
bitarray   0.8.3
impyla     0.14.2.1+8.gc010d59 /Users/dknupp/Documents/code/impyla
pip        19.0.3
setuptools 40.8.0
six        1.12.0
thrift     0.11.0
wheel      0.33.1
(python2_venv) [dknupp@mbp ~/Documents/code]$ python
Python 2.7.10 (default, Aug 17 2018, 19:45:58)
[GCC 4.2.1 Compatible Apple LLVM 10.0.0 (clang-1000.0.42)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from impala.dbapi import connect
>>> ^D
```

**Python 3**
```
[dknupp@mbp ~/Documents/code]$ virtualenv --python /usr/local/bin/python3 /tmp/python3_venv
Running virtualenv with interpreter /usr/local/bin/python3
Using base prefix '/usr/local/Cellar/python/3.7.2_1/Frameworks/Python.framework/Versions/3.7'
New python executable in /tmp/python3_venv/bin/python3.7
Also creating executable in /tmp/python3_venv/bin/python
Installing setuptools, pip, wheel...
done.
[dknupp@mbp ~/Documents/code]$ source /tmp/python3_venv/bin/activate
(python3_venv) [dknupp@mbp ~/Documents/code]$ python --version
Python 3.7.2
(python3_venv) [dknupp@mbp ~/Documents/code]$ pip list
Package    Version
---------- -------
pip        19.0.3
setuptools 40.8.0
wheel      0.33.1
(python3_venv) [dknupp@mbp ~/Documents/code]$ pip install -e impyla/
Obtaining file:///Users/dknupp/Documents/code/impyla
Collecting six (from impyla==0.14.2.1+8.gc010d59)
  Using cached https://files.pythonhosted.org/packages/73/fb/00a976f728d0d1fecfe898238ce23f502a721c0ac0ecfedb80e0d88c64e9/six-1.12.0-py2.py3-none-any.whl
Collecting bitarray (from impyla==0.14.2.1+8.gc010d59)
Collecting thrift>=0.9.3 (from impyla==0.14.2.1+8.gc010d59)
Collecting thriftpy2==0.4.0 (from impyla==0.14.2.1+8.gc010d59)
Collecting ply<4.0,>=3.4 (from thriftpy2==0.4.0->impyla==0.14.2.1+8.gc010d59)
  Using cached https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl
Installing collected packages: six, bitarray, thrift, ply, thriftpy2, impyla
  Running setup.py develop for impyla
Successfully installed bitarray-0.8.3 impyla ply-3.11 six-1.12.0 thrift-0.11.0 thriftpy2-0.4.0
(python3_venv) [dknupp@mbp ~/Documents/code]$ pip list
Package    Version             Location
---------- ------------------- -----------------------------------
bitarray   0.8.3
impyla     0.14.2.1+8.gc010d59 /Users/dknupp/Documents/code/impyla
pip        19.0.3
ply        3.11
setuptools 40.8.0
six        1.12.0
thrift     0.11.0
thriftpy2  0.4.0
wheel      0.33.1
(python3_venv) [dknupp@mbp ~/Documents/code]$ python
Python 3.7.2 (default, Jan 13 2019, 12:50:01)
[Clang 10.0.0 (clang-1000.11.45.5)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from impala.dbapi import connect
>>>
```