### PR TITLE
Make connecting over HTTP compatible with python 3.

### DIFF
--- a/impala/_thrift_api.py
+++ b/impala/_thrift_api.py
@@ -61,9 +61,9 @@ if six.PY2:
 
 
 if six.PY3:
-    # import thriftpy2 code
+    # When using python 3, import from thriftpy2 rather than thrift
     from thriftpy2 import load
-    from thrift.transport.THttpClient import THttpClient
+    from thriftpy2.http import THttpClient
     from thriftpy2.thrift import TClient, TApplicationException
     # TODO: reenable cython
     # from thriftpy2.protocol import TBinaryProtocol
@@ -124,6 +124,7 @@ def get_socket(host, port, use_ssl, ca_cert):
     else:
         return TSocket(host, port)
 
+
 def get_http_transport(host, port, http_path, timeout=None, use_ssl=False,
                        ca_cert=None, auth_mechanism='NOSASL', user=None,
                        password=None):
@@ -154,10 +155,13 @@ def get_http_transport(host, port, http_path, timeout=None, use_ssl=False,
         log.debug('get_http_transport: password=%s', password)
         auth_mechanism = 'PLAIN'  # sasl doesn't know mechanism LDAP
         # Set the BASIC auth header
-        auth = base64.encodestring('%s:%s' % (user, password)).strip('\n')
+        user_password = '%s:%s'.encode() % (user.encode(), password.encode())
+        auth = base64.encodestring(user_password).decode().strip('\n')
+
         transport.setCustomHeaders({'Authorization': 'Basic %s' % auth})
 
     return transport
+
 
 def get_transport(socket, host, kerberos_service_name, auth_mechanism='NOSASL',
                   user=None, password=None):

--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -211,8 +211,8 @@ class HiveServer2Cursor(Cursor):
                 modifiedRows = int(resultDict.get('NumModifiedRows', -1))
                 errorRows = int(resultDict.get('NumRowErrors', -1))
 
-        return (modifiedRows, errorRows)      
-      
+        return (modifiedRows, errorRows)
+
     @property
     def lastrowid(self):
         # PEP 249
@@ -1034,9 +1034,19 @@ class ThriftRPC(object):
 
 
 def open_transport(transport):
-    if six.PY2 and not transport.isOpen():
-        transport.open()
-    elif six.PY3 and not transport.is_open():
+    """
+    Open transport, accounting for API differences between thrift versus thriftpy2,
+    as well as TBufferedTransport versus THttpClient.
+    """
+    # python2 and thrift, or any THttpClient
+    if 'isOpen' in dir(transport):
+        transport_is_open = transport.isOpen()
+
+    # python3 and thriftpy2 (for TBufferedTransport only)
+    if 'is_open' in dir(transport):
+        transport_is_open = transport.is_open()
+
+    if not transport_is_open:
         transport.open()
 
 


### PR DESCRIPTION
- Under python 3, base64.encodestring() requires a byte sequence.

- For python 3, import THttpClient from thriftpy2.http

- Impyla uses thrift for python 2 and thriftpy2 for python 3.
  These libraries provide slightly different API's for opening the
  transport. For thrift, the method is called isOpen() regardless
  of the transport type. For thriftpy2, THttpClient retains isOpen(),
  but otherwise uses is_open().

Tested by connecting to unsecure, kerberized, and HTTP impalad's
using both python 2 and python 3.