### PR TITLE
Added "fetchType" to TFetchResultsReq.

### DIFF
--- a/impala/_thrift_gen/TCLIService/ttypes.py
+++ b/impala/_thrift_gen/TCLIService/ttypes.py
@@ -6182,6 +6182,7 @@ class TFetchResultsReq(object):
    - operationHandle
    - orientation
    - maxRows
+   - fetchType
   """
 
   thrift_spec = (
@@ -6189,12 +6190,14 @@ class TFetchResultsReq(object):
     (1, TType.STRUCT, 'operationHandle', (TOperationHandle, TOperationHandle.thrift_spec), None, ), # 1
     (2, TType.I32, 'orientation', None,     0, ), # 2
     (3, TType.I64, 'maxRows', None, None, ), # 3
+    (4, TType.I16, 'fetchType', None, 0, ), # 4
   )
 
-  def __init__(self, operationHandle=None, orientation=thrift_spec[2][4], maxRows=None,):
+  def __init__(self, operationHandle=None, orientation=thrift_spec[2][4], maxRows=None, fetchType=thrift_spec[4][4],):
     self.operationHandle = operationHandle
     self.orientation = orientation
     self.maxRows = maxRows
+    self.fetchType = fetchType
 
   def read(self, iprot):
     if iprot.__class__ == TBinaryProtocol.TBinaryProtocolAccelerated and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None and fastbinary is not None:
@@ -6221,6 +6224,11 @@ class TFetchResultsReq(object):
           self.maxRows = iprot.readI64()
         else:
           iprot.skip(ftype)
+      elif fid == 4:
+        if ftype == TType.I16:
+          self.fetchType = iprot.readI16()
+        else:
+          iprot.skip(ftype)
       else:
         iprot.skip(ftype)
       iprot.readFieldEnd()
@@ -6243,6 +6251,10 @@ class TFetchResultsReq(object):
       oprot.writeFieldBegin('maxRows', TType.I64, 3)
       oprot.writeI64(self.maxRows)
       oprot.writeFieldEnd()
+    if self.fetchType is not None:
+      oprot.writeFieldBegin('fetchType', TType.I16, 4)
+      oprot.writeI16(self.fetchType)
+      oprot.writeFieldEnd()
     oprot.writeFieldStop()
     oprot.writeStructEnd()
 
@@ -6261,6 +6273,7 @@ class TFetchResultsReq(object):
     value = (value * 31) ^ hash(self.operationHandle)
     value = (value * 31) ^ hash(self.orientation)
     value = (value * 31) ^ hash(self.maxRows)
+    value = (value * 31) ^ hash(self.fetchType)
     return value
 
   def __repr__(self):

--- a/impala/thrift/TCLIService.thrift
+++ b/impala/thrift/TCLIService.thrift
@@ -1058,6 +1058,9 @@ struct TFetchResultsReq {
   // Max number of rows that should be returned in
   // the rowset.
   3: required i64 maxRows
+
+  // The type of a fetch results request. 0 represents Query output. 1 represents Log
+  4: optional i16 fetchType = 0
 }
 
 struct TFetchResultsResp {


### PR DESCRIPTION
The "fetchType" attribute was removed from an earlier commit. There
is code that is still reference the fetchType in hiveserver2.py. The
code was in an exception so it was most likely never hit. However, it
is needed for any HS2 api that has not implemented the deprecated
GetLog API call.