### PR TITLE
[Fix #351 Improves the example of a cursor iteration to execute the `print` fun…

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The `Cursor` object also exposes the iterator interface, which is buffered
 ```python
 cursor.execute('SELECT * FROM mytable LIMIT 100')
 for row in cursor:
-    process(row)
+    print(row)
 ```
 
 Furthermore the `Cursor` object returns you information about the columns

--- a/impala/interface.py
+++ b/impala/interface.py
@@ -18,7 +18,6 @@ import datetime
 import re
 import six
 from six import reraise
-from six.moves import range
 
 from impala.util import _escape
 from impala.error import (  # pylint: disable=unused-import


### PR DESCRIPTION
Improves the example of a cursor iteration to execute the `print` function instead `process`. 
This could be a bit confusing for inexperienced users. [Fix #351