### PR TITLE
Make thriftpy2 range locked, not specific version locked.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,8 @@ setup(
     package_data={'impala.thrift': ['*.thrift']},
     install_requires=['six', 'bitarray', 'thrift>=0.9.3'],
     extras_require={
-        ":python_version>='3.0'": ["thriftpy2==0.4.0"],
+        ":python_version>='3.0'": ["thriftpy2>=0.4.0,<0.5.0",
+                                   ],
     },
     keywords=('cloudera impala python hadoop sql hdfs mpp spark pydata '
               'pandas distributed db api pep 249 hive hiveserver2 hs2'),


### PR DESCRIPTION
Allows for happybase and impyla to co-exist in a 3.7 environment.

Update based on @ethe note on the #342 PR