### PR TITLE
fix ImportError  'THttpClient' in python3+

### DIFF
--- a/impala/_thrift_api.py
+++ b/impala/_thrift_api.py
@@ -63,6 +63,7 @@ if six.PY2:
 if six.PY3:
     # import thriftpy2 code
     from thriftpy2 import load
+    from thrift.transport.THttpClient import THttpClient
     from thriftpy2.thrift import TClient, TApplicationException
     # TODO: reenable cython
     # from thriftpy2.protocol import TBinaryProtocol


### PR DESCRIPTION
hi, My Python Version is  `python3.6`.

when `import hiveserver2`, then raise `ImportError: cannot import name 'THttpClient'`.

This is my solution, it worked.