### PR TITLE
Improve prerequisite info about SASL

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Required:
 
 Optional:
 
-* `thrift_sasl==0.2.1` for hive and/or Kerberos support:
+* `thrift_sasl>=0.2.1` for hive and/or Kerberos support. This also requires a SASL
+   library to be installed on your system - see [System SASL](#system-sasl)
 
 * `pandas` for conversion to `DataFrame` objects; but see the [Ibis project][ibis] instead
 
@@ -43,6 +44,21 @@ Optional:
 
 * `pytest` for running tests; `unittest2` for testing on Python 2.6
 
+
+#### System SASL
+Different systems require different packages to be installed to enable SASL support
+in Impyla. Some examples of how to install the packages on different distributions
+follow.
+
+Ubuntu:
+```bash
+apt-get install libsasl2-dev libsasl2-2 libsasl2-modules-gssapi-mit
+```
+
+RHEL/CentOS:
+```bash
+yum install cyrus-sasl-md5 cyrus-sasl-plain cyrus-sasl-gssapi cyrus-sasl-devel
+```
 
 ### Installation
 


### PR DESCRIPTION
Document later thrift-sasl versions as supported

Add some info about how to install SASL libraries
on different distros (taken from #149).