### PR TITLE
Implement GSSAPI authentication over http transport.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Optional:
 * `thrift_sasl>=0.2.1` for hive and/or Kerberos support. This also requires a SASL
    library to be installed on your system - see [System SASL](#system-sasl)
 
-* `kerberos` for Kerberos over HTTP support.
+* `kerberos>=1.3.0` for Kerberos over HTTP support.
 
 * `pandas` for conversion to `DataFrame` objects; but see the [Ibis project][ibis] instead
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Optional:
 * `thrift_sasl>=0.2.1` for hive and/or Kerberos support. This also requires a SASL
    library to be installed on your system - see [System SASL](#system-sasl)
 
+* `kerberos` for Kerberos over HTTP support.
+
 * `pandas` for conversion to `DataFrame` objects; but see the [Ibis project][ibis] instead
 
 * `sqlalchemy` for the SQLAlchemy engine

--- a/impala/_thrift_api.py
+++ b/impala/_thrift_api.py
@@ -272,6 +272,9 @@ class ImpalaHttpClient(TTransportBase):
       self.__auth_cookie = None
     return self.__auth_cookie
 
+  def isAuthCookieSet(self):
+    return self.__auth_cookie is not None
+
   def deleteAuthCookie(self):
     self.__auth_cookie = None
     self.__auth_cookie_expiry = None
@@ -344,7 +347,7 @@ class ImpalaHttpClient(TTransportBase):
     # A '401 Unauthorized' response might mean that we tried cookie-based authentication
     # with an expired cookie.
     # Delete the cookie and try again.
-    if self.code == 401 and self.getAuthCookie():
+    if self.code == 401 and self.isAuthCookieSet():
       log.debug('Received "401 Unauthorized" response. '
                 'Delete auth cookie and then retry.')
       self.deleteAuthCookie()
@@ -433,7 +436,6 @@ def get_http_transport(host, port, http_path, timeout=None, use_ssl=False,
                 return {"Authorization": "Negotiate " + negotiate_details}
 
         transport.setGetCustomHeadersFunc(get_auth_headers)
-        transport.refreshCustomHeaders()
 
     return transport
 

--- a/impala/_thrift_api.py
+++ b/impala/_thrift_api.py
@@ -21,12 +21,14 @@
 from __future__ import absolute_import
 
 import base64
+import datetime
 import getpass
 import os
 from io import BytesIO
 
 from six.moves import urllib
 from six.moves import http_client
+from six.moves import http_cookies
 import warnings
 
 import six
@@ -120,17 +122,19 @@ class ImpalaHttpClient(TTransportBase):
   MIN_REQUEST_SIZE_FOR_EXPECT = 1024
 
   def __init__(self, uri_or_host, port=None, path=None, cafile=None, cert_file=None,
-               key_file=None, ssl_context=None):
+               key_file=None, ssl_context=None, auth_cookie_name=None):
     """ImpalaHttpClient supports two different types of construction:
 
     ImpalaHttpClient(host, port, path) - deprecated
     ImpalaHttpClient(uri, [port=<n>, path=<s>, cafile=<filename>, cert_file=<filename>,
-        key_file=<filename>, ssl_context=<context>])
+        key_file=<filename>, ssl_context=<context>, auth_cookie_name=<cookiename>])
 
     Only the second supports https.  To properly authenticate against the server,
     provide the client's identity by specifying cert_file and key_file.  To properly
     authenticate the server, specify either cafile or ssl_context with a CA defined.
     NOTE: if both cafile and ssl_context are defined, ssl_context will override cafile.
+    auth_cookie_name is used to specify the name of the cookie used for cookie-based
+    authentication.
     """
     if port is not None:
       warnings.warn(
@@ -174,11 +178,15 @@ class ImpalaHttpClient(TTransportBase):
       self.proxy_auth = self.basic_proxy_auth_header(parsed)
     else:
       self.realhost = self.realport = self.proxy_auth = None
+    self.__auth_cookie_name = auth_cookie_name
+    self.__auth_cookie = None
+    self.__auth_cookie_expiry = None
     self.__wbuf = BytesIO()
     self.__http = None
     self.__http_response = None
     self.__timeout = None
     self.__custom_headers = None
+    self.__get_custom_headers_func = None
 
   @staticmethod
   def basic_proxy_auth_header(proxy):
@@ -226,6 +234,48 @@ class ImpalaHttpClient(TTransportBase):
   def setCustomHeaders(self, headers):
     self.__custom_headers = headers
 
+  def setGetCustomHeadersFunc(self, func):
+    self.__get_custom_headers_func = func
+
+  def refreshCustomHeaders(self):
+    if self.__get_custom_headers_func:
+      self.__custom_headers = self.__get_custom_headers_func(self.getAuthCookie())
+
+  def setAuthCookie(self):
+    if self.__auth_cookie_name:
+      if 'Set-Cookie' in self.headers:
+        cookies = http_cookies.SimpleCookie()
+        try:
+          cookies.load(self.headers['Set-Cookie'])
+        except:
+          return
+
+        if self.__auth_cookie_name in cookies:
+          c = cookies[self.__auth_cookie_name]
+          path = self.path if self.path.startswith('/') else '/%s' % self.path
+          if 'path' not in c or not c['path'] or c['path'] == '/' or c['path'] == path:
+            self.__auth_cookie = c
+            if 'max-age' not in c or not c['max-age']:
+              self.__auth_cookie_expiry = None
+            else:
+              try:
+                max_age_sec = int(c['max-age'])
+                self.__auth_cookie_expiry = \
+                    datetime.datetime.now() + datetime.timedelta(0, max_age_sec)
+              except:
+                self.__auth_cookie_expiry = None
+          # TODO: implement support for 'Eexpires' cookie attribute as well.
+
+  def getAuthCookie(self):
+    if self.__auth_cookie and self.__auth_cookie_expiry and \
+        self.__auth_cookie_expiry <= datetime.datetime.now():
+      self.__auth_cookie = None
+    return self.__auth_cookie
+
+  def deleteAuthCookie(self):
+    self.__auth_cookie = None
+    self.__auth_cookie_expiry = None
+
   def read(self, sz):
     return self.__http_response.read(sz)
 
@@ -236,55 +286,69 @@ class ImpalaHttpClient(TTransportBase):
     self.__wbuf.write(buf)
 
   def flush(self):
-    if self.isOpen():
-      self.close()
-    self.open()
+    def sendRequestRecvResp(data):
+      if self.isOpen():
+        self.close()
+      self.open()
+
+      # HTTP request
+      if self.using_proxy() and self.scheme == "http":
+        # need full URL of real host for HTTP proxy here (HTTPS uses CONNECT tunnel)
+        self.__http.putrequest('POST', "http://%s:%s%s" %
+                               (self.realhost, self.realport, self.path))
+      else:
+        self.__http.putrequest('POST', self.path)
+
+      # Write headers
+      self.__http.putheader('Content-Type', 'application/x-thrift')
+      data_len = len(data)
+      self.__http.putheader('Content-Length', str(data_len))
+      if data_len > ImpalaHttpClient.MIN_REQUEST_SIZE_FOR_EXPECT:
+        # Add the 'Expect' header to large requests. Note that we do not explicitly wait for
+        # the '100 continue' response before sending the data - HTTPConnection simply
+        # ignores these types of responses, but we'll get the right behavior anyways.
+        self.__http.putheader("Expect", "100-continue")
+      if self.using_proxy() and self.scheme == "http" and self.proxy_auth is not None:
+        self.__http.putheader("Proxy-Authorization", self.proxy_auth)
+
+      self.refreshCustomHeaders()
+      if not self.__custom_headers or 'User-Agent' not in self.__custom_headers:
+        user_agent = 'Python/ImpalaHttpClient'
+        script = os.path.basename(sys.argv[0])
+        if script:
+          user_agent = '%s (%s)' % (user_agent, urllib.parse.quote(script))
+        self.__http.putheader('User-Agent', user_agent)
+
+      if self.__custom_headers:
+        for key, val in six.iteritems(self.__custom_headers):
+          self.__http.putheader(key, val)
+
+      self.__http.endheaders()
+
+      # Write payload
+      self.__http.send(data)
+
+      # Get reply to flush the request
+      self.__http_response = self.__http.getresponse()
+      self.code = self.__http_response.status
+      self.message = self.__http_response.reason
+      self.headers = self.__http_response.msg
+      self.setAuthCookie()
 
     # Pull data out of buffer
     data = self.__wbuf.getvalue()
     self.__wbuf = BytesIO()
 
-    # HTTP request
-    if self.using_proxy() and self.scheme == "http":
-      # need full URL of real host for HTTP proxy here (HTTPS uses CONNECT tunnel)
-      self.__http.putrequest('POST', "http://%s:%s%s" %
-                             (self.realhost, self.realport, self.path))
-    else:
-      self.__http.putrequest('POST', self.path)
+    sendRequestRecvResp(data)
 
-    # Write headers
-    self.__http.putheader('Content-Type', 'application/x-thrift')
-    data_len = len(data)
-    self.__http.putheader('Content-Length', str(data_len))
-    if data_len > ImpalaHttpClient.MIN_REQUEST_SIZE_FOR_EXPECT:
-      # Add the 'Expect' header to large requests. Note that we do not explicitly wait for
-      # the '100 continue' response before sending the data - HTTPConnection simply
-      # ignores these types of responses, but we'll get the right behavior anyways.
-      self.__http.putheader("Expect", "100-continue")
-    if self.using_proxy() and self.scheme == "http" and self.proxy_auth is not None:
-      self.__http.putheader("Proxy-Authorization", self.proxy_auth)
-
-    if not self.__custom_headers or 'User-Agent' not in self.__custom_headers:
-      user_agent = 'Python/ImpalaHttpClient'
-      script = os.path.basename(sys.argv[0])
-      if script:
-        user_agent = '%s (%s)' % (user_agent, urllib.parse.quote(script))
-      self.__http.putheader('User-Agent', user_agent)
-
-    if self.__custom_headers:
-      for key, val in six.iteritems(self.__custom_headers):
-        self.__http.putheader(key, val)
-
-    self.__http.endheaders()
-
-    # Write payload
-    self.__http.send(data)
-
-    # Get reply to flush the request
-    self.__http_response = self.__http.getresponse()
-    self.code = self.__http_response.status
-    self.message = self.__http_response.reason
-    self.headers = self.__http_response.msg
+    # A '401 Unauthorized' response might mean that we tried cookie-based authentication
+    # with an expired cookie.
+    # Delete the cookie and try again.
+    if self.code == 401 and self.getAuthCookie():
+      log.debug('Received "401 Unauthorized" response. '
+                'Delete auth cookie and then retry.')
+      self.deleteAuthCookie()
+      sendRequestRecvResp(data)
 
     if self.code >= 300:
       # Report any http response code that is not 1XX (informational response) or
@@ -317,7 +381,8 @@ def get_socket(host, port, use_ssl, ca_cert):
 
 def get_http_transport(host, port, http_path, timeout=None, use_ssl=False,
                        ca_cert=None, auth_mechanism='NOSASL', user=None,
-                       password=None):
+                       password=None, kerberos_host=None, kerberos_service_name=None,
+                       auth_cookie_name=None):
     # TODO: support timeout
     if timeout is not None:
         log.error('get_http_transport does not support a timeout')
@@ -325,14 +390,14 @@ def get_http_transport(host, port, http_path, timeout=None, use_ssl=False,
         url = 'https://%s:%s/%s' % (host, port, http_path)
         log.debug('get_http_transport url=%s', url)
         # TODO(#362): Add server authentication with thrift 0.12.
-        transport = ImpalaHttpClient(url)
+        transport = ImpalaHttpClient(url, auth_cookie_name=auth_cookie_name)
     else:
         url = 'http://%s:%s/%s' % (host, port, http_path)
         log.debug('get_http_transport url=%s', url)
-        transport = ImpalaHttpClient(url)
+        transport = ImpalaHttpClient(url, auth_cookie_name=auth_cookie_name)
 
-    # Set defaults for PLAIN SASL / LDAP connections.
     if auth_mechanism in ['PLAIN', 'LDAP']:
+        # Set defaults for PLAIN SASL / LDAP connections.
         if user is None:
             user = getpass.getuser()
             log.debug('get_http_transport: user=%s', user)
@@ -352,6 +417,23 @@ def get_http_transport(host, port, http_path, timeout=None, use_ssl=False,
             auth = base64.encodestring(user_password).decode().strip('\n')
 
         transport.setCustomHeaders({'Authorization': 'Basic %s' % auth})
+
+    elif auth_mechanism == 'GSSAPI':
+        # For GSSAPI over http we need to dynamically generate custom request headers.
+        def get_auth_headers(auth_cookie):
+            import kerberos
+            if auth_cookie:
+                cookie_value = auth_cookie.output(attrs=['value'], header='' ).strip()
+                return {'Cookie': cookie_value}
+            else:
+                _, krb_context = kerberos.authGSSClientInit("%s@%s" %
+                                    (kerberos_service_name, kerberos_host))
+                kerberos.authGSSClientStep(krb_context, "")
+                negotiate_details = kerberos.authGSSClientResponse(krb_context)
+                return {"Authorization": "Negotiate " + negotiate_details}
+
+        transport.setGetCustomHeadersFunc(get_auth_headers)
+        transport.refreshCustomHeaders()
 
     return transport
 

--- a/impala/dbapi.py
+++ b/impala/dbapi.py
@@ -42,7 +42,7 @@ def connect(host='localhost', port=21050, database=None, timeout=None,
             password=None, kerberos_service_name='impala', use_ldap=None,
             ldap_user=None, ldap_password=None, use_kerberos=None,
             protocol=None, krb_host=None, use_http_transport=False,
-            http_path=''):
+            http_path='', auth_cookie_name=None):
     """Get a connection to HiveServer2 (HS2).
 
     These options are largely compatible with the impala-shell command line
@@ -80,6 +80,14 @@ def connect(host='localhost', port=21050, database=None, timeout=None,
         `'impala'` by default.
     use_ldap : bool, optional
         Specify `auth_mechanism='LDAP'` instead.
+    use_http_transport: bool optional
+        Set it to True to use http transport of False to use binary transport.
+    http_path: str, optional
+        Specify the path in the http URL. Used only when `use_http_transport` is True.
+    auth_cookie_name: str, optional
+        Specify the name of the cookie used for cookie-based authentication. Used only
+        when `use_http_transport` is True.
+        Currently cookie-based authentication is only supported for GSSAPI over http.
 
         .. deprecated:: 0.11.0
     ldap_user : str, optional
@@ -147,7 +155,8 @@ def connect(host='localhost', port=21050, database=None, timeout=None,
                           kerberos_service_name=kerberos_service_name,
                           auth_mechanism=auth_mechanism, krb_host=krb_host,
                           use_http_transport=use_http_transport,
-                          http_path=http_path)
+                          http_path=http_path,
+                          auth_cookie_name=auth_cookie_name)
     return hs2.HiveServer2Connection(service, default_db=database)
 
 

--- a/impala/dbapi.py
+++ b/impala/dbapi.py
@@ -42,7 +42,7 @@ def connect(host='localhost', port=21050, database=None, timeout=None,
             password=None, kerberos_service_name='impala', use_ldap=None,
             ldap_user=None, ldap_password=None, use_kerberos=None,
             protocol=None, krb_host=None, use_http_transport=False,
-            http_path='', auth_cookie_name=None):
+            http_path='', auth_cookie_names=['impala.auth', 'hive.server2.auth']):
     """Get a connection to HiveServer2 (HS2).
 
     These options are largely compatible with the impala-shell command line
@@ -84,9 +84,15 @@ def connect(host='localhost', port=21050, database=None, timeout=None,
         Set it to True to use http transport of False to use binary transport.
     http_path: str, optional
         Specify the path in the http URL. Used only when `use_http_transport` is True.
-    auth_cookie_name: str, optional
-        Specify the name of the cookie used for cookie-based authentication. Used only
-        when `use_http_transport` is True.
+    auth_cookie_names: list of str or str, optional
+        Specify the list of possible names for the cookie used for cookie-based
+        authentication. If the list of names contains one cookie name only, a str value
+        can be specified instead of a list.
+        Used only when `use_http_transport` is True.
+        By default 'auth_cookie_names' is set to the list of auth cookie names used by
+        Impala and Hive.
+        If 'auth_cookie_names' is explicitly set to an empty value (None, [], or ''),
+        Impyla won't attempt to do cookie based authentication.
         Currently cookie-based authentication is only supported for GSSAPI over http.
 
         .. deprecated:: 0.11.0
@@ -156,7 +162,7 @@ def connect(host='localhost', port=21050, database=None, timeout=None,
                           auth_mechanism=auth_mechanism, krb_host=krb_host,
                           use_http_transport=use_http_transport,
                           http_path=http_path,
-                          auth_cookie_name=auth_cookie_name)
+                          auth_cookie_names=auth_cookie_names)
     return hs2.HiveServer2Connection(service, default_db=database)
 
 

--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -796,29 +796,30 @@ def threaded(func):
 def connect(host, port, timeout=None, use_ssl=False, ca_cert=None,
             user=None, password=None, kerberos_service_name='impala',
             auth_mechanism=None, krb_host=None, use_http_transport=False,
-            http_path=''):
+            http_path='', auth_cookie_name=None):
     log.debug('Connecting to HiveServer2 %s:%s with %s authentication '
               'mechanism', host, port, auth_mechanism)
+
+    if krb_host:
+        kerberos_host = krb_host
+    else:
+        kerberos_host = host
 
     if use_http_transport:
         # TODO(#362): Add server authentication with thrift 0.12.
         if ca_cert:
             raise NotSupportedError("Server authentication is not supported " +
                                     "with HTTP endpoints")
-        if krb_host:
-            raise NotSupportedError("Kerberos authentication is not " +
-                                    "supported with HTTP endpoints")
+
         transport = get_http_transport(host, port, http_path=http_path,
                                        use_ssl=use_ssl, ca_cert=ca_cert,
+                                       auth_mechanism=auth_mechanism,
                                        user=user, password=password,
-                                       auth_mechanism=auth_mechanism)
+                                       kerberos_host=kerberos_host,
+                                       kerberos_service_name=kerberos_service_name,
+                                       auth_cookie_name=auth_cookie_name)
     else:
         sock = get_socket(host, port, use_ssl, ca_cert)
-
-        if krb_host:
-            kerberos_host = krb_host
-        else:
-            kerberos_host = host
 
         if timeout is not None:
             timeout = timeout * 1000.  # TSocket expects millis

--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -796,7 +796,7 @@ def threaded(func):
 def connect(host, port, timeout=None, use_ssl=False, ca_cert=None,
             user=None, password=None, kerberos_service_name='impala',
             auth_mechanism=None, krb_host=None, use_http_transport=False,
-            http_path='', auth_cookie_name=None):
+            http_path='', auth_cookie_names=None):
     log.debug('Connecting to HiveServer2 %s:%s with %s authentication '
               'mechanism', host, port, auth_mechanism)
 
