### PR TITLE
Fix Thrift compilation with current Impala

### DIFF
--- a/impala/thrift/process_thrift.sh
+++ b/impala/thrift/process_thrift.sh
@@ -29,7 +29,7 @@ source $IMPALA_REPO/bin/impala-config.sh
 set -u
 
 echo "Copying thrift files from the main Impala repo at $IMPALA_REPO"
-cp $IMPALA_REPO/common/thrift/hive-2-api/TCLIService.thrift $IMPYLA_REPO/impala/thrift
+cp $IMPALA_REPO/common/thrift/hive-3-api/TCLIService.thrift $IMPYLA_REPO/impala/thrift
 cp $IMPALA_REPO/common/thrift/ImpalaService.thrift $IMPYLA_REPO/impala/thrift
 cp $IMPALA_REPO/common/thrift/ErrorCodes.thrift $IMPYLA_REPO/impala/thrift
 cp $IMPALA_REPO/common/thrift/ExecStats.thrift $IMPYLA_REPO/impala/thrift
@@ -39,7 +39,7 @@ cp $IMPALA_REPO/common/thrift/Status.thrift $IMPYLA_REPO/impala/thrift
 cp $IMPALA_REPO/common/thrift/Types.thrift $IMPYLA_REPO/impala/thrift
 
 echo "Copying thrift from $IMPALA_THRIFT_VERSION"
-cp $IMPALA_TOOLCHAIN/thrift-$IMPALA_THRIFT_VERSION/share/fb303/if/fb303.thrift \
+cp $IMPALA_TOOLCHAIN_PACKAGES_HOME/thrift-$IMPALA_THRIFT_VERSION/share/fb303/if/fb303.thrift \
     $IMPYLA_REPO/impala/thrift
 
 # beeswax.thrift already includes a namespace py declaration, which breaks my
@@ -50,7 +50,7 @@ grep -v 'namespace py beeswaxd' $IMPALA_REPO/common/thrift/beeswax.thrift \
 
 # hive_metastore.thrift assumes a directory structure for fb303.thrift, so we
 # change the include statement here
-cat $HIVE_SRC_DIR/metastore/if/hive_metastore.thrift \
+cat $HIVE_SRC_DIR/standalone-metastore/src/main/thrift/hive_metastore.thrift \
         | sed 's/share\/fb303\/if\///g' \
         > $IMPYLA_REPO/impala/thrift/hive_metastore.thrift
 
@@ -77,7 +77,7 @@ for THRIFT_FILE in $IMPYLA_REPO/impala/thrift/*.thrift; do
 done
 
 echo "Generating thrift python modules"
-THRIFT_BIN="$IMPALA_TOOLCHAIN/thrift-$IMPALA_THRIFT_VERSION/bin/thrift"
+THRIFT_BIN="$IMPALA_TOOLCHAIN_PACKAGES_HOME/thrift-$IMPALA_THRIFT_VERSION/bin/thrift"
 $THRIFT_BIN -r --gen py:new_style -out $IMPYLA_REPO $IMPYLA_REPO/impala/thrift/ImpalaService.thrift
 
 echo "Removing extraneous $IMPYLA_REPO/__init__.py"


### PR DESCRIPTION
impala/thrift/process_thrift.sh needs an Impala checkout to run, and
some of the directory locations needed to be updated to run with a
current Impala build.