### PR TITLE
Add HTTP code handling to THttpClient (#380)

### DIFF
--- a/impala/_thrift_api.py
+++ b/impala/_thrift_api.py
@@ -107,7 +107,8 @@ if six.PY3:
     from RuntimeProfile import TRuntimeProfileFormat
     ThriftClient = TClient
 
-
+# ImpalaHttpClient is copied from Impala Shell.
+# The implementations should be kept in sync as much as possible.
 class ImpalaHttpClient(TTransportBase):
   """Http implementation of TTransport base."""
 
@@ -226,6 +227,9 @@ class ImpalaHttpClient(TTransportBase):
   def read(self, sz):
     return self.__http_response.read(sz)
 
+  def readBody(self):
+    return self.__http_response.read()
+
   def write(self, buf):
     self.__wbuf.write(buf)
 
@@ -283,7 +287,8 @@ class ImpalaHttpClient(TTransportBase):
     if self.code >= 300:
       # Report any http response code that is not 1XX (informational response) or
       # 2XX (successful).
-      raise HttpError(self.code, self.message)
+      body = self.readBody()
+      raise HttpError(self.code, self.message, body)
 
 
 def get_socket(host, port, use_ssl, ca_cert):

--- a/impala/error.py
+++ b/impala/error.py
@@ -68,6 +68,15 @@ class RPCError(Error):
 class HiveServer2Error(RPCError):
     pass
 
+class HttpError(RPCError):
+    """An error containing an http response code"""
+    def __init__(self, code, message):
+        self.code = code
+        self.message = message
+
+    def __str__(self):
+        return "HTTP code {}: {}".format(self.code, self.message)
+
 
 class BeeswaxError(RPCError):
     pass

--- a/impala/error.py
+++ b/impala/error.py
@@ -70,11 +70,13 @@ class HiveServer2Error(RPCError):
 
 class HttpError(RPCError):
     """An error containing an http response code"""
-    def __init__(self, code, message):
+    def __init__(self, code, message, body):
         self.code = code
         self.message = message
+        self.body = body
 
     def __str__(self):
+        # Don't try to print the body as we don't know what format it is.
         return "HTTP code {}: {}".format(self.code, self.message)
 
 

--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -31,7 +31,7 @@ from impala.interface import Connection, Cursor, _bind_parameters
 from impala.error import (NotSupportedError, OperationalError,
                           ProgrammingError, HiveServer2Error)
 from impala._thrift_api import (
-    get_socket, get_http_transport, get_transport, THttpClient,
+    get_socket, get_http_transport, get_transport, ImpalaHttpClient,
     TTransportException, TBinaryProtocol, TOpenSessionReq, TFetchResultsReq,
     TCloseSessionReq, TExecuteStatementReq, TGetInfoReq, TGetInfoType, TTypeId,
     TFetchOrientation, TGetResultSetMetadataReq, TStatusCode, TGetColumnsReq,

--- a/impala/tests/test_http_connect.py
+++ b/impala/tests/test_http_connect.py
@@ -49,6 +49,7 @@ def http_503_server():
       # Respond with 503.
       self.send_response(code=http_client.SERVICE_UNAVAILABLE, message="Service Unavailable")
       self.end_headers()
+      self.wfile.write("extra text".encode('utf-8'))
 
   class TestHTTPServer503(object):
     def __init__(self):
@@ -88,6 +89,7 @@ class TestHttpConnect(object):
     except HttpError as e:
       assert str(e) == "HTTP code 503: Service Unavailable"
       assert e.code == http_client.SERVICE_UNAVAILABLE
+      assert e.body.decode("utf-8") == "extra text"
 
 
 def get_unused_port():

--- a/impala/tests/test_http_connect.py
+++ b/impala/tests/test_http_connect.py
@@ -12,7 +12,61 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import socket
+import threading
+from contextlib import closing
+
 import pytest
+import six
+from six.moves import SimpleHTTPServer
+from six.moves import http_client
+from six.moves import socketserver
+
+from impala.error import HttpError
+
+
+@pytest.yield_fixture
+def http_503_server():
+  class RequestHandler503(SimpleHTTPServer.SimpleHTTPRequestHandler):
+    """A custom http handler that checks for duplicate 'Host' headers from the most
+    recent http request, and always returns a 503 http code"""
+
+    def do_POST(self):
+      # Ensure that only one 'Host' header is contained in the request before responding.
+      request_headers = None
+      host_hdr_count = 0
+      if six.PY2:
+        # The unfortunately named self.headers here is an instance of mimetools.Message that
+        # contains the request headers.
+        request_headers = self.headers.headers
+        host_hdr_count = sum([header.startswith('Host:') for header in request_headers])
+      if six.PY3:
+        # In Python3 self.Headers is an HTTPMessage.
+        request_headers = self.headers
+        host_hdr_count = sum([header[0] == 'Host' for header in request_headers.items()])
+      assert host_hdr_count == 1, "need single 'Host:' header in %s" % request_headers
+
+      # Respond with 503.
+      self.send_response(code=http_client.SERVICE_UNAVAILABLE, message="Service Unavailable")
+      self.end_headers()
+
+  class TestHTTPServer503(object):
+    def __init__(self):
+      self.HOST = "localhost"
+      self.PORT = get_unused_port()
+      self.httpd = socketserver.TCPServer((self.HOST, self.PORT), RequestHandler503)
+
+      self.http_server_thread = threading.Thread(target=self.httpd.serve_forever)
+      self.http_server_thread.start()
+
+  server = TestHTTPServer503()
+  yield server
+
+  # Cleanup after test.
+  if server.httpd is not None:
+    server.httpd.shutdown()
+  if server.http_server_thread is not None:
+    server.http_server_thread.join()
 
 from impala.dbapi import connect
 
@@ -23,3 +77,22 @@ class TestHttpConnect(object):
     cur.execute('select 1')
     rows = cur.fetchall()
     assert rows == [(1,)]
+
+  def test_http_interactions(self, http_503_server):
+    """Test interactions with the http server when using hs2-http protocol.
+    Check that there is an HttpError exception when the server returns a 503 error."""
+    con = connect("localhost", http_503_server.PORT, use_http_transport=True)
+    try:
+      con.cursor()
+      assert False, "Should have got exception"
+    except HttpError as e:
+      assert str(e) == "HTTP code 503: Service Unavailable"
+      assert e.code == http_client.SERVICE_UNAVAILABLE
+
+
+def get_unused_port():
+  """ Find an unused port http://stackoverflow.com/questions/1365265 """
+  with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+    s.bind(('', 0))
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    return s.getsockname()[1]


### PR DESCRIPTION
Before this change Impyla is not checking HTTP return codes when
using the hs2-http protocol. Impyla is sending a request message
(e.g. send_CloseOperation) but the HTTP call to send this message may
fail. This will result in a failure when reading the reply (e.g. in
recv_CloseOperation) as there is no reply data to read. This will
typically result in an 'EOFError'.

Replace use of HTTPClient with ImpalaHttpClient. This code is copied
from Impala Shell. Make some small changes to enable this code to run on
Python3 as well as Python2. Http errors result in the throwing of a new
exception 'HttpError' (a subclass of RpcError) so that the http code can
be accessed directly.

This change does not contain any attempt to recover from an HTTP
failures but it does allow the failure to be detected. In future it may
be possible to retry after certain HTTP errors.

Testing:
- Add a new test that tries to connect to an HTTP
  server that always returns a 503 error. Check that an HttpError
  exception is thrown that contains the Http error code and message.