@@ -817,7 +817,7 @@ def connect(host, port, timeout=None, use_ssl=False, ca_cert=None,
                                        user=user, password=password,
                                        kerberos_host=kerberos_host,
                                        kerberos_service_name=kerberos_service_name,
-                                       auth_cookie_name=auth_cookie_name)
+                                       auth_cookie_names=auth_cookie_names)
     else:
         sock = get_socket(host, port, use_ssl, ca_cert)
 

--- a/impala/tests/test_util.py
+++ b/impala/tests/test_util.py
@@ -1,0 +1,126 @@
+# Copyright 2013 Cloudera Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import sys
+from datetime import datetime, timedelta
+
+if sys.version_info[:2] <= (2, 6):
+    import unittest2 as unittest
+else:
+    import unittest
+
+import pytest
+from impala.util import cookie_matches_path, get_cookie_expiry, get_first_matching_cookie
+
+
+class ImpalaUtilTests(unittest.TestCase):
+    def test_cookie_matches_path(self):
+        assert cookie_matches_path({}, '/')
+        assert cookie_matches_path({}, '')
+        assert cookie_matches_path({}, 'cliservice')
+        assert cookie_matches_path({}, '/cliservice')
+        assert cookie_matches_path({}, '/cliservice/')
+
+        assert cookie_matches_path({'path': ''}, '/')
+        assert cookie_matches_path({'path': '/'}, '')
+        assert cookie_matches_path({'path': '/'}, 'clisevice')
+        assert cookie_matches_path({'path': '/'}, '/clisevice')
+
+        assert not cookie_matches_path({'path': '/cliservice'}, '')
+        assert not cookie_matches_path({'path': '/cliservice'}, '/')
+        assert cookie_matches_path({'path': '/cliservice'}, 'cliservice')
+        assert cookie_matches_path({'path': 'cliservice'}, '/cliservice')
+        assert cookie_matches_path({'path': '/cliservice/'}, '/cliservice/')
+        assert cookie_matches_path({'path': '/cliservice'}, 'cliservice/abc/def/ghi')
+        assert cookie_matches_path({'path': '/cliservice/'}, 'cliservice/?q=abcd')
+
+        assert not cookie_matches_path({'path': '/a/b/c//'}, '/a')
+        assert not cookie_matches_path({'path': '/a/b/c//'}, '/a/b')
+        assert cookie_matches_path({'path': '/a/b/c//'}, 'a/b/c')
+        assert cookie_matches_path({'path': '/a/b/c//'}, '/a/b/c')
+        assert cookie_matches_path({'path': '/a/b/c//'}, 'a/b/c/d')
+        assert cookie_matches_path({'path': '/a/b/c//'}, '/a/b/c/d')
+        assert cookie_matches_path({'path': '/a/b/c//'}, '/a/b/c/d/e/f/g/h')
+
+    def test_get_cookie_expiry(self):
+        assert get_cookie_expiry({}) is None
+        assert get_cookie_expiry({'max-age': ''}) is None
+
+        hour = timedelta(hours=1)
+        sec = timedelta(seconds=1)
+        now = datetime.now()
+        assert now <= get_cookie_expiry({'max-age': '0'}) <= now + sec
+        now = datetime.now()
+        assert now - sec <= get_cookie_expiry({'max-age': '-1'}) <= now
+
+        now = datetime.now()
+        assert now - hour <= get_cookie_expiry({'max-age': '-3600'}) <= now - hour + sec
+        now = datetime.now()
+        assert now + hour <= get_cookie_expiry({'max-age': '3600'}) <= now + hour + sec
+
+        now = datetime.now()
+        days2k = timedelta(days=2000)
+        assert now - days2k <= get_cookie_expiry({'max-age': '-172800000'}) <= now - days2k + sec
+        now = datetime.now()
+        assert now + days2k <= get_cookie_expiry({'max-age': '172800000'}) <= now + days2k + sec
+
+
+    def test_get_first_matching_cookie(self):
+        assert get_first_matching_cookie(['a', 'b'], '/path', {}) is None
+
+        headers = {'Set-Cookie': '''c_cookie=c_value
+        b_cookie=b_value
+        a_cookie=a_value'''}
+        c = get_first_matching_cookie(['a_cookie', 'b_cookie'], '/path', headers)
+        assert c.key == 'a_cookie' and c.value == 'a_value'
+        c = get_first_matching_cookie(['b_cookie', 'a_cookie'], '/path', headers)
+        assert c.key == 'b_cookie' and c.value == 'b_value'
+
+        headers = {'Set-Cookie': '''c_cookie=c_value;Path=/
+        b_cookie=b_value;Path=/path
+        a_cookie=a_value;Path=/'''}
+        c = get_first_matching_cookie(['a_cookie', 'b_cookie'], '/path', headers)
+        assert c.key == 'a_cookie' and c.value == 'a_value'
+        c = get_first_matching_cookie(['b_cookie', 'a_cookie'], '/path', headers)
+        assert c.key == 'b_cookie' and c.value == 'b_value'
+
+        headers = {'Set-Cookie': '''c_cookie=c_value;Path=/
+        b_cookie=b_value;Path=/path
+        a_cookie=a_value;Path=/path/path2'''}
+        c = get_first_matching_cookie(['a_cookie', 'b_cookie'], '/path', headers)
+        assert c.key == 'b_cookie' and c.value == 'b_value'
+        c = get_first_matching_cookie(['b_cookie', 'a_cookie'], '/path', headers)
+        assert c.key == 'b_cookie' and c.value == 'b_value'
+
+        headers = {'Set-Cookie': '''c_cookie=c_value;Path=/
+        b_cookie=b_value;Path=/path
+        a_cookie=a_value;Path=/path'''}
+        c = get_first_matching_cookie(['a_cookie', 'b_cookie'], '/path/path1', headers)
+        assert c.key == 'a_cookie' and c.value == 'a_value'
+        c = get_first_matching_cookie(['b_cookie', 'a_cookie'], '/path/path1', headers)
+        assert c.key == 'b_cookie' and c.value == 'b_value'
+
+        headers = {'Set-Cookie': '''c_cookie=c_value;Path=/
+        b_cookie=b_value;Path=/path1
+        a_cookie=a_value;Path=/path2'''}
+        c = get_first_matching_cookie(['a_cookie', 'b_cookie'], '/path', headers)
+        assert c is None
+
+        headers = {'Set-Cookie': '''c_cookie=c_value;Path=/
+        b_cookie=b_value;Path=/path1
+        a_cookie=a_value;Path=/path2'''}
+        c = get_first_matching_cookie(['a_cookie', 'b_cookie', 'c_cookie'], '/path', headers)
+        assert c.key == 'c_cookie' and c.value == 'c_value'

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         ":python_version>='3.0'": ["thriftpy2>=0.4.0,<0.5.0",
                                    ],
         "kerberos": ["thrift_sasl==0.2.1",
-                     "kerberos",
+                     "kerberos>=1.3.0",
                     ],
     },
     keywords=('cloudera impala python hadoop sql hdfs mpp spark pydata '

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup(
         ":python_version>='3.0'": ["thriftpy2>=0.4.0,<0.5.0",
                                    ],
         "kerberos": ["thrift_sasl==0.2.1",
+                     "kerberos",
                     ],
     },
     keywords=('cloudera impala python hadoop sql hdfs mpp spark pydata '


### PR DESCRIPTION
The implementation adds a new dependency on 'kerberos' python module,
which is a pip-installed module distributed under Apache License Version 2.

When using impyla with GSSAPI over http, it is assumed that the client has a
preexisting kinit-cached Kerberos ticket that impyla can pass to the server
automatically without the user needing to reenter their password.

Examples:

1. Hive
from impala.dbapi import connect
conn = connect('hiveserver2.example.com', 10001,
  auth_mechanism="GSSAPI",
  kerberos_service_name='hive',
  use_http_transport=True,
  http_path='cliservice',
  auth_cookie_name='hive.server2.auth')
cursor = conn.cursor()
cursor.execute("show databases")
res = cursor.fetchall()

2. Impala
from impala.dbapi import connect
conn = connect('impala-coordinator.exmple.com', 28000,
  auth_mechanism="GSSAPI",
  kerberos_service_name='impala',
  use_http_transport=True,
  http_path='cliservice',
  auth_cookie_name='impala.auth')
cursor = conn.cursor()
cursor.execute("show databases")
res = cursor.fetchall()