### PR TITLE
Fixed numeric parameter substitution bug  - Fixes #317 and #349

### DIFF
--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -336,10 +336,15 @@ class HiveServer2Cursor(Cursor):
         """
         log.debug('Executing query %s', operation)
 
+        paramstyle = None
+        if configuration:
+            paramstyle = configuration.pop('paramstyle', None)
+
         def op():
             if parameters:
                 self._last_operation_string = _bind_parameters(operation,
-                                                               parameters)
+                                                               parameters,
+                                                               paramstyle)
             else:
                 self._last_operation_string = operation
 
@@ -757,12 +762,12 @@ def connect(host, port, timeout=None, use_ssl=False, ca_cert=None,
     log.debug('Connecting to HiveServer2 %s:%s with %s authentication '
               'mechanism', host, port, auth_mechanism)
     sock = get_socket(host, port, use_ssl, ca_cert)
-    
+
     if krb_host:
         kerberos_host = krb_host
     else:
         kerberos_host = host
-    
+
     if timeout is not None:
         timeout = timeout * 1000.  # TSocket expects millis
     if six.PY2:

--- a/impala/interface.py
+++ b/impala/interface.py
@@ -180,7 +180,7 @@ class Cursor(object):
             reraise(exc_type, exc_val, exc_tb)
 
 
-def _replace_numeric_markers(operation, string_parameters):
+def _replace_numeric_markers(operation, string_parameters, paramstyle):
     """
     Replaces qname, format, and numeric markers in the given operation, from
     the string_parameters list.
@@ -214,19 +214,30 @@ def _replace_numeric_markers(operation, string_parameters):
         return op
 
     # replace qmark parameters and format parameters
-    operation = replace_markers('?', operation, string_parameters)
-    operation = replace_markers(r'%s', operation, string_parameters)
+    # If paramstyle is explicitly specified don't try to substitue them all
+    if paramstyle == 'qmark' or paramstyle is None:
+        operation = replace_markers('?', operation, string_parameters)
+    if paramstyle == 'format' or paramstyle is None:
+        operation = replace_markers(r'%s', operation, string_parameters)
 
     # replace numbered parameters
-    # Go through them backwards so smaller numbers don't replace
-    # parts of larger ones
-    for index in range(len(string_parameters), 0, -1):
-        operation = operation.replace(':' + str(index),
-                                      string_parameters[index - 1])
+    if paramstyle == 'numeric' or paramstyle is None:
+        operation = re.sub(r'(:)(\d+)', r'{\2}', operation)
+        # offset by one
+        operation = operation.format(*[''] + string_parameters)
+
+    if paramstyle in {'named', 'pyformat'}:
+        raise ProgrammingError(
+            "paramstyle '%s' is not compatible with parameters passed as List."
+            "please you a dict for you parameters instead or specify"
+            " a different paramstyle",
+            paramstyle
+        )
+
     return operation
 
 
-def _bind_parameters_list(operation, parameters):
+def _bind_parameters_list(operation, parameters, paramstyle):
     string_parameters = []
     for value in parameters:
         if value is None:
@@ -237,7 +248,7 @@ def _bind_parameters_list(operation, parameters):
             string_parameters.append(str(value))
 
     # replace qmark and numeric parameters
-    return _replace_numeric_markers(operation, string_parameters)
+    return _replace_numeric_markers(operation, string_parameters, paramstyle)
 
 
 def _bind_parameters_dict(operation, parameters):
@@ -259,11 +270,11 @@ def _bind_parameters_dict(operation, parameters):
     return operation % string_parameters
 
 
-def _bind_parameters(operation, parameters):
+def _bind_parameters(operation, parameters, paramstyle=None):
     # If parameters is a list, assume either qmark, format, or numeric
     # format. If not, assume either named or pyformat parameters
     if isinstance(parameters, (list, tuple)):
-        return _bind_parameters_list(operation, parameters)
+        return _bind_parameters_list(operation, parameters, paramstyle)
     elif isinstance(parameters, dict):
         return _bind_parameters_dict(operation, parameters)
     else:

--- a/impala/tests/test_query_parameters.py
+++ b/impala/tests/test_query_parameters.py
@@ -22,8 +22,8 @@ from impala.interface import _bind_parameters
 from impala.dbapi import ProgrammingError
 
 
-def dt(expected, query, params):
-    result = _bind_parameters(query, params)
+def dt(expected, query, params, **kwargs):
+    result = _bind_parameters(query, params, **kwargs)
     assert expected == result
 
 
@@ -240,6 +240,44 @@ def test_format():
         with raises(ProgrammingError):
             dt("should have raised exception", q[0], q[1])
 
+def test_avoid_substitution():
+  """Regression tests for cases where a parameter *should not* be substituted."""
+  # Only markers matching the specified paramstyle should be replaced, including
+  # if the parameter is embedded in a substituted string.
+  dt("select :2, ?, :named from test where a='string' and b='42'",
+     "select :2, ?, :named from test where a=%s and b=%s",
+     ['string', '42'], paramstyle='format')
+  dt("select * from test where a='string :2 ? %s :named' and b='42'",
+     "select * from test where a=%s and b=%s",
+     ['string :2 ? %s :named', '42'], paramstyle='format')
+
+  dt("select :2, %s, :named from test where a='string' and b='42'",
+     "select :2, %s, :named from test where a=? and b=?",
+     ['string', '42'], paramstyle='qmark')
+  dt("select * from test where a='string :2 ? %s :named' and b='42'",
+     "select * from test where a=? and b=?",
+     ['string :2 ? %s :named', '42'], paramstyle='qmark')
+
+  dt("select ?, %s, :named from test where a='string' and b='42'",
+     "select ?, %s, :named from test where a=:1 and b=:2",
+     ['string', '42'], paramstyle='numeric')
+  dt("select * from test where a='string :2 ? %s :named' and b='42'",
+      "select * from test where a=:1 and b=:2",
+     ['string :2 ? %s :named', '42'], paramstyle='numeric')
+
+  # BUG: %s picks up named parameters as stringified dict when dict is passed.
+  dt('select ?, {\'x\': "\'string\'"}, :1 from test where a=\'string\'',
+     "select ?, %s, :1 from test where a=:x",
+     {'x': 'string'}, paramstyle='named')
+  dt("select * from test where a='string :2 ? %s :named' and b='42'",
+      "select * from test where a=:x and b=:y",
+      {'x': 'string :2 ? %s :named', 'y':'42'}, paramstyle='named')
+
+  # BUG: if a parameter is substituted with a string containing another parameter
+  # specifier, double substitution can occur.
+  dt("select * from test where a='string '42'' and b='42'",
+     "select * from test where a=%s and b=%s",
+     ['string :2', '42'])
 
 def test_date_type():
     import datetime


### PR DESCRIPTION
1) For direct use of `numbe`r paramstyle fixed by making the substitution operation from a loop to a one shot regex substitution.
2) For qmark or format paramstyle: After the substition already happens successfully but gets processed again at the numeric paramstyle step. 
Fixed (workaround) by allowing the user to explicitly define the paramstyle he is using.
Bug 2) could be improved by sniffing the paramstyle or sticking with the default one and just stick with this one instead of trying to solve everything and allowing a mix of several styles?

Please advise for running your tests. Do you use a local instance running in docker?

Usage of solution 2):

`cursor.execute("INSERT INTO test_impyla VALUES (?, ?)", ['this will not go wrong:2', 'im not going to creep in'], configuration={'paramstyle': 'qmark'})`

For 1) it's seamless

 - Fixes #317 and #349