### PR TITLE
Unify Python 2 and 3 thrift handling and remove thriftpy2

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Required:
 
 * `six`, `bitarray`
 
-* `thrift==0.11.0
+* `thrift==0.11.0`
 
 Optional:
 

--- a/README.md
+++ b/README.md
@@ -30,11 +30,7 @@ Required:
 
 * `six`, `bitarray`
 
-* `thrift==0.11.0 for Python 2.x
-
-* `thriftpy2` for Python 3+
-
-
+* `thrift==0.11.0
 
 Optional:
 

--- a/impala/_thrift_api.py
+++ b/impala/_thrift_api.py
@@ -48,9 +48,6 @@ log = get_logger_and_init_null(__name__)
 from thrift.transport.TSocket import TSocket
 from thrift.transport.TTransport import (
     TBufferedTransport, TTransportException, TTransportBase)
-from thrift.Thrift import TApplicationException
-from thrift.protocol.TBinaryProtocol import (
-    TBinaryProtocolAccelerated as TBinaryProtocol)
 
 # import HS2 codegen objects
 from impala._thrift_gen.ImpalaService import ImpalaHiveServer2Service

--- a/impala/_thrift_api.py
+++ b/impala/_thrift_api.py
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This package is here to clean up references to thrift, because we're using
-# thriftpy2 for Py3 at the moment.  This should all be temporary, as Apache
-# Thrift gains Py3 compatibility.
+# This package's main goal in the past was to clean up references to thrift, because
+# we were using thriftpy2 for Py3. This is no longer necessary since upgrading to
+# Thrift 0.11.0, as Thrift supports Python 3 since 0.10.0. Now there are only some
+# leftover utility classes and functions.
 
 # pylint: disable=wrong-import-position
 
@@ -42,74 +43,19 @@ from impala.util import get_first_matching_cookie, get_cookie_expiry
 log = get_logger_and_init_null(__name__)
 
 
-if six.PY2:
-    # pylint: disable=import-error,unused-import
-    # import Apache Thrift code
-    from thrift.transport.TSocket import TSocket
-    from thrift.transport.TTransport import (
-        TBufferedTransport, TTransportException, TTransportBase)
-    from thrift.Thrift import TApplicationException
-    from thrift.protocol.TBinaryProtocol import (
-        TBinaryProtocolAccelerated as TBinaryProtocol)
+# pylint: disable=import-error,unused-import
+# import Apache Thrift code
+from thrift.transport.TSocket import TSocket
+from thrift.transport.TTransport import (
+    TBufferedTransport, TTransportException, TTransportBase)
+from thrift.Thrift import TApplicationException
+from thrift.protocol.TBinaryProtocol import (
+    TBinaryProtocolAccelerated as TBinaryProtocol)
 
-    # import HS2 codegen objects
-    from impala._thrift_gen.TCLIService.ttypes import (
-        TOpenSessionReq, TFetchResultsReq, TCloseSessionReq,
-        TExecuteStatementReq, TGetInfoReq, TGetInfoType, TTypeId,
-        TFetchOrientation, TGetResultSetMetadataReq, TStatusCode,
-        TGetColumnsReq, TGetSchemasReq, TGetTablesReq, TGetFunctionsReq,
-        TGetOperationStatusReq, TOperationState, TCancelOperationReq,
-        TCloseOperationReq, TGetLogReq, TProtocolVersion)
-    from impala._thrift_gen.ImpalaService.ImpalaHiveServer2Service import (
-        TGetRuntimeProfileReq, TGetExecSummaryReq)
-    from impala._thrift_gen.ImpalaService import ImpalaHiveServer2Service
-    from impala._thrift_gen.ExecStats.ttypes import TExecStats
-    ThriftClient = ImpalaHiveServer2Service.Client
-    from impala._thrift_gen.RuntimeProfile.ttypes import TRuntimeProfileFormat
+# import HS2 codegen objects
+from impala._thrift_gen.ImpalaService import ImpalaHiveServer2Service
+ThriftClient = ImpalaHiveServer2Service.Client
 
-
-if six.PY3:
-    # When using python 3, import from thriftpy2 rather than thrift
-    from thriftpy2 import load
-    from thriftpy2.thrift import TClient, TApplicationException
-    # TODO: reenable cython
-    # from thriftpy2.protocol import TBinaryProtocol
-    from thriftpy2.protocol.binary import TBinaryProtocol  # noqa
-    from thriftpy2.transport import (TSocket, TTransportException, TTransportBase) # noqa
-    # TODO: reenable cython
-    # from thriftpy2.transport import TBufferedTransport
-    from thriftpy2.transport.buffered import TBufferedTransport  # noqa
-    thrift_dir = os.path.join(os.path.dirname(__file__), 'thrift')
-
-    # dynamically load the HS2 modules
-    # Put them under the impala module to avoid conflicts with PyHive and other packages
-    # (see #277).
-    ExecStats = load(os.path.join(thrift_dir, 'ExecStats.thrift'),
-                     include_dirs=[thrift_dir], module_name="impala.ExecStats_thrift")
-    TCLIService = load(os.path.join(thrift_dir, 'TCLIService.thrift'),
-                       include_dirs=[thrift_dir], module_name="impala.TCLIService_thrift")
-    ImpalaService = load(os.path.join(thrift_dir, 'ImpalaService.thrift'),
-                         include_dirs=[thrift_dir], module_name="impala.ImpalaService_thrift")
-    RuntimeProfile = load(os.path.join(thrift_dir, 'RuntimeProfile.thrift'),
-                          include_dirs=[thrift_dir], module_name="impala.RuntimeProfile_thrift")
-    sys.modules[ExecStats.__name__] = ExecStats
-    sys.modules[TCLIService.__name__] = TCLIService
-    sys.modules[ImpalaService.__name__] = ImpalaService
-    sys.modules[RuntimeProfile.__name__] = RuntimeProfile
-
-    # import the HS2 objects
-    from impala.TCLIService_thrift import (  # noqa
-        TOpenSessionReq, TFetchResultsReq, TCloseSessionReq,
-        TExecuteStatementReq, TGetInfoReq, TGetInfoType, TTypeId,
-        TFetchOrientation, TGetResultSetMetadataReq, TStatusCode,
-        TGetColumnsReq, TGetSchemasReq, TGetTablesReq, TGetFunctionsReq,
-        TGetOperationStatusReq, TOperationState, TCancelOperationReq,
-        TCloseOperationReq, TGetLogReq, TProtocolVersion)
-    from impala.ImpalaService_thrift import (  # noqa
-        TGetRuntimeProfileReq, TGetExecSummaryReq, ImpalaHiveServer2Service)
-    from impala.ExecStats_thrift import TExecStats  # noqa
-    from impala.RuntimeProfile_thrift import TRuntimeProfileFormat
-    ThriftClient = TClient
 
 # ImpalaHttpClient is copied from Impala Shell.
 # The implementations should be kept in sync as much as possible.
@@ -349,18 +295,11 @@ def get_socket(host, port, use_ssl, ca_cert):
               host, port, use_ssl, ca_cert)
 
     if use_ssl:
-        if six.PY2:
-            from thrift.transport.TSSLSocket import TSSLSocket
-            if ca_cert is None:
-                return TSSLSocket(host, port, validate=False)
-            else:
-                return TSSLSocket(host, port, validate=True, ca_certs=ca_cert)
+        from thrift.transport.TSSLSocket import TSSLSocket
+        if ca_cert is None:
+            return TSSLSocket(host, port, validate=False)
         else:
-            from thriftpy2.transport.sslsocket import TSSLSocket
-            if ca_cert is None:
-                return TSSLSocket(host, port, validate=False)
-            else:
-                return TSSLSocket(host, port, validate=True, cafile=ca_cert)
+            return TSSLSocket(host, port, validate=True, ca_certs=ca_cert)
     else:
         return TSocket(host, port)
 

--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -26,16 +26,22 @@ import time
 from bitarray import bitarray
 from six.moves import range
 
+from thrift.transport.TTransport import TTransportException
+from thrift.Thrift import TApplicationException
+from thrift.protocol.TBinaryProtocol import (
+    TBinaryProtocolAccelerated as TBinaryProtocol)
+from impala._thrift_gen.TCLIService.ttypes import (
+    TOpenSessionReq, TFetchResultsReq, TCloseSessionReq,
+    TExecuteStatementReq, TGetInfoReq, TGetInfoType, TTypeId,
+    TFetchOrientation, TGetResultSetMetadataReq, TStatusCode,
+    TGetColumnsReq, TGetSchemasReq, TGetTablesReq, TGetFunctionsReq,
+    TGetOperationStatusReq, TOperationState, TCancelOperationReq,
+    TCloseOperationReq, TGetLogReq, TProtocolVersion)
+from impala._thrift_gen.ImpalaService.ImpalaHiveServer2Service import (
+    TGetRuntimeProfileReq, TGetExecSummaryReq)
 from impala._thrift_api import (
-    get_socket, get_http_transport, get_transport, TTransportException, TBinaryProtocol, TOpenSessionReq,
-    TFetchResultsReq,
-    TCloseSessionReq, TExecuteStatementReq, TGetInfoReq, TGetInfoType, TTypeId,
-    TFetchOrientation, TGetResultSetMetadataReq, TStatusCode, TGetColumnsReq,
-    TGetSchemasReq, TGetTablesReq, TGetFunctionsReq, TGetOperationStatusReq,
-    TOperationState, TCancelOperationReq, TCloseOperationReq, TGetLogReq,
-    TProtocolVersion, TGetRuntimeProfileReq, TRuntimeProfileFormat,
-    TGetExecSummaryReq, ImpalaHiveServer2Service, TExecStats, ThriftClient,
-    TApplicationException)
+    get_socket, get_http_transport, get_transport, ThriftClient)
+from impala._thrift_gen.RuntimeProfile.ttypes import TRuntimeProfileFormat
 from impala.compat import Decimal
 from impala.error import (NotSupportedError, OperationalError,
                           ProgrammingError, HiveServer2Error, HttpError)
@@ -823,27 +829,14 @@ def connect(host, port, timeout=None, use_ssl=False, ca_cert=None,
 
         if timeout is not None:
             timeout = timeout * 1000.  # TSocket expects millis
-        if six.PY2:
-            sock.setTimeout(timeout)
-        elif six.PY3:
-            try:
-                # thriftpy has a release where set_timeout is missing
-                sock.set_timeout(timeout)
-            except AttributeError:
-                sock.socket_timeout = timeout
-                sock.connect_timeout = timeout
+        sock.setTimeout(timeout)
         log.debug('sock=%s', sock)
         transport = get_transport(sock, kerberos_host, kerberos_service_name,
                                 auth_mechanism, user, password)
 
     transport.open()
     protocol = TBinaryProtocol(transport)
-    if six.PY2:
-        # ThriftClient == ImpalaHiveServer2Service.Client
-        service = ThriftClient(protocol)
-    elif six.PY3:
-        # ThriftClient == TClient
-        service = ThriftClient(ImpalaHiveServer2Service, protocol)
+    service = ThriftClient(protocol)
     log.debug('transport=%s protocol=%s service=%s', transport, protocol,
               service)
 
@@ -928,10 +921,6 @@ class CBatch(Batch):
             type_ = schema[j][1]
             nulls = tcols[j].nulls
             values = tcols[j].values
-
-            # thriftpy sometimes returns unicode instead of bytes
-            if six.PY3 and isinstance(nulls, str):
-                nulls = nulls.encode('utf-8')
 
             is_null = bitarray(endian='little')
             is_null.frombytes(nulls)
@@ -1082,18 +1071,9 @@ class ThriftRPC(object):
 
 def open_transport(transport):
     """
-    Open transport, accounting for API differences between thrift versus thriftpy2,
-    as well as TBufferedTransport versus THttpClient.
+    Open transport if needed.
     """
-    # python2 and thrift, or any THttpClient
-    if 'isOpen' in dir(transport):
-        transport_is_open = transport.isOpen()
-
-    # python3 and thriftpy2 (for TBufferedTransport only)
-    if 'is_open' in dir(transport):
-        transport_is_open = transport.is_open()
-
-    if not transport_is_open:
+    if not transport.isOpen():
         transport.open()
 
 

--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -28,8 +28,7 @@ from six.moves import range
 
 from thrift.transport.TTransport import TTransportException
 from thrift.Thrift import TApplicationException
-from thrift.protocol.TBinaryProtocol import (
-    TBinaryProtocolAccelerated as TBinaryProtocol)
+from thrift.protocol.TBinaryProtocol import TBinaryProtocolAccelerated
 from impala._thrift_gen.TCLIService.ttypes import (
     TOpenSessionReq, TFetchResultsReq, TCloseSessionReq,
     TExecuteStatementReq, TGetInfoReq, TGetInfoType, TTypeId,
@@ -835,7 +834,7 @@ def connect(host, port, timeout=None, use_ssl=False, ca_cert=None,
                                 auth_mechanism, user, password)
 
     transport.open()
-    protocol = TBinaryProtocol(transport)
+    protocol = TBinaryProtocolAccelerated(transport)
     service = ThriftClient(protocol)
     log.debug('transport=%s protocol=%s service=%s', transport, protocol,
               service)

--- a/impala/tests/test_hs2_fault_injection.py
+++ b/impala/tests/test_hs2_fault_injection.py
@@ -15,8 +15,7 @@ import logging
 
 import six
 
-from thrift.protocol.TBinaryProtocol import (
-    TBinaryProtocolAccelerated as TBinaryProtocol)
+from thrift.protocol.TBinaryProtocol import TBinaryProtocolAccelerated
 # noinspection PyProtectedMember
 from impala._thrift_gen.ImpalaService import ImpalaHiveServer2Service
 
@@ -116,7 +115,7 @@ class TestHS2FaultInjection(object):
 
     def connect(self):
         self.transport.open()
-        protocol = TBinaryProtocol(self.transport)
+        protocol = TBinaryProtocolAccelerated(self.transport)
         service = ThriftClient(protocol)
         service = HS2Service(service, retries=3)
         return hs2.HiveServer2Connection(service, default_db=None)

--- a/impala/tests/test_hs2_fault_injection.py
+++ b/impala/tests/test_hs2_fault_injection.py
@@ -15,23 +15,15 @@ import logging
 
 import six
 
-if six.PY2:
-    from thrift.protocol.TBinaryProtocol import (
-        TBinaryProtocolAccelerated as TBinaryProtocol)
-    # noinspection PyProtectedMember
-    from impala._thrift_gen.ImpalaService import ImpalaHiveServer2Service
+from thrift.protocol.TBinaryProtocol import (
+    TBinaryProtocolAccelerated as TBinaryProtocol)
+# noinspection PyProtectedMember
+from impala._thrift_gen.ImpalaService import ImpalaHiveServer2Service
 
-    ThriftClient = ImpalaHiveServer2Service.Client
-
-if six.PY3:
-    # When using python 3, import from thriftpy2 rather than thrift
-    # TODO: reenable cython
-    from thriftpy2.protocol.binary import TBinaryProtocol  # noqa
-    from thriftpy2.transport import (TSocket, TTransportException, TTransportBase)  # noqa
-    from thriftpy2.transport.buffered import TBufferedTransport  # noqa
+ThriftClient = ImpalaHiveServer2Service.Client
 
 from impala import hiveserver2 as hs2
-from impala._thrift_api import ThriftClient, ImpalaHttpClient, ImpalaHiveServer2Service
+from impala._thrift_api import ImpalaHttpClient
 from impala.error import HttpError
 from impala.hiveserver2 import HS2Service
 from impala.tests.util import ImpylaTestEnv
@@ -125,14 +117,7 @@ class TestHS2FaultInjection(object):
     def connect(self):
         self.transport.open()
         protocol = TBinaryProtocol(self.transport)
-        service = None
-        if six.PY2:
-            # ThriftClient == ImpalaHiveServer2Service.Client
-            service = ThriftClient(protocol)
-        elif six.PY3:
-            # ThriftClient == TClient
-            # service = ThriftClient(protocol)
-            service = ThriftClient(ImpalaHiveServer2Service, protocol)
+        service = ThriftClient(protocol)
         service = HS2Service(service, retries=3)
         return hs2.HiveServer2Connection(service, default_db=None)
 

--- a/jenkins/run-dbapi.sh
+++ b/jenkins/run-dbapi.sh
@@ -79,7 +79,7 @@ conda info -a
 CONDA_ENV_NAME=pyenv-impyla-dbapi-test
 conda create -y -q -n $CONDA_ENV_NAME python=$PYTHON_VERSION pip
 source activate $CONDA_ENV_NAME
-pip install thriftpy2 sqlalchemy
+pip install sqlalchemy
 pip install unittest2 pytest-cov
 
 # build impyla

--- a/setup.py
+++ b/setup.py
@@ -41,13 +41,8 @@ setup(
     packages=find_packages(),
     install_package_data=True,
     package_data={'impala.thrift': ['*.thrift']},
-    install_requires=['six', 'bitarray'],
+    install_requires=['six', 'bitarray', 'thrift==0.11.0'],
     extras_require={
-        # TODO: Python 3 could also use Thrift 0.11.0
-        ":python_version<'3.0'": ["thrift==0.11.0"],
-        ":python_version>='3.0'": ["thriftpy2>=0.4.0,<0.5.0",
-                                   ],
-
         "kerberos": ["thrift_sasl==0.4.3a1",
                      "kerberos>=1.3.0",
                     ],

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     install_package_data=True,
     package_data={'impala.thrift': ['*.thrift']},
     install_requires=['six', 'bitarray', 'thrift==0.11.0'],
-    extras_require={                         ],
+    extras_require={
         "kerberos": ["thrift_sasl==0.4.3a2",
                      "kerberos>=1.3.0",
                     ],


### PR DESCRIPTION
Apache Thrift supports Python 3 since 0.10.0 so switching to 0.11.0
allowed to use the same implementation for both Python versions.

Before this commit thriftpy2 was used with Python 3. Now thriftpy2
and the hacks to hide the differences between the two Thrift libraries
are removed.