### PR TITLE
Server certs should not be verified if SSL is enabled and ca_cert is not specified

### DIFF
--- a/impala/_thrift_api.py
+++ b/impala/_thrift_api.py
@@ -373,10 +373,18 @@ def get_http_transport(host, port, http_path, timeout=None, use_ssl=False,
     if timeout is not None:
         log.error('get_http_transport does not support a timeout')
     if use_ssl:
+        ssl_ctx = ssl.create_default_context(cafile=ca_cert)
+        if ca_cert:
+          ssl_ctx.verify_mode = ssl.CERT_REQUIRED
+        else:
+          ssl_ctx.check_hostname = False  # Mandated by the SSL lib for CERT_NONE mode.
+          ssl_ctx.verify_mode = ssl.CERT_NONE
+
         url = 'https://%s:%s/%s' % (host, port, http_path)
         log.debug('get_http_transport url=%s', url)
         # TODO(#362): Add server authentication with thrift 0.12.
-        transport = ImpalaHttpClient(url, auth_cookie_names=auth_cookie_names)
+        transport = ImpalaHttpClient(url, ssl_context=ssl_ctx,
+                                     auth_cookie_names=auth_cookie_names)
     else:
         url = 'http://%s:%s/%s' % (host, port, http_path)
         log.debug('get_http_transport url=%s', url)


### PR DESCRIPTION
The docstring for connect() method in impala.dbapi module states:

ca_cert : str, optional
  Local path to the the third-party CA certificate. If SSL is enabled
  but the certificate is not specified, the server certificate will
  not be validated.

However, the current behavior is different: if SSL is enabled,
'ca_cert' is set to None and HTTP transport is used, impyla will still
check the server certificate and reject it if it is invalid (or
self-signed).

This behavior is incorrect and not in line with impala-shell.

Testing:
- All tests ran clean with Python2 and Python3.
- Manually tested against impala coordinator with self-signed server
  certificate.