### PR TITLE
Implement simple retry which throws the underlying HttpError if retrying fails

### DIFF
--- a/impala/_thrift_api.py
+++ b/impala/_thrift_api.py
@@ -340,7 +340,7 @@ class ImpalaHttpClient(TTransportBase):
       # Report any http response code that is not 1XX (informational response) or
       # 2XX (successful).
       body = self.readBody()
-      raise HttpError(self.code, self.message, body)
+      raise HttpError(self.code, self.message, body, self.headers)
 
 
 def get_socket(host, port, use_ssl, ca_cert):

--- a/impala/dbapi.py
+++ b/impala/dbapi.py
@@ -42,7 +42,8 @@ def connect(host='localhost', port=21050, database=None, timeout=None,
             password=None, kerberos_service_name='impala', use_ldap=None,
             ldap_user=None, ldap_password=None, use_kerberos=None,
             protocol=None, krb_host=None, use_http_transport=False,
-            http_path='', auth_cookie_names=['impala.auth', 'hive.server2.auth']):
+            http_path='', auth_cookie_names=['impala.auth', 'hive.server2.auth'],
+            retries=3):
     """Get a connection to HiveServer2 (HS2).
 
     These options are largely compatible with the impala-shell command line
@@ -162,7 +163,8 @@ def connect(host='localhost', port=21050, database=None, timeout=None,
                           auth_mechanism=auth_mechanism, krb_host=krb_host,
                           use_http_transport=use_http_transport,
                           http_path=http_path,
-                          auth_cookie_names=auth_cookie_names)
+                          auth_cookie_names=auth_cookie_names,
+                          retries=retries)
     return hs2.HiveServer2Connection(service, default_db=database)
 
 

--- a/impala/error.py
+++ b/impala/error.py
@@ -70,10 +70,11 @@ class HiveServer2Error(RPCError):
 
 class HttpError(RPCError):
     """An error containing an http response code"""
-    def __init__(self, code, message, body):
+    def __init__(self, code, message, body, http_headers):
         self.code = code
         self.message = message
         self.body = body
+        self.http_headers = http_headers
 
     def __str__(self):
         # Don't try to print the body as we don't know what format it is.

--- a/impala/tests/test_dbapi_connect.py
+++ b/impala/tests/test_dbapi_connect.py
@@ -14,8 +14,9 @@
 
 from __future__ import absolute_import, print_function
 
-import os
 import sys
+
+from impala.error import NotSupportedError
 
 if sys.version_info[:2] <= (2, 6):
     import unittest2 as unittest
@@ -86,6 +87,15 @@ class ImpalaConnectionTests(unittest.TestCase):
     def test_hive_nosasl_connect(self):
         self.connection = connect(ENV.host, ENV.hive_port, timeout=5)
         self._execute_queries(self.connection)
+
+    def test_bad_auth(self):
+        """Test some simple error messages"""
+        try:
+            connect(ENV.host, ENV.port, auth_mechanism="foo")
+            assert False, "should have got exception"
+        except NotSupportedError as e:
+            assert 'Unsupported authentication mechanism: FOO' in str(e)
+
 
 class ImpalaSocketTests(unittest.TestCase):
 

--- a/impala/tests/test_hs2_fault_injection.py
+++ b/impala/tests/test_hs2_fault_injection.py
@@ -1,0 +1,364 @@
+# Copyright 2020 Cloudera Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+
+import six
+
+if six.PY2:
+    from thrift.protocol.TBinaryProtocol import (
+        TBinaryProtocolAccelerated as TBinaryProtocol)
+    # noinspection PyProtectedMember
+    from impala._thrift_gen.ImpalaService import ImpalaHiveServer2Service
+
+    ThriftClient = ImpalaHiveServer2Service.Client
+
+if six.PY3:
+    # When using python 3, import from thriftpy2 rather than thrift
+    # TODO: reenable cython
+    from thriftpy2.protocol.binary import TBinaryProtocol  # noqa
+    from thriftpy2.transport import (TSocket, TTransportException, TTransportBase)  # noqa
+    from thriftpy2.transport.buffered import TBufferedTransport  # noqa
+
+from impala import hiveserver2 as hs2
+from impala._thrift_api import ThriftClient, ImpalaHttpClient, ImpalaHiveServer2Service
+from impala.error import HttpError
+from impala.hiveserver2 import HS2Service
+from impala.tests.util import ImpylaTestEnv
+
+ENV = ImpylaTestEnv()
+
+
+# This code is based on https://github.com/apache/impala/blob/master/tests/custom_cluster/test_hs2_fault_injection.py
+
+
+class FaultInjectingHttpClient(ImpalaHttpClient, object):
+    """Class for injecting faults into ImpalaHttpClient. Faults are injected by using the
+    'enable_fault' method. The 'flush' method is overridden to check for injected faults
+    and raise exceptions, if needed."""
+
+    def __init__(self, *args, **kwargs):
+        super(FaultInjectingHttpClient, self).__init__(*args, **kwargs)
+        self.fault_code = None
+        self.fault_message = None
+        self.fault_enabled = False
+        self.num_requests = 0
+        self.fault_frequency = 0
+
+    # noinspection PyAttributeOutsideInit
+    def enable_fault(self, http_code, http_message, fault_frequency, fault_body=None,
+                     fault_headers=None, set_num_requests=None):
+        """Inject fault with given code and message at the given frequency.
+        As an example, if frequency is 20% then inject fault for 1 out of every 5
+        requests."""
+        if fault_headers is None:
+            fault_headers = {}
+        self.fault_enabled = True
+        self.fault_code = http_code
+        self.fault_message = http_message
+        self.fault_frequency = fault_frequency
+        assert 0 < fault_frequency <= 1
+        if set_num_requests is not None:
+            self.num_requests = set_num_requests
+        else:
+            self.num_requests = 0
+        self.fault_body = fault_body
+        self.fault_headers = fault_headers
+
+    def disable_fault(self):
+        self.fault_enabled = False
+
+    def _check_code(self):
+        if self.code >= 300:
+            # Report any http response code that is not 1XX (informational response) or
+            # 2XX (successful).
+            raise HttpError(self.code, self.message, self.body, self.headers)
+
+    def _inject_fault(self):
+        if not self.fault_enabled:
+            return False
+        if self.fault_frequency == 1:
+            return True
+        if round(self.num_requests % (1 / self.fault_frequency)) == 1:
+            return True
+        return False
+
+    # noinspection PyAttributeOutsideInit
+    def flush(self):
+        ImpalaHttpClient.flush(self)
+        self.num_requests += 1
+        # Override code and message with the injected fault
+        if self.fault_code is not None and self._inject_fault():
+            self.code = self.fault_code
+            self.message = self.fault_message
+            self.body = self.fault_body
+            self.headers = self.fault_headers
+            self._check_code()
+
+    def _read(self, sz):
+        """Keep pep8 quiet"""
+        pass
+
+
+# noinspection PyMethodMayBeStatic
+class TestHS2FaultInjection(object):
+    """Class for testing the http fault injection in various rpcs used by Impyla"""
+
+    def setup(self):
+        url = 'http://%s:%s/%s' % (ENV.host, ENV.http_port, "cliservice")
+        self.transport = FaultInjectingHttpClient(url)
+        self.configuration = {'idle_session_timeout': '30'}
+
+    def teardown(self):
+        self.transport.disable_fault()
+
+    def connect(self):
+        self.transport.open()
+        protocol = TBinaryProtocol(self.transport)
+        service = None
+        if six.PY2:
+            # ThriftClient == ImpalaHiveServer2Service.Client
+            service = ThriftClient(protocol)
+        elif six.PY3:
+            # ThriftClient == TClient
+            # service = ThriftClient(protocol)
+            service = ThriftClient(ImpalaHiveServer2Service, protocol)
+        service = HS2Service(service, retries=3)
+        return hs2.HiveServer2Connection(service, default_db=None)
+
+    def __expect_msg_retry(self, impala_rpc_name):
+        """Returns expected log message for rpcs which can be retried"""
+        return ("Caught HttpError HTTP code 502: Injected Fault  in {0} (tries_left=3)".
+                format(impala_rpc_name))
+
+    def __expect_msg_retry_with_extra(self, impala_rpc_name):
+        """Returns expected log message for rpcs which can be retried and where the http
+        message has a message body"""
+        return ("Caught HttpError HTTP code 503: Injected Fault EXTRA in {0} (tries_left=3)".
+                format(impala_rpc_name))
+
+    def __expect_msg_retry_with_retry_after(self, impala_rpc_name):
+        """Returns expected log message for rpcs which can be retried and where the http
+        message has a body and a Retry-After header that can be correctly decoded"""
+        return ("Caught HttpError HTTP code 503: Injected Fault EXTRA in {0} (tries_left=3), retry after 1 secs".
+                format(impala_rpc_name))
+
+    def __expect_msg_retry_with_retry_after_sleep(self):
+        """Returns expected log message for the sleep which uses a value
+        from the Retry-After header"""
+        return ("sleeping after seeing Retry-After value of 1")
+
+    def __expect_msg_retry_after_default_sleep(self):
+        """Returns expected log message for the default sleep time of 1 second"""
+        return ("sleeping for 1 second before retrying")
+
+    def __expect_msg_retry_with_retry_after_no_extra(self, impala_rpc_name):
+        """Returns expected log message for rpcs which can be retried and the http
+        message has a Retry-After header that can be correctly decoded"""
+        return ("Caught HttpError HTTP code 503: Injected Fault  in {0} (tries_left=3), retry after 1 secs".
+                format(impala_rpc_name))
+
+    def __expect_msg_no_retry(self, impala_rpc_name):
+        """Returns expected log message for rpcs which can not be retried"""
+        return ("Caught HttpError HTTP code 502: Injected Fault  in {0} which is not retryable".
+                format(impala_rpc_name))
+
+    def test_connect(self, caplog):
+        """Tests fault injection in cursor() call.
+        OpenSession rpc fails.
+        Retries results in a successful connection."""
+        caplog.set_level(logging.DEBUG)
+        self.transport.enable_fault(502, "Injected Fault", 0.2)
+        con = self.connect()
+        cur = con.cursor(configuration=self.configuration)
+        cur.close()
+        con.close()
+        assert self.__expect_msg_retry("OpenSession") in caplog.text
+
+    def test_connect_proxy(self, caplog):
+        """Tests fault injection in cursor() call.
+        The injected error has a message body.
+        OpenSession rpc fails.
+        Retries results in a successful connection."""
+        caplog.set_level(logging.DEBUG)
+        self.transport.enable_fault(503, "Injected Fault", 0.20, 'EXTRA')
+        con = self.connect()
+        cur = con.cursor(configuration=self.configuration)
+        cur.close()
+        con.close()
+        assert self.__expect_msg_retry_with_extra("OpenSession") in caplog.text
+        assert self.__expect_msg_retry_after_default_sleep() in caplog.text
+
+    def test_connect_proxy_no_retry(self, caplog):
+        """Tests fault injection in cursor() call.
+        The injected error contains headers but no Retry-After header.
+        OpenSession rpc fails.
+        Retries results in a successful connection."""
+        caplog.set_level(logging.DEBUG)
+        self.transport.enable_fault(503, "Injected Fault", 0.20, 'EXTRA',
+                                    {"header1": "value1"})
+        con = self.connect()
+        cur = con.cursor(configuration=self.configuration)
+        cur.close()
+        con.close()
+        assert self.__expect_msg_retry_with_extra("OpenSession") in caplog.text
+        assert self.__expect_msg_retry_after_default_sleep() in caplog.text
+
+    def test_connect_proxy_bad_retry(self, caplog):
+        """Tests fault injection in cursor() call.
+        The injected error contains a body and a junk Retry-After header.
+        OpenSession rpc fails.
+        Retries results in a successful connection."""
+        caplog.set_level(logging.DEBUG)
+        self.transport.enable_fault(503, "Injected Fault", 0.20, 'EXTRA',
+                                    {"header1": "value1",
+                                     "Retry-After": "junk"})
+        con = self.connect()
+        cur = con.cursor(configuration=self.configuration)
+        cur.close()
+        con.close()
+        assert self.__expect_msg_retry_with_extra("OpenSession") in caplog.text
+        assert self.__expect_msg_retry_after_default_sleep() in caplog.text
+
+    def test_connect_proxy_retry(self, caplog):
+        """Tests fault injection in cursor() call.
+        The injected error contains a body and a Retry-After header that can be decoded.
+        Retries results in a successful connection."""
+        caplog.set_level(logging.DEBUG)
+        self.transport.enable_fault(503, "Injected Fault", 0.20, 'EXTRA',
+                                    {"header1": "value1",
+                                     "Retry-After": "1"})
+        con = self.connect()
+        cur = con.cursor(configuration=self.configuration)
+        cur.close()
+        con.close()
+        assert self.__expect_msg_retry_with_retry_after("OpenSession") in caplog.text
+        assert self.__expect_msg_retry_with_retry_after_sleep() in caplog.text
+
+    def test_connect_proxy_retry_no_body(self, caplog):
+        """Tests fault injection in cursor() call.
+        The injected error has no body but does have a Retry-After header that can be decoded.
+        Retries results in a successful connection."""
+        caplog.set_level(logging.DEBUG)
+        self.transport.enable_fault(503, "Injected Fault", 0.20, None,
+                                    {"header1": "value1",
+                                     "Retry-After": "1"})
+        con = self.connect()
+        cur = con.cursor(configuration=self.configuration)
+        cur.close()
+        con.close()
+        assert self.__expect_msg_retry_with_retry_after_no_extra("OpenSession") in caplog.text
+
+    def test_execute_query(self, caplog):
+        """Tests fault injection in execute().
+        ExecuteStatement rpc fails and results in error since retries are not supported."""
+        con = self.connect()
+        cur = con.cursor(configuration=self.configuration)
+        caplog.set_level(logging.DEBUG)
+        self.transport.enable_fault(502, "Injected Fault", 0.50)
+
+        query_handle = None
+        try:
+            query_handle = cur.execute('select 1')
+            assert False, 'execute should have failed'
+        except HttpError as e:
+            assert str(e) == 'HTTP code 502: Injected Fault'
+        assert query_handle is None
+        cur.close()
+        con.close()
+        assert self.__expect_msg_no_retry("ExecuteStatement") in caplog.text
+
+    def test_get_query_state(self, caplog):
+        """Tests fault injection in fetchall().
+        GetOperationStatus rpc fails but is retried successfully."""
+        con = self.connect()
+        cur = con.cursor(configuration=self.configuration)
+        caplog.set_level(logging.DEBUG)
+        cur.execute('select 1', {})
+        self.transport.enable_fault(502, "Injected Fault", 0.1)
+        cur.fetchall()
+        cur.close()
+        con.close()
+        assert self.__expect_msg_retry("GetOperationStatus") in caplog.text
+
+    def test_get_result_set_metadata(self, caplog):
+        """Tests fault injection in fetchcbatch().
+        GetResultSetMetadata rpc fails and is retried succesfully."""
+        con = self.connect()
+        cur = con.cursor(configuration=self.configuration)
+        caplog.set_level(logging.DEBUG)
+        cur.execute('select 1', {})
+        self.transport.enable_fault(502, "Injected Fault", 0.1)
+        cur.fetchcbatch()
+        cur.close()
+        con.close()
+        assert self.__expect_msg_retry("GetResultSetMetadata") in caplog.text
+
+    def test_fetch_results(self, caplog):
+        """Tests fault injection in fetchcbatch().
+        FetchResults rpc fails and cannot be retried."""
+        con = self.connect()
+        cur = con.cursor(configuration=self.configuration)
+        caplog.set_level(logging.DEBUG)
+        cur.execute('select 1', {})
+        try:
+            self.transport.enable_fault(502, "Injected Fault", 0.5, set_num_requests=1)
+            cur.fetchcbatch()
+            assert False, 'should see exception'
+        except HttpError as e:
+            assert str(e) == 'HTTP code 502: Injected Fault'
+        self.transport.disable_fault()
+        cur.close()
+        con.close()
+        assert self.__expect_msg_no_retry("FetchResults") in caplog.text
+
+    def test_close_operation(self, caplog):
+        """Tests fault injection in fetchcbatch().
+        CloseOperation rpc fails and cannot be retried.."""
+        con = self.connect()
+        cur = con.cursor(configuration=self.configuration)
+        caplog.set_level(logging.DEBUG)
+        cur.execute('select 1', {})
+        cur.fetchcbatch()
+        try:
+            self.transport.enable_fault(502, "Injected Fault", 0.5)
+            cur.close()
+        except HttpError as e:
+            assert str(e) == 'HTTP code 502: Injected Fault'
+        self.transport.disable_fault()
+        cur.close()
+        con.close()
+        assert self.__expect_msg_no_retry("CloseOperation") in caplog.text
+
+    def test_get_runtime_profile_summary(self, caplog):
+        """Tests fault injection in get_profile(), get_summary(), and get_log().
+        GetRuntimeProfile, GetExecSummary and GetLog rpcs fail due to fault, but succeed
+        after retries"""
+        con = self.connect()
+        cur = con.cursor(configuration=self.configuration)
+        caplog.set_level(logging.DEBUG)
+        cur.execute('select 1', {})
+        cur.fetchcbatch()
+        self.transport.enable_fault(502, "Injected Fault", 0.50)
+        profile = cur.get_profile()
+        assert profile is not None
+        summary = cur.get_summary()
+        assert summary is not None
+        ret_log = cur.get_log()
+        assert ret_log is not None
+        self.transport.disable_fault()
+        cur.close()
+        con.close()
+        assert self.__expect_msg_retry("GetRuntimeProfile") in caplog.text
+        assert self.__expect_msg_retry("GetExecSummary") in caplog.text
+        assert self.__expect_msg_retry("GetLog") in caplog.text

--- a/impala/tests/test_http_connect.py
+++ b/impala/tests/test_http_connect.py
@@ -23,7 +23,9 @@ from six.moves import http_client
 from six.moves import socketserver
 
 from impala.error import HttpError
+from impala.tests.util import ImpylaTestEnv
 
+ENV = ImpylaTestEnv()
 
 @pytest.yield_fixture
 def http_503_server():
@@ -73,7 +75,7 @@ from impala.dbapi import connect
 
 class TestHttpConnect(object):
   def test_simple_connect(self):
-    con = connect("localhost", 28000, use_http_transport=True)
+    con = connect("localhost", ENV.http_port, use_http_transport=True, http_path="cliservice")
     cur = con.cursor()
     cur.execute('select 1')
     rows = cur.fetchall()

--- a/impala/tests/test_impala.py
+++ b/impala/tests/test_impala.py
@@ -11,11 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import sys
 
 import pytest
 from pytest import yield_fixture
 
 BIGGER_TABLE_NUM_ROWS = 100
+
+if sys.version_info >= (3, 0):
+    def xrange(*args, **kwargs):
+        return iter(range(*args, **kwargs))
 
 @yield_fixture(scope='module')
 def bigger_table(cur):

--- a/impala/tests/util.py
+++ b/impala/tests/util.py
@@ -25,13 +25,14 @@ def get_env_var(name, coercer, default):
     if name in os.environ:
         return coercer(os.environ[name])
     else:
-        sys.stderr.write("{0} not set; using {1!r}".format(name, default))
+        sys.stderr.write("{0} not set; using {1!r}\n".format(name, default))
         return default
 
 
 class ImpylaTestEnv(object):
 
-    def __init__(self, host=None, port=None, hive_port=None, auth_mech=None):
+    def __init__(self, host=None, port=None, hive_port=None, auth_mech=None,
+                 http_port=None):
         if host is not None:
             self.host = host
         else:
@@ -41,6 +42,11 @@ class ImpylaTestEnv(object):
             self.port = port
         else:
             self.port = get_env_var('IMPYLA_TEST_PORT', int, 21050)
+
+        if http_port is not None:
+            self.http_port = http_port
+        else:
+            self.http_port = get_env_var('IMPYLA_TEST_HTTP_PORT', int, 28000)
 
         if hive_port is not None:
             self.hive_port = hive_port


### PR DESCRIPTION

Copy design from IMPALA-9466 and add client retry for hs2-http protocol.
Added retries for idempotent rpcs: OpenSession, GetResultSetMetadata,
CancelOperation, GetOperationStatus, GetRuntimeProfile, GetExecSummary,
and GetLog. Not done were PingImpalaHS2Service (not available) and
CloseImpalaOperation (as we cannot distinguish the non-dml statements
which are idempotent) Ported test_hs2_fault_injection.py from Impala
shell.

Add http_headers to HttpError and sleep if the 'Retry-After' header
contains an integer value.

Allow override of the http_port by setting IMPYLA_TEST_HTTP_PORT

All tests ran clean with Python2 and Python3.