### PR TITLE
Set long_description_content_type to markdown in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     cmdclass=versioneer.get_cmdclass(),
     description='Python client for the Impala distributed query engine',
     long_description=readme(),
+    long_description_content_type='text/markdown',
     maintainer='Wes McKinney',
     maintainer_email='wes.mckinney@twosigma.com',
     author='Uri Laserson',


### PR DESCRIPTION
PyPI now requires that the long description content type be specified.
(Default is reSturcturedText.)