### PR TITLE
Add a changelog of recent commits before cutting the next release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+Changelog
+=========
+
+0.15a1
+------
+* **Improvements**
+  - Selectively install thriftpy2 requirement based on python version (#342)
+  - Add thrift query profile support (#333)
+  - Add lastrowid to HiveServer2Cursor (#308)
+  - Enable SQLAlchemy cursor configuration (#298)
+  - Coerce floats if possible (#291)
+  - Add SQLalchemy support storing table as Kudu (#259) (#260)
+  - Add support for NULL_TYPE result column (#257)
+  - Add support for optional krb_host parameter in connection (#248)
+  - Various documentation improvements
+
+* **Bug Fixes**
+  - Fix unexpected SQLAlchemy keyword argument 'username' (#343)
+  - Fix unicode issue in README file (#341)
+  - Fix for a socket leak in HiveServer2Cursor (#327)
+  - Avoid using reserved async keyword to support Python 3.7 (#322)
+  - Bump required thrift version to 0.9.3 or above (#303)
+  - Fix SQLalchemy connection string parsing and LDAP auth (#261)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include ez_setup.py
 include README.md
 include LICENSE.txt
+include CHANGELOG.md
 include versioneer.py
 include impala/_version.py


### PR DESCRIPTION
It doesn't appear that impyla has ever included a change log in the manifest.
Since there have been so many changes, and also many requests about which
issues are getting fixed, it seems like a good time to amend that.

Based on some discussions I've had with a few on this projects, it also
feels like it might be a good time to bump the minor version to 15. In order
to avoid the types of problems we had before with regard to releasing
0.14.2, I'm also proposing that we adopt a pre-release version string at
the outset, although I'm not sure whether an alpha release (i.e., 0.15a1)
or an "rc" release (i.e., 0.15rc1) makes the most sense. In either case,
the package should only install if a user specifically requests the version.
Bare "pip install impyla" should still grab the current official release.