### PR TITLE
Fix specifying dependency on thrift package

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Required:
 
 * `six`, `bitarray`
 
-* `thrift` for Python 2.x
+* `thrift==0.9.3` for Python 2.x
 
 * `thriftpy2` for Python 3+
 

--- a/setup.py
+++ b/setup.py
@@ -41,8 +41,9 @@ setup(
     packages=find_packages(),
     install_package_data=True,
     package_data={'impala.thrift': ['*.thrift']},
-    install_requires=['six', 'bitarray', 'thrift>=0.9.3'],
+    install_requires=['six', 'bitarray'],
     extras_require={
+        ":python_version<'3.0'": ["thrift==0.9.3"],
         ":python_version>='3.0'": ["thriftpy2>=0.4.0,<0.5.0",
                                    ],
         "kerberos": ["thrift_sasl==0.2.1",


### PR DESCRIPTION
- thrift package is not used with Python 3
- pin thrift version to 0.9.3 for Python 2

Tested with Python 2 and Python 3