### PR TITLE
Add no_utf8strings to thrift compiler option

### DIFF
--- a/impala/_thrift_gen/ErrorCodes/constants.py
+++ b/impala/_thrift_gen/ErrorCodes/constants.py
@@ -3,14 +3,13 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.TRecursive import fix_spec
 
-import sys
 from .ttypes import *
 TErrorMessage = [
     "",

--- a/impala/_thrift_gen/ErrorCodes/ttypes.py
+++ b/impala/_thrift_gen/ErrorCodes/ttypes.py
@@ -3,14 +3,13 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.TRecursive import fix_spec
 
-import sys
 
 from thrift.transport import TTransport
 all_structs = []

--- a/impala/_thrift_gen/ExecStats/constants.py
+++ b/impala/_thrift_gen/ExecStats/constants.py
@@ -3,12 +3,11 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.TRecursive import fix_spec
 
-import sys
 from .ttypes import *

--- a/impala/_thrift_gen/ExecStats/ttypes.py
+++ b/impala/_thrift_gen/ExecStats/ttypes.py
@@ -3,14 +3,13 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.TRecursive import fix_spec
 
-import sys
 import impala._thrift_gen.Status.ttypes
 import impala._thrift_gen.Types.ttypes
 
@@ -182,12 +181,12 @@ class TPlanNodeExecSummary(object):
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.label = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.label = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.label_detail = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.label_detail = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 5:
@@ -237,11 +236,11 @@ class TPlanNodeExecSummary(object):
             oprot.writeFieldEnd()
         if self.label is not None:
             oprot.writeFieldBegin('label', TType.STRING, 3)
-            oprot.writeString(self.label.encode('utf-8') if sys.version_info[0] == 2 else self.label)
+            oprot.writeString(self.label)
             oprot.writeFieldEnd()
         if self.label_detail is not None:
             oprot.writeFieldBegin('label_detail', TType.STRING, 4)
-            oprot.writeString(self.label_detail.encode('utf-8') if sys.version_info[0] == 2 else self.label_detail)
+            oprot.writeString(self.label_detail)
             oprot.writeFieldEnd()
         if self.num_children is not None:
             oprot.writeFieldBegin('num_children', TType.I32, 5)
@@ -426,7 +425,7 @@ class TExecSummary(object):
                     self.error_logs = []
                     (_etype23, _size20) = iprot.readListBegin()
                     for _i24 in range(_size20):
-                        _elem25 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem25 = iprot.readString()
                         self.error_logs.append(_elem25)
                     iprot.readListEnd()
                 else:
@@ -444,7 +443,7 @@ class TExecSummary(object):
                     iprot.skip(ftype)
             elif fid == 8:
                 if ftype == TType.STRING:
-                    self.queued_reason = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.queued_reason = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -484,7 +483,7 @@ class TExecSummary(object):
             oprot.writeFieldBegin('error_logs', TType.LIST, 5)
             oprot.writeListBegin(TType.STRING, len(self.error_logs))
             for iter29 in self.error_logs:
-                oprot.writeString(iter29.encode('utf-8') if sys.version_info[0] == 2 else iter29)
+                oprot.writeString(iter29)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.progress is not None:
@@ -497,7 +496,7 @@ class TExecSummary(object):
             oprot.writeFieldEnd()
         if self.queued_reason is not None:
             oprot.writeFieldBegin('queued_reason', TType.STRING, 8)
-            oprot.writeString(self.queued_reason.encode('utf-8') if sys.version_info[0] == 2 else self.queued_reason)
+            oprot.writeString(self.queued_reason)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -530,8 +529,8 @@ TPlanNodeExecSummary.thrift_spec = (
     None,  # 0
     (1, TType.I32, 'node_id', None, None, ),  # 1
     (2, TType.I32, 'fragment_idx', None, None, ),  # 2
-    (3, TType.STRING, 'label', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'label_detail', 'UTF8', None, ),  # 4
+    (3, TType.STRING, 'label', None, None, ),  # 3
+    (4, TType.STRING, 'label_detail', None, None, ),  # 4
     (5, TType.I32, 'num_children', None, None, ),  # 5
     (6, TType.STRUCT, 'estimated_stats', [TExecStats, None], None, ),  # 6
     (7, TType.LIST, 'exec_stats', (TType.STRUCT, [TExecStats, None], False), None, ),  # 7
@@ -550,10 +549,10 @@ TExecSummary.thrift_spec = (
     (2, TType.STRUCT, 'status', [impala._thrift_gen.Status.ttypes.TStatus, None], None, ),  # 2
     (3, TType.LIST, 'nodes', (TType.STRUCT, [TPlanNodeExecSummary, None], False), None, ),  # 3
     (4, TType.MAP, 'exch_to_sender_map', (TType.I32, None, TType.I32, None, False), None, ),  # 4
-    (5, TType.LIST, 'error_logs', (TType.STRING, 'UTF8', False), None, ),  # 5
+    (5, TType.LIST, 'error_logs', (TType.STRING, None, False), None, ),  # 5
     (6, TType.STRUCT, 'progress', [TExecProgress, None], None, ),  # 6
     (7, TType.BOOL, 'is_queued', None, None, ),  # 7
-    (8, TType.STRING, 'queued_reason', 'UTF8', None, ),  # 8
+    (8, TType.STRING, 'queued_reason', None, None, ),  # 8
 )
 fix_spec(all_structs)
 del all_structs

--- a/impala/_thrift_gen/ImpalaService/ImpalaHiveServer2Service-remote
+++ b/impala/_thrift_gen/ImpalaService/ImpalaHiveServer2Service-remote
@@ -4,7 +4,7 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 import sys

--- a/impala/_thrift_gen/ImpalaService/ImpalaHiveServer2Service.py
+++ b/impala/_thrift_gen/ImpalaService/ImpalaHiveServer2Service.py
@@ -3,14 +3,13 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.TRecursive import fix_spec
 
-import sys
 import impala._thrift_gen.TCLIService.TCLIService
 import logging
 from .ttypes import *

--- a/impala/_thrift_gen/ImpalaService/ImpalaService-remote
+++ b/impala/_thrift_gen/ImpalaService/ImpalaService-remote
@@ -4,7 +4,7 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 import sys

--- a/impala/_thrift_gen/ImpalaService/ImpalaService.py
+++ b/impala/_thrift_gen/ImpalaService/ImpalaService.py
@@ -3,14 +3,13 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.TRecursive import fix_spec
 
-import sys
 import impala._thrift_gen.beeswax.BeeswaxService
 import logging
 from .ttypes import *
@@ -942,7 +941,7 @@ class GetRuntimeProfile_result(object):
                 break
             if fid == 0:
                 if ftype == TType.STRING:
-                    self.success = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.success = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 1:
@@ -963,7 +962,7 @@ class GetRuntimeProfile_result(object):
         oprot.writeStructBegin('GetRuntimeProfile_result')
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.STRING, 0)
-            oprot.writeString(self.success.encode('utf-8') if sys.version_info[0] == 2 else self.success)
+            oprot.writeString(self.success)
             oprot.writeFieldEnd()
         if self.error is not None:
             oprot.writeFieldBegin('error', TType.STRUCT, 1)
@@ -987,7 +986,7 @@ class GetRuntimeProfile_result(object):
         return not (self == other)
 all_structs.append(GetRuntimeProfile_result)
 GetRuntimeProfile_result.thrift_spec = (
-    (0, TType.STRING, 'success', 'UTF8', None, ),  # 0
+    (0, TType.STRING, 'success', None, None, ),  # 0
     (1, TType.STRUCT, 'error', [impala._thrift_gen.beeswax.ttypes.BeeswaxException, None], None, ),  # 1
 )
 

--- a/impala/_thrift_gen/ImpalaService/constants.py
+++ b/impala/_thrift_gen/ImpalaService/constants.py
@@ -3,12 +3,11 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.TRecursive import fix_spec
 
-import sys
 from .ttypes import *

--- a/impala/_thrift_gen/ImpalaService/ttypes.py
+++ b/impala/_thrift_gen/ImpalaService/ttypes.py
@@ -3,14 +3,13 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.TRecursive import fix_spec
 
-import sys
 import impala._thrift_gen.ExecStats.ttypes
 import impala._thrift_gen.Status.ttypes
 import impala._thrift_gen.Types.ttypes
@@ -291,7 +290,7 @@ class TInsertResult(object):
                     self.rows_modified = {}
                     (_ktype1, _vtype2, _size0) = iprot.readMapBegin()
                     for _i4 in range(_size0):
-                        _key5 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key5 = iprot.readString()
                         _val6 = iprot.readI64()
                         self.rows_modified[_key5] = _val6
                     iprot.readMapEnd()
@@ -316,7 +315,7 @@ class TInsertResult(object):
             oprot.writeFieldBegin('rows_modified', TType.MAP, 1)
             oprot.writeMapBegin(TType.STRING, TType.I64, len(self.rows_modified))
             for kiter7, viter8 in self.rows_modified.items():
-                oprot.writeString(kiter7.encode('utf-8') if sys.version_info[0] == 2 else kiter7)
+                oprot.writeString(kiter7)
                 oprot.writeI64(viter8)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
@@ -367,12 +366,12 @@ class TPingImpalaServiceResp(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.version = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.version = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.webserver_address = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.webserver_address = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -387,11 +386,11 @@ class TPingImpalaServiceResp(object):
         oprot.writeStructBegin('TPingImpalaServiceResp')
         if self.version is not None:
             oprot.writeFieldBegin('version', TType.STRING, 1)
-            oprot.writeString(self.version.encode('utf-8') if sys.version_info[0] == 2 else self.version)
+            oprot.writeString(self.version)
             oprot.writeFieldEnd()
         if self.webserver_address is not None:
             oprot.writeFieldBegin('webserver_address', TType.STRING, 2)
-            oprot.writeString(self.webserver_address.encode('utf-8') if sys.version_info[0] == 2 else self.webserver_address)
+            oprot.writeString(self.webserver_address)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -434,12 +433,12 @@ class TResetTableReq(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.table_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.table_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -454,11 +453,11 @@ class TResetTableReq(object):
         oprot.writeStructBegin('TResetTableReq')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.table_name is not None:
             oprot.writeFieldBegin('table_name', TType.STRING, 2)
-            oprot.writeString(self.table_name.encode('utf-8') if sys.version_info[0] == 2 else self.table_name)
+            oprot.writeString(self.table_name)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -733,7 +732,7 @@ class TGetRuntimeProfileResp(object):
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.profile = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.profile = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -758,7 +757,7 @@ class TGetRuntimeProfileResp(object):
             oprot.writeFieldEnd()
         if self.profile is not None:
             oprot.writeFieldBegin('profile', TType.STRING, 2)
-            oprot.writeString(self.profile.encode('utf-8') if sys.version_info[0] == 2 else self.profile)
+            oprot.writeString(self.profile)
             oprot.writeFieldEnd()
         if self.thrift_profile is not None:
             oprot.writeFieldBegin('thrift_profile', TType.STRUCT, 3)
@@ -785,20 +784,20 @@ class TGetRuntimeProfileResp(object):
 all_structs.append(TInsertResult)
 TInsertResult.thrift_spec = (
     None,  # 0
-    (1, TType.MAP, 'rows_modified', (TType.STRING, 'UTF8', TType.I64, None, False), None, ),  # 1
+    (1, TType.MAP, 'rows_modified', (TType.STRING, None, TType.I64, None, False), None, ),  # 1
     (2, TType.I64, 'num_row_errors', None, None, ),  # 2
 )
 all_structs.append(TPingImpalaServiceResp)
 TPingImpalaServiceResp.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'version', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'webserver_address', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'version', None, None, ),  # 1
+    (2, TType.STRING, 'webserver_address', None, None, ),  # 2
 )
 all_structs.append(TResetTableReq)
 TResetTableReq.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'table_name', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'table_name', None, None, ),  # 2
 )
 all_structs.append(TGetExecSummaryReq)
 TGetExecSummaryReq.thrift_spec = (
@@ -823,7 +822,7 @@ all_structs.append(TGetRuntimeProfileResp)
 TGetRuntimeProfileResp.thrift_spec = (
     None,  # 0
     (1, TType.STRUCT, 'status', [impala._thrift_gen.TCLIService.ttypes.TStatus, None], None, ),  # 1
-    (2, TType.STRING, 'profile', 'UTF8', None, ),  # 2
+    (2, TType.STRING, 'profile', None, None, ),  # 2
     (3, TType.STRUCT, 'thrift_profile', [impala._thrift_gen.RuntimeProfile.ttypes.TRuntimeProfileTree, None], None, ),  # 3
 )
 fix_spec(all_structs)

--- a/impala/_thrift_gen/Metrics/constants.py
+++ b/impala/_thrift_gen/Metrics/constants.py
@@ -3,12 +3,11 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.TRecursive import fix_spec
 
-import sys
 from .ttypes import *

--- a/impala/_thrift_gen/Metrics/ttypes.py
+++ b/impala/_thrift_gen/Metrics/ttypes.py
@@ -3,14 +3,13 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.TRecursive import fix_spec
 
-import sys
 
 from thrift.transport import TTransport
 all_structs = []

--- a/impala/_thrift_gen/RuntimeProfile/constants.py
+++ b/impala/_thrift_gen/RuntimeProfile/constants.py
@@ -3,12 +3,11 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.TRecursive import fix_spec
 
-import sys
 from .ttypes import *

--- a/impala/_thrift_gen/RuntimeProfile/ttypes.py
+++ b/impala/_thrift_gen/RuntimeProfile/ttypes.py
@@ -3,14 +3,13 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.TRecursive import fix_spec
 
-import sys
 import impala._thrift_gen.ExecStats.ttypes
 import impala._thrift_gen.Metrics.ttypes
 import impala._thrift_gen.Types.ttypes
@@ -62,7 +61,7 @@ class TCounter(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
@@ -87,7 +86,7 @@ class TCounter(object):
         oprot.writeStructBegin('TCounter')
         if self.name is not None:
             oprot.writeFieldBegin('name', TType.STRING, 1)
-            oprot.writeString(self.name.encode('utf-8') if sys.version_info[0] == 2 else self.name)
+            oprot.writeString(self.name)
             oprot.writeFieldEnd()
         if self.unit is not None:
             oprot.writeFieldBegin('unit', TType.I32, 2)
@@ -146,7 +145,7 @@ class TEventSequence(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
@@ -164,7 +163,7 @@ class TEventSequence(object):
                     self.labels = []
                     (_etype9, _size6) = iprot.readListBegin()
                     for _i10 in range(_size6):
-                        _elem11 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem11 = iprot.readString()
                         self.labels.append(_elem11)
                     iprot.readListEnd()
                 else:
@@ -181,7 +180,7 @@ class TEventSequence(object):
         oprot.writeStructBegin('TEventSequence')
         if self.name is not None:
             oprot.writeFieldBegin('name', TType.STRING, 1)
-            oprot.writeString(self.name.encode('utf-8') if sys.version_info[0] == 2 else self.name)
+            oprot.writeString(self.name)
             oprot.writeFieldEnd()
         if self.timestamps is not None:
             oprot.writeFieldBegin('timestamps', TType.LIST, 2)
@@ -194,7 +193,7 @@ class TEventSequence(object):
             oprot.writeFieldBegin('labels', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.labels))
             for iter13 in self.labels:
-                oprot.writeString(iter13.encode('utf-8') if sys.version_info[0] == 2 else iter13)
+                oprot.writeString(iter13)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -250,7 +249,7 @@ class TTimeSeriesCounter(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
@@ -290,7 +289,7 @@ class TTimeSeriesCounter(object):
         oprot.writeStructBegin('TTimeSeriesCounter')
         if self.name is not None:
             oprot.writeFieldBegin('name', TType.STRING, 1)
-            oprot.writeString(self.name.encode('utf-8') if sys.version_info[0] == 2 else self.name)
+            oprot.writeString(self.name)
             oprot.writeFieldEnd()
         if self.unit is not None:
             oprot.writeFieldBegin('unit', TType.I32, 2)
@@ -368,7 +367,7 @@ class TSummaryStatsCounter(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
@@ -408,7 +407,7 @@ class TSummaryStatsCounter(object):
         oprot.writeStructBegin('TSummaryStatsCounter')
         if self.name is not None:
             oprot.writeFieldBegin('name', TType.STRING, 1)
-            oprot.writeString(self.name.encode('utf-8') if sys.version_info[0] == 2 else self.name)
+            oprot.writeString(self.name)
             oprot.writeFieldEnd()
         if self.unit is not None:
             oprot.writeFieldBegin('unit', TType.I32, 2)
@@ -570,7 +569,7 @@ class TRuntimeProfileNode(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
@@ -604,8 +603,8 @@ class TRuntimeProfileNode(object):
                     self.info_strings = {}
                     (_ktype28, _vtype29, _size27) = iprot.readMapBegin()
                     for _i31 in range(_size27):
-                        _key32 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val33 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key32 = iprot.readString()
+                        _val33 = iprot.readString()
                         self.info_strings[_key32] = _val33
                     iprot.readMapEnd()
                 else:
@@ -615,7 +614,7 @@ class TRuntimeProfileNode(object):
                     self.info_strings_display_order = []
                     (_etype37, _size34) = iprot.readListBegin()
                     for _i38 in range(_size34):
-                        _elem39 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem39 = iprot.readString()
                         self.info_strings_display_order.append(_elem39)
                     iprot.readListEnd()
                 else:
@@ -625,11 +624,11 @@ class TRuntimeProfileNode(object):
                     self.child_counters_map = {}
                     (_ktype41, _vtype42, _size40) = iprot.readMapBegin()
                     for _i44 in range(_size40):
-                        _key45 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key45 = iprot.readString()
                         _val46 = set()
                         (_etype50, _size47) = iprot.readSetBegin()
                         for _i51 in range(_size47):
-                            _elem52 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                            _elem52 = iprot.readString()
                             _val46.add(_elem52)
                         iprot.readSetEnd()
                         self.child_counters_map[_key45] = _val46
@@ -687,7 +686,7 @@ class TRuntimeProfileNode(object):
         oprot.writeStructBegin('TRuntimeProfileNode')
         if self.name is not None:
             oprot.writeFieldBegin('name', TType.STRING, 1)
-            oprot.writeString(self.name.encode('utf-8') if sys.version_info[0] == 2 else self.name)
+            oprot.writeString(self.name)
             oprot.writeFieldEnd()
         if self.num_children is not None:
             oprot.writeFieldBegin('num_children', TType.I32, 2)
@@ -712,25 +711,25 @@ class TRuntimeProfileNode(object):
             oprot.writeFieldBegin('info_strings', TType.MAP, 6)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.info_strings))
             for kiter72, viter73 in self.info_strings.items():
-                oprot.writeString(kiter72.encode('utf-8') if sys.version_info[0] == 2 else kiter72)
-                oprot.writeString(viter73.encode('utf-8') if sys.version_info[0] == 2 else viter73)
+                oprot.writeString(kiter72)
+                oprot.writeString(viter73)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.info_strings_display_order is not None:
             oprot.writeFieldBegin('info_strings_display_order', TType.LIST, 7)
             oprot.writeListBegin(TType.STRING, len(self.info_strings_display_order))
             for iter74 in self.info_strings_display_order:
-                oprot.writeString(iter74.encode('utf-8') if sys.version_info[0] == 2 else iter74)
+                oprot.writeString(iter74)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.child_counters_map is not None:
             oprot.writeFieldBegin('child_counters_map', TType.MAP, 8)
             oprot.writeMapBegin(TType.STRING, TType.SET, len(self.child_counters_map))
             for kiter75, viter76 in self.child_counters_map.items():
-                oprot.writeString(kiter75.encode('utf-8') if sys.version_info[0] == 2 else kiter75)
+                oprot.writeString(kiter75)
                 oprot.writeSetBegin(TType.STRING, len(viter76))
                 for iter77 in viter76:
-                    oprot.writeString(iter77.encode('utf-8') if sys.version_info[0] == 2 else iter77)
+                    oprot.writeString(iter77)
                 oprot.writeSetEnd()
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
@@ -952,21 +951,21 @@ class TRuntimeProfileForest(object):
 all_structs.append(TCounter)
 TCounter.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'name', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'name', None, None, ),  # 1
     (2, TType.I32, 'unit', None, None, ),  # 2
     (3, TType.I64, 'value', None, None, ),  # 3
 )
 all_structs.append(TEventSequence)
 TEventSequence.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'name', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'name', None, None, ),  # 1
     (2, TType.LIST, 'timestamps', (TType.I64, None, False), None, ),  # 2
-    (3, TType.LIST, 'labels', (TType.STRING, 'UTF8', False), None, ),  # 3
+    (3, TType.LIST, 'labels', (TType.STRING, None, False), None, ),  # 3
 )
 all_structs.append(TTimeSeriesCounter)
 TTimeSeriesCounter.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'name', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'name', None, None, ),  # 1
     (2, TType.I32, 'unit', None, None, ),  # 2
     (3, TType.I32, 'period_ms', None, None, ),  # 3
     (4, TType.LIST, 'values', (TType.I64, None, False), None, ),  # 4
@@ -975,7 +974,7 @@ TTimeSeriesCounter.thrift_spec = (
 all_structs.append(TSummaryStatsCounter)
 TSummaryStatsCounter.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'name', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'name', None, None, ),  # 1
     (2, TType.I32, 'unit', None, None, ),  # 2
     (3, TType.I64, 'sum', None, None, ),  # 3
     (4, TType.I64, 'total_num_values', None, None, ),  # 4
@@ -991,14 +990,14 @@ TRuntimeProfileNodeMetadata.thrift_spec = (
 all_structs.append(TRuntimeProfileNode)
 TRuntimeProfileNode.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'name', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'name', None, None, ),  # 1
     (2, TType.I32, 'num_children', None, None, ),  # 2
     (3, TType.LIST, 'counters', (TType.STRUCT, [TCounter, None], False), None, ),  # 3
     (4, TType.I64, 'metadata', None, None, ),  # 4
     (5, TType.BOOL, 'indent', None, None, ),  # 5
-    (6, TType.MAP, 'info_strings', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 6
-    (7, TType.LIST, 'info_strings_display_order', (TType.STRING, 'UTF8', False), None, ),  # 7
-    (8, TType.MAP, 'child_counters_map', (TType.STRING, 'UTF8', TType.SET, (TType.STRING, 'UTF8', False), False), None, ),  # 8
+    (6, TType.MAP, 'info_strings', (TType.STRING, None, TType.STRING, None, False), None, ),  # 6
+    (7, TType.LIST, 'info_strings_display_order', (TType.STRING, None, False), None, ),  # 7
+    (8, TType.MAP, 'child_counters_map', (TType.STRING, None, TType.SET, (TType.STRING, None, False), False), None, ),  # 8
     (9, TType.LIST, 'event_sequences', (TType.STRUCT, [TEventSequence, None], False), None, ),  # 9
     (10, TType.LIST, 'time_series_counters', (TType.STRUCT, [TTimeSeriesCounter, None], False), None, ),  # 10
     (11, TType.LIST, 'summary_stats_counters', (TType.STRUCT, [TSummaryStatsCounter, None], False), None, ),  # 11

--- a/impala/_thrift_gen/Status/constants.py
+++ b/impala/_thrift_gen/Status/constants.py
@@ -3,12 +3,11 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.TRecursive import fix_spec
 
-import sys
 from .ttypes import *

--- a/impala/_thrift_gen/Status/ttypes.py
+++ b/impala/_thrift_gen/Status/ttypes.py
@@ -3,14 +3,13 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.TRecursive import fix_spec
 
-import sys
 import impala._thrift_gen.ErrorCodes.ttypes
 
 from thrift.transport import TTransport
@@ -48,7 +47,7 @@ class TStatus(object):
                     self.error_msgs = []
                     (_etype3, _size0) = iprot.readListBegin()
                     for _i4 in range(_size0):
-                        _elem5 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem5 = iprot.readString()
                         self.error_msgs.append(_elem5)
                     iprot.readListEnd()
                 else:
@@ -71,7 +70,7 @@ class TStatus(object):
             oprot.writeFieldBegin('error_msgs', TType.LIST, 2)
             oprot.writeListBegin(TType.STRING, len(self.error_msgs))
             for iter6 in self.error_msgs:
-                oprot.writeString(iter6.encode('utf-8') if sys.version_info[0] == 2 else iter6)
+                oprot.writeString(iter6)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -96,7 +95,7 @@ all_structs.append(TStatus)
 TStatus.thrift_spec = (
     None,  # 0
     (1, TType.I32, 'status_code', None, None, ),  # 1
-    (2, TType.LIST, 'error_msgs', (TType.STRING, 'UTF8', False), None, ),  # 2
+    (2, TType.LIST, 'error_msgs', (TType.STRING, None, False), None, ),  # 2
 )
 fix_spec(all_structs)
 del all_structs

--- a/impala/_thrift_gen/TCLIService/TCLIService-remote
+++ b/impala/_thrift_gen/TCLIService/TCLIService-remote
@@ -4,7 +4,7 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 import sys

--- a/impala/_thrift_gen/TCLIService/TCLIService.py
+++ b/impala/_thrift_gen/TCLIService/TCLIService.py
@@ -3,14 +3,13 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.TRecursive import fix_spec
 
-import sys
 import logging
 from .ttypes import *
 from thrift.Thrift import TProcessor

--- a/impala/_thrift_gen/TCLIService/constants.py
+++ b/impala/_thrift_gen/TCLIService/constants.py
@@ -3,14 +3,13 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.TRecursive import fix_spec
 
-import sys
 from .ttypes import *
 PRIMITIVE_TYPES = set((
     0,

--- a/impala/_thrift_gen/TCLIService/ttypes.py
+++ b/impala/_thrift_gen/TCLIService/ttypes.py
@@ -3,14 +3,13 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.TRecursive import fix_spec
 
-import sys
 
 from thrift.transport import TTransport
 all_structs = []
@@ -413,7 +412,7 @@ class TTypeQualifierValue(object):
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.stringValue = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.stringValue = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -432,7 +431,7 @@ class TTypeQualifierValue(object):
             oprot.writeFieldEnd()
         if self.stringValue is not None:
             oprot.writeFieldBegin('stringValue', TType.STRING, 2)
-            oprot.writeString(self.stringValue.encode('utf-8') if sys.version_info[0] == 2 else self.stringValue)
+            oprot.writeString(self.stringValue)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -476,7 +475,7 @@ class TTypeQualifiers(object):
                     self.qualifiers = {}
                     (_ktype1, _vtype2, _size0) = iprot.readMapBegin()
                     for _i4 in range(_size0):
-                        _key5 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key5 = iprot.readString()
                         _val6 = TTypeQualifierValue()
                         _val6.read(iprot)
                         self.qualifiers[_key5] = _val6
@@ -497,7 +496,7 @@ class TTypeQualifiers(object):
             oprot.writeFieldBegin('qualifiers', TType.MAP, 1)
             oprot.writeMapBegin(TType.STRING, TType.STRUCT, len(self.qualifiers))
             for kiter7, viter8 in self.qualifiers.items():
-                oprot.writeString(kiter7.encode('utf-8') if sys.version_info[0] == 2 else kiter7)
+                oprot.writeString(kiter7)
                 viter8.write(oprot)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
@@ -744,7 +743,7 @@ class TStructTypeEntry(object):
                     self.nameToTypePtr = {}
                     (_ktype10, _vtype11, _size9) = iprot.readMapBegin()
                     for _i13 in range(_size9):
-                        _key14 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key14 = iprot.readString()
                         _val15 = iprot.readI32()
                         self.nameToTypePtr[_key14] = _val15
                     iprot.readMapEnd()
@@ -764,7 +763,7 @@ class TStructTypeEntry(object):
             oprot.writeFieldBegin('nameToTypePtr', TType.MAP, 1)
             oprot.writeMapBegin(TType.STRING, TType.I32, len(self.nameToTypePtr))
             for kiter16, viter17 in self.nameToTypePtr.items():
-                oprot.writeString(kiter16.encode('utf-8') if sys.version_info[0] == 2 else kiter16)
+                oprot.writeString(kiter16)
                 oprot.writeI32(viter17)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
@@ -812,7 +811,7 @@ class TUnionTypeEntry(object):
                     self.nameToTypePtr = {}
                     (_ktype19, _vtype20, _size18) = iprot.readMapBegin()
                     for _i22 in range(_size18):
-                        _key23 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key23 = iprot.readString()
                         _val24 = iprot.readI32()
                         self.nameToTypePtr[_key23] = _val24
                     iprot.readMapEnd()
@@ -832,7 +831,7 @@ class TUnionTypeEntry(object):
             oprot.writeFieldBegin('nameToTypePtr', TType.MAP, 1)
             oprot.writeMapBegin(TType.STRING, TType.I32, len(self.nameToTypePtr))
             for kiter25, viter26 in self.nameToTypePtr.items():
-                oprot.writeString(kiter25.encode('utf-8') if sys.version_info[0] == 2 else kiter25)
+                oprot.writeString(kiter25)
                 oprot.writeI32(viter26)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
@@ -877,7 +876,7 @@ class TUserDefinedTypeEntry(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.typeClassName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.typeClassName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -892,7 +891,7 @@ class TUserDefinedTypeEntry(object):
         oprot.writeStructBegin('TUserDefinedTypeEntry')
         if self.typeClassName is not None:
             oprot.writeFieldBegin('typeClassName', TType.STRING, 1)
-            oprot.writeString(self.typeClassName.encode('utf-8') if sys.version_info[0] == 2 else self.typeClassName)
+            oprot.writeString(self.typeClassName)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -1125,7 +1124,7 @@ class TColumnDesc(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.columnName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.columnName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
@@ -1141,7 +1140,7 @@ class TColumnDesc(object):
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.comment = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.comment = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -1156,7 +1155,7 @@ class TColumnDesc(object):
         oprot.writeStructBegin('TColumnDesc')
         if self.columnName is not None:
             oprot.writeFieldBegin('columnName', TType.STRING, 1)
-            oprot.writeString(self.columnName.encode('utf-8') if sys.version_info[0] == 2 else self.columnName)
+            oprot.writeString(self.columnName)
             oprot.writeFieldEnd()
         if self.typeDesc is not None:
             oprot.writeFieldBegin('typeDesc', TType.STRUCT, 2)
@@ -1168,7 +1167,7 @@ class TColumnDesc(object):
             oprot.writeFieldEnd()
         if self.comment is not None:
             oprot.writeFieldBegin('comment', TType.STRING, 4)
-            oprot.writeString(self.comment.encode('utf-8') if sys.version_info[0] == 2 else self.comment)
+            oprot.writeString(self.comment)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -1618,7 +1617,7 @@ class TStringValue(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.value = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.value = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -1633,7 +1632,7 @@ class TStringValue(object):
         oprot.writeStructBegin('TStringValue')
         if self.value is not None:
             oprot.writeFieldBegin('value', TType.STRING, 1)
-            oprot.writeString(self.value.encode('utf-8') if sys.version_info[0] == 2 else self.value)
+            oprot.writeString(self.value)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -2349,7 +2348,7 @@ class TStringColumn(object):
                     self.values = []
                     (_etype93, _size90) = iprot.readListBegin()
                     for _i94 in range(_size90):
-                        _elem95 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem95 = iprot.readString()
                         self.values.append(_elem95)
                     iprot.readListEnd()
                 else:
@@ -2373,7 +2372,7 @@ class TStringColumn(object):
             oprot.writeFieldBegin('values', TType.LIST, 1)
             oprot.writeListBegin(TType.STRING, len(self.values))
             for iter96 in self.values:
-                oprot.writeString(iter96.encode('utf-8') if sys.version_info[0] == 2 else iter96)
+                oprot.writeString(iter96)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.nulls is not None:
@@ -2759,14 +2758,14 @@ class TStatus(object):
                     self.infoMessages = []
                     (_etype121, _size118) = iprot.readListBegin()
                     for _i122 in range(_size118):
-                        _elem123 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem123 = iprot.readString()
                         self.infoMessages.append(_elem123)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.sqlState = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.sqlState = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
@@ -2776,7 +2775,7 @@ class TStatus(object):
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.STRING:
-                    self.errorMessage = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.errorMessage = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -2797,12 +2796,12 @@ class TStatus(object):
             oprot.writeFieldBegin('infoMessages', TType.LIST, 2)
             oprot.writeListBegin(TType.STRING, len(self.infoMessages))
             for iter124 in self.infoMessages:
-                oprot.writeString(iter124.encode('utf-8') if sys.version_info[0] == 2 else iter124)
+                oprot.writeString(iter124)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.sqlState is not None:
             oprot.writeFieldBegin('sqlState', TType.STRING, 3)
-            oprot.writeString(self.sqlState.encode('utf-8') if sys.version_info[0] == 2 else self.sqlState)
+            oprot.writeString(self.sqlState)
             oprot.writeFieldEnd()
         if self.errorCode is not None:
             oprot.writeFieldBegin('errorCode', TType.I32, 4)
@@ -2810,7 +2809,7 @@ class TStatus(object):
             oprot.writeFieldEnd()
         if self.errorMessage is not None:
             oprot.writeFieldBegin('errorMessage', TType.STRING, 5)
-            oprot.writeString(self.errorMessage.encode('utf-8') if sys.version_info[0] == 2 else self.errorMessage)
+            oprot.writeString(self.errorMessage)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -3090,12 +3089,12 @@ class TOpenSessionReq(object):
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.username = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.username = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.password = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.password = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
@@ -3103,8 +3102,8 @@ class TOpenSessionReq(object):
                     self.configuration = {}
                     (_ktype126, _vtype127, _size125) = iprot.readMapBegin()
                     for _i129 in range(_size125):
-                        _key130 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val131 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key130 = iprot.readString()
+                        _val131 = iprot.readString()
                         self.configuration[_key130] = _val131
                     iprot.readMapEnd()
                 else:
@@ -3125,18 +3124,18 @@ class TOpenSessionReq(object):
             oprot.writeFieldEnd()
         if self.username is not None:
             oprot.writeFieldBegin('username', TType.STRING, 2)
-            oprot.writeString(self.username.encode('utf-8') if sys.version_info[0] == 2 else self.username)
+            oprot.writeString(self.username)
             oprot.writeFieldEnd()
         if self.password is not None:
             oprot.writeFieldBegin('password', TType.STRING, 3)
-            oprot.writeString(self.password.encode('utf-8') if sys.version_info[0] == 2 else self.password)
+            oprot.writeString(self.password)
             oprot.writeFieldEnd()
         if self.configuration is not None:
             oprot.writeFieldBegin('configuration', TType.MAP, 4)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.configuration))
             for kiter132, viter133 in self.configuration.items():
-                oprot.writeString(kiter132.encode('utf-8') if sys.version_info[0] == 2 else kiter132)
-                oprot.writeString(viter133.encode('utf-8') if sys.version_info[0] == 2 else viter133)
+                oprot.writeString(kiter132)
+                oprot.writeString(viter133)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -3206,8 +3205,8 @@ class TOpenSessionResp(object):
                     self.configuration = {}
                     (_ktype135, _vtype136, _size134) = iprot.readMapBegin()
                     for _i138 in range(_size134):
-                        _key139 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val140 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key139 = iprot.readString()
+                        _val140 = iprot.readString()
                         self.configuration[_key139] = _val140
                     iprot.readMapEnd()
                 else:
@@ -3238,8 +3237,8 @@ class TOpenSessionResp(object):
             oprot.writeFieldBegin('configuration', TType.MAP, 4)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.configuration))
             for kiter141, viter142 in self.configuration.items():
-                oprot.writeString(kiter141.encode('utf-8') if sys.version_info[0] == 2 else kiter141)
-                oprot.writeString(viter142.encode('utf-8') if sys.version_info[0] == 2 else viter142)
+                oprot.writeString(kiter141)
+                oprot.writeString(viter142)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -3413,7 +3412,7 @@ class TGetInfoValue(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.stringValue = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.stringValue = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
@@ -3453,7 +3452,7 @@ class TGetInfoValue(object):
         oprot.writeStructBegin('TGetInfoValue')
         if self.stringValue is not None:
             oprot.writeFieldBegin('stringValue', TType.STRING, 1)
-            oprot.writeString(self.stringValue.encode('utf-8') if sys.version_info[0] == 2 else self.stringValue)
+            oprot.writeString(self.stringValue)
             oprot.writeFieldEnd()
         if self.smallIntValue is not None:
             oprot.writeFieldBegin('smallIntValue', TType.I16, 2)
@@ -3671,7 +3670,7 @@ class TExecuteStatementReq(object):
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.statement = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.statement = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -3679,8 +3678,8 @@ class TExecuteStatementReq(object):
                     self.confOverlay = {}
                     (_ktype144, _vtype145, _size143) = iprot.readMapBegin()
                     for _i147 in range(_size143):
-                        _key148 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val149 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key148 = iprot.readString()
+                        _val149 = iprot.readString()
                         self.confOverlay[_key148] = _val149
                     iprot.readMapEnd()
                 else:
@@ -3706,14 +3705,14 @@ class TExecuteStatementReq(object):
             oprot.writeFieldEnd()
         if self.statement is not None:
             oprot.writeFieldBegin('statement', TType.STRING, 2)
-            oprot.writeString(self.statement.encode('utf-8') if sys.version_info[0] == 2 else self.statement)
+            oprot.writeString(self.statement)
             oprot.writeFieldEnd()
         if self.confOverlay is not None:
             oprot.writeFieldBegin('confOverlay', TType.MAP, 3)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.confOverlay))
             for kiter150, viter151 in self.confOverlay.items():
-                oprot.writeString(kiter150.encode('utf-8') if sys.version_info[0] == 2 else kiter150)
-                oprot.writeString(viter151.encode('utf-8') if sys.version_info[0] == 2 else viter151)
+                oprot.writeString(kiter150)
+                oprot.writeString(viter151)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.runAsync is not None:
@@ -4104,12 +4103,12 @@ class TGetSchemasReq(object):
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.catalogName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.catalogName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.schemaName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.schemaName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -4128,11 +4127,11 @@ class TGetSchemasReq(object):
             oprot.writeFieldEnd()
         if self.catalogName is not None:
             oprot.writeFieldBegin('catalogName', TType.STRING, 2)
-            oprot.writeString(self.catalogName.encode('utf-8') if sys.version_info[0] == 2 else self.catalogName)
+            oprot.writeString(self.catalogName)
             oprot.writeFieldEnd()
         if self.schemaName is not None:
             oprot.writeFieldBegin('schemaName', TType.STRING, 3)
-            oprot.writeString(self.schemaName.encode('utf-8') if sys.version_info[0] == 2 else self.schemaName)
+            oprot.writeString(self.schemaName)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -4260,17 +4259,17 @@ class TGetTablesReq(object):
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.catalogName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.catalogName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.schemaName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.schemaName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.tableName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tableName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 5:
@@ -4278,7 +4277,7 @@ class TGetTablesReq(object):
                     self.tableTypes = []
                     (_etype155, _size152) = iprot.readListBegin()
                     for _i156 in range(_size152):
-                        _elem157 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem157 = iprot.readString()
                         self.tableTypes.append(_elem157)
                     iprot.readListEnd()
                 else:
@@ -4299,21 +4298,21 @@ class TGetTablesReq(object):
             oprot.writeFieldEnd()
         if self.catalogName is not None:
             oprot.writeFieldBegin('catalogName', TType.STRING, 2)
-            oprot.writeString(self.catalogName.encode('utf-8') if sys.version_info[0] == 2 else self.catalogName)
+            oprot.writeString(self.catalogName)
             oprot.writeFieldEnd()
         if self.schemaName is not None:
             oprot.writeFieldBegin('schemaName', TType.STRING, 3)
-            oprot.writeString(self.schemaName.encode('utf-8') if sys.version_info[0] == 2 else self.schemaName)
+            oprot.writeString(self.schemaName)
             oprot.writeFieldEnd()
         if self.tableName is not None:
             oprot.writeFieldBegin('tableName', TType.STRING, 4)
-            oprot.writeString(self.tableName.encode('utf-8') if sys.version_info[0] == 2 else self.tableName)
+            oprot.writeString(self.tableName)
             oprot.writeFieldEnd()
         if self.tableTypes is not None:
             oprot.writeFieldBegin('tableTypes', TType.LIST, 5)
             oprot.writeListBegin(TType.STRING, len(self.tableTypes))
             for iter158 in self.tableTypes:
-                oprot.writeString(iter158.encode('utf-8') if sys.version_info[0] == 2 else iter158)
+                oprot.writeString(iter158)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -4572,22 +4571,22 @@ class TGetColumnsReq(object):
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.catalogName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.catalogName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.schemaName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.schemaName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.tableName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tableName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.STRING:
-                    self.columnName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.columnName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -4606,19 +4605,19 @@ class TGetColumnsReq(object):
             oprot.writeFieldEnd()
         if self.catalogName is not None:
             oprot.writeFieldBegin('catalogName', TType.STRING, 2)
-            oprot.writeString(self.catalogName.encode('utf-8') if sys.version_info[0] == 2 else self.catalogName)
+            oprot.writeString(self.catalogName)
             oprot.writeFieldEnd()
         if self.schemaName is not None:
             oprot.writeFieldBegin('schemaName', TType.STRING, 3)
-            oprot.writeString(self.schemaName.encode('utf-8') if sys.version_info[0] == 2 else self.schemaName)
+            oprot.writeString(self.schemaName)
             oprot.writeFieldEnd()
         if self.tableName is not None:
             oprot.writeFieldBegin('tableName', TType.STRING, 4)
-            oprot.writeString(self.tableName.encode('utf-8') if sys.version_info[0] == 2 else self.tableName)
+            oprot.writeString(self.tableName)
             oprot.writeFieldEnd()
         if self.columnName is not None:
             oprot.writeFieldBegin('columnName', TType.STRING, 5)
-            oprot.writeString(self.columnName.encode('utf-8') if sys.version_info[0] == 2 else self.columnName)
+            oprot.writeString(self.columnName)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -4744,17 +4743,17 @@ class TGetFunctionsReq(object):
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.catalogName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.catalogName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.schemaName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.schemaName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.functionName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.functionName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -4773,15 +4772,15 @@ class TGetFunctionsReq(object):
             oprot.writeFieldEnd()
         if self.catalogName is not None:
             oprot.writeFieldBegin('catalogName', TType.STRING, 2)
-            oprot.writeString(self.catalogName.encode('utf-8') if sys.version_info[0] == 2 else self.catalogName)
+            oprot.writeString(self.catalogName)
             oprot.writeFieldEnd()
         if self.schemaName is not None:
             oprot.writeFieldBegin('schemaName', TType.STRING, 3)
-            oprot.writeString(self.schemaName.encode('utf-8') if sys.version_info[0] == 2 else self.schemaName)
+            oprot.writeString(self.schemaName)
             oprot.writeFieldEnd()
         if self.functionName is not None:
             oprot.writeFieldBegin('functionName', TType.STRING, 4)
-            oprot.writeString(self.functionName.encode('utf-8') if sys.version_info[0] == 2 else self.functionName)
+            oprot.writeString(self.functionName)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -4977,7 +4976,7 @@ class TGetOperationStatusResp(object):
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.sqlState = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.sqlState = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
@@ -4987,7 +4986,7 @@ class TGetOperationStatusResp(object):
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.STRING:
-                    self.errorMessage = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.errorMessage = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 9:
@@ -5015,7 +5014,7 @@ class TGetOperationStatusResp(object):
             oprot.writeFieldEnd()
         if self.sqlState is not None:
             oprot.writeFieldBegin('sqlState', TType.STRING, 3)
-            oprot.writeString(self.sqlState.encode('utf-8') if sys.version_info[0] == 2 else self.sqlState)
+            oprot.writeString(self.sqlState)
             oprot.writeFieldEnd()
         if self.errorCode is not None:
             oprot.writeFieldBegin('errorCode', TType.I32, 4)
@@ -5023,7 +5022,7 @@ class TGetOperationStatusResp(object):
             oprot.writeFieldEnd()
         if self.errorMessage is not None:
             oprot.writeFieldBegin('errorMessage', TType.STRING, 5)
-            oprot.writeString(self.errorMessage.encode('utf-8') if sys.version_info[0] == 2 else self.errorMessage)
+            oprot.writeString(self.errorMessage)
             oprot.writeFieldEnd()
         if self.hasResultSet is not None:
             oprot.writeFieldBegin('hasResultSet', TType.BOOL, 9)
@@ -5624,12 +5623,12 @@ class TGetDelegationTokenReq(object):
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.owner = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.owner = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.renewer = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.renewer = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -5648,11 +5647,11 @@ class TGetDelegationTokenReq(object):
             oprot.writeFieldEnd()
         if self.owner is not None:
             oprot.writeFieldBegin('owner', TType.STRING, 2)
-            oprot.writeString(self.owner.encode('utf-8') if sys.version_info[0] == 2 else self.owner)
+            oprot.writeString(self.owner)
             oprot.writeFieldEnd()
         if self.renewer is not None:
             oprot.writeFieldBegin('renewer', TType.STRING, 3)
-            oprot.writeString(self.renewer.encode('utf-8') if sys.version_info[0] == 2 else self.renewer)
+            oprot.writeString(self.renewer)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -5707,7 +5706,7 @@ class TGetDelegationTokenResp(object):
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.delegationToken = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.delegationToken = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -5726,7 +5725,7 @@ class TGetDelegationTokenResp(object):
             oprot.writeFieldEnd()
         if self.delegationToken is not None:
             oprot.writeFieldBegin('delegationToken', TType.STRING, 2)
-            oprot.writeString(self.delegationToken.encode('utf-8') if sys.version_info[0] == 2 else self.delegationToken)
+            oprot.writeString(self.delegationToken)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -5777,7 +5776,7 @@ class TCancelDelegationTokenReq(object):
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.delegationToken = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.delegationToken = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -5796,7 +5795,7 @@ class TCancelDelegationTokenReq(object):
             oprot.writeFieldEnd()
         if self.delegationToken is not None:
             oprot.writeFieldBegin('delegationToken', TType.STRING, 2)
-            oprot.writeString(self.delegationToken.encode('utf-8') if sys.version_info[0] == 2 else self.delegationToken)
+            oprot.writeString(self.delegationToken)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -5908,7 +5907,7 @@ class TRenewDelegationTokenReq(object):
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.delegationToken = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.delegationToken = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -5927,7 +5926,7 @@ class TRenewDelegationTokenReq(object):
             oprot.writeFieldEnd()
         if self.delegationToken is not None:
             oprot.writeFieldBegin('delegationToken', TType.STRING, 2)
-            oprot.writeString(self.delegationToken.encode('utf-8') if sys.version_info[0] == 2 else self.delegationToken)
+            oprot.writeString(self.delegationToken)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -6098,7 +6097,7 @@ class TGetLogResp(object):
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.log = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.log = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -6117,7 +6116,7 @@ class TGetLogResp(object):
             oprot.writeFieldEnd()
         if self.log is not None:
             oprot.writeFieldBegin('log', TType.STRING, 2)
-            oprot.writeString(self.log.encode('utf-8') if sys.version_info[0] == 2 else self.log)
+            oprot.writeString(self.log)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -6143,12 +6142,12 @@ all_structs.append(TTypeQualifierValue)
 TTypeQualifierValue.thrift_spec = (
     None,  # 0
     (1, TType.I32, 'i32Value', None, None, ),  # 1
-    (2, TType.STRING, 'stringValue', 'UTF8', None, ),  # 2
+    (2, TType.STRING, 'stringValue', None, None, ),  # 2
 )
 all_structs.append(TTypeQualifiers)
 TTypeQualifiers.thrift_spec = (
     None,  # 0
-    (1, TType.MAP, 'qualifiers', (TType.STRING, 'UTF8', TType.STRUCT, [TTypeQualifierValue, None], False), None, ),  # 1
+    (1, TType.MAP, 'qualifiers', (TType.STRING, None, TType.STRUCT, [TTypeQualifierValue, None], False), None, ),  # 1
 )
 all_structs.append(TPrimitiveTypeEntry)
 TPrimitiveTypeEntry.thrift_spec = (
@@ -6170,17 +6169,17 @@ TMapTypeEntry.thrift_spec = (
 all_structs.append(TStructTypeEntry)
 TStructTypeEntry.thrift_spec = (
     None,  # 0
-    (1, TType.MAP, 'nameToTypePtr', (TType.STRING, 'UTF8', TType.I32, None, False), None, ),  # 1
+    (1, TType.MAP, 'nameToTypePtr', (TType.STRING, None, TType.I32, None, False), None, ),  # 1
 )
 all_structs.append(TUnionTypeEntry)
 TUnionTypeEntry.thrift_spec = (
     None,  # 0
-    (1, TType.MAP, 'nameToTypePtr', (TType.STRING, 'UTF8', TType.I32, None, False), None, ),  # 1
+    (1, TType.MAP, 'nameToTypePtr', (TType.STRING, None, TType.I32, None, False), None, ),  # 1
 )
 all_structs.append(TUserDefinedTypeEntry)
 TUserDefinedTypeEntry.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'typeClassName', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'typeClassName', None, None, ),  # 1
 )
 all_structs.append(TTypeEntry)
 TTypeEntry.thrift_spec = (
@@ -6200,10 +6199,10 @@ TTypeDesc.thrift_spec = (
 all_structs.append(TColumnDesc)
 TColumnDesc.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'columnName', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'columnName', None, None, ),  # 1
     (2, TType.STRUCT, 'typeDesc', [TTypeDesc, None], None, ),  # 2
     (3, TType.I32, 'position', None, None, ),  # 3
-    (4, TType.STRING, 'comment', 'UTF8', None, ),  # 4
+    (4, TType.STRING, 'comment', None, None, ),  # 4
 )
 all_structs.append(TTableSchema)
 TTableSchema.thrift_spec = (
@@ -6243,7 +6242,7 @@ TDoubleValue.thrift_spec = (
 all_structs.append(TStringValue)
 TStringValue.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'value', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'value', None, None, ),  # 1
 )
 all_structs.append(TColumnValue)
 TColumnValue.thrift_spec = (
@@ -6300,7 +6299,7 @@ TDoubleColumn.thrift_spec = (
 all_structs.append(TStringColumn)
 TStringColumn.thrift_spec = (
     None,  # 0
-    (1, TType.LIST, 'values', (TType.STRING, 'UTF8', False), None, ),  # 1
+    (1, TType.LIST, 'values', (TType.STRING, None, False), None, ),  # 1
     (2, TType.STRING, 'nulls', 'BINARY', None, ),  # 2
 )
 all_structs.append(TBinaryColumn)
@@ -6332,10 +6331,10 @@ all_structs.append(TStatus)
 TStatus.thrift_spec = (
     None,  # 0
     (1, TType.I32, 'statusCode', None, None, ),  # 1
-    (2, TType.LIST, 'infoMessages', (TType.STRING, 'UTF8', False), None, ),  # 2
-    (3, TType.STRING, 'sqlState', 'UTF8', None, ),  # 3
+    (2, TType.LIST, 'infoMessages', (TType.STRING, None, False), None, ),  # 2
+    (3, TType.STRING, 'sqlState', None, None, ),  # 3
     (4, TType.I32, 'errorCode', None, None, ),  # 4
-    (5, TType.STRING, 'errorMessage', 'UTF8', None, ),  # 5
+    (5, TType.STRING, 'errorMessage', None, None, ),  # 5
 )
 all_structs.append(THandleIdentifier)
 THandleIdentifier.thrift_spec = (
@@ -6360,9 +6359,9 @@ all_structs.append(TOpenSessionReq)
 TOpenSessionReq.thrift_spec = (
     None,  # 0
     (1, TType.I32, 'client_protocol', None, 5, ),  # 1
-    (2, TType.STRING, 'username', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'password', 'UTF8', None, ),  # 3
-    (4, TType.MAP, 'configuration', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 4
+    (2, TType.STRING, 'username', None, None, ),  # 2
+    (3, TType.STRING, 'password', None, None, ),  # 3
+    (4, TType.MAP, 'configuration', (TType.STRING, None, TType.STRING, None, False), None, ),  # 4
 )
 all_structs.append(TOpenSessionResp)
 TOpenSessionResp.thrift_spec = (
@@ -6370,7 +6369,7 @@ TOpenSessionResp.thrift_spec = (
     (1, TType.STRUCT, 'status', [TStatus, None], None, ),  # 1
     (2, TType.I32, 'serverProtocolVersion', None, 5, ),  # 2
     (3, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None, ),  # 3
-    (4, TType.MAP, 'configuration', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 4
+    (4, TType.MAP, 'configuration', (TType.STRING, None, TType.STRING, None, False), None, ),  # 4
 )
 all_structs.append(TCloseSessionReq)
 TCloseSessionReq.thrift_spec = (
@@ -6385,7 +6384,7 @@ TCloseSessionResp.thrift_spec = (
 all_structs.append(TGetInfoValue)
 TGetInfoValue.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'stringValue', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'stringValue', None, None, ),  # 1
     (2, TType.I16, 'smallIntValue', None, None, ),  # 2
     (3, TType.I32, 'integerBitmask', None, None, ),  # 3
     (4, TType.I32, 'integerFlag', None, None, ),  # 4
@@ -6408,8 +6407,8 @@ all_structs.append(TExecuteStatementReq)
 TExecuteStatementReq.thrift_spec = (
     None,  # 0
     (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None, ),  # 1
-    (2, TType.STRING, 'statement', 'UTF8', None, ),  # 2
-    (3, TType.MAP, 'confOverlay', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 3
+    (2, TType.STRING, 'statement', None, None, ),  # 2
+    (3, TType.MAP, 'confOverlay', (TType.STRING, None, TType.STRING, None, False), None, ),  # 3
     (4, TType.BOOL, 'runAsync', None, False, ),  # 4
 )
 all_structs.append(TExecuteStatementResp)
@@ -6444,8 +6443,8 @@ all_structs.append(TGetSchemasReq)
 TGetSchemasReq.thrift_spec = (
     None,  # 0
     (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None, ),  # 1
-    (2, TType.STRING, 'catalogName', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'schemaName', 'UTF8', None, ),  # 3
+    (2, TType.STRING, 'catalogName', None, None, ),  # 2
+    (3, TType.STRING, 'schemaName', None, None, ),  # 3
 )
 all_structs.append(TGetSchemasResp)
 TGetSchemasResp.thrift_spec = (
@@ -6457,10 +6456,10 @@ all_structs.append(TGetTablesReq)
 TGetTablesReq.thrift_spec = (
     None,  # 0
     (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None, ),  # 1
-    (2, TType.STRING, 'catalogName', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'schemaName', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'tableName', 'UTF8', None, ),  # 4
-    (5, TType.LIST, 'tableTypes', (TType.STRING, 'UTF8', False), None, ),  # 5
+    (2, TType.STRING, 'catalogName', None, None, ),  # 2
+    (3, TType.STRING, 'schemaName', None, None, ),  # 3
+    (4, TType.STRING, 'tableName', None, None, ),  # 4
+    (5, TType.LIST, 'tableTypes', (TType.STRING, None, False), None, ),  # 5
 )
 all_structs.append(TGetTablesResp)
 TGetTablesResp.thrift_spec = (
@@ -6483,10 +6482,10 @@ all_structs.append(TGetColumnsReq)
 TGetColumnsReq.thrift_spec = (
     None,  # 0
     (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None, ),  # 1
-    (2, TType.STRING, 'catalogName', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'schemaName', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'tableName', 'UTF8', None, ),  # 4
-    (5, TType.STRING, 'columnName', 'UTF8', None, ),  # 5
+    (2, TType.STRING, 'catalogName', None, None, ),  # 2
+    (3, TType.STRING, 'schemaName', None, None, ),  # 3
+    (4, TType.STRING, 'tableName', None, None, ),  # 4
+    (5, TType.STRING, 'columnName', None, None, ),  # 5
 )
 all_structs.append(TGetColumnsResp)
 TGetColumnsResp.thrift_spec = (
@@ -6498,9 +6497,9 @@ all_structs.append(TGetFunctionsReq)
 TGetFunctionsReq.thrift_spec = (
     None,  # 0
     (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None, ),  # 1
-    (2, TType.STRING, 'catalogName', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'schemaName', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'functionName', 'UTF8', None, ),  # 4
+    (2, TType.STRING, 'catalogName', None, None, ),  # 2
+    (3, TType.STRING, 'schemaName', None, None, ),  # 3
+    (4, TType.STRING, 'functionName', None, None, ),  # 4
 )
 all_structs.append(TGetFunctionsResp)
 TGetFunctionsResp.thrift_spec = (
@@ -6518,9 +6517,9 @@ TGetOperationStatusResp.thrift_spec = (
     None,  # 0
     (1, TType.STRUCT, 'status', [TStatus, None], None, ),  # 1
     (2, TType.I32, 'operationState', None, None, ),  # 2
-    (3, TType.STRING, 'sqlState', 'UTF8', None, ),  # 3
+    (3, TType.STRING, 'sqlState', None, None, ),  # 3
     (4, TType.I32, 'errorCode', None, None, ),  # 4
-    (5, TType.STRING, 'errorMessage', 'UTF8', None, ),  # 5
+    (5, TType.STRING, 'errorMessage', None, None, ),  # 5
     None,  # 6
     None,  # 7
     None,  # 8
@@ -6576,20 +6575,20 @@ all_structs.append(TGetDelegationTokenReq)
 TGetDelegationTokenReq.thrift_spec = (
     None,  # 0
     (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None, ),  # 1
-    (2, TType.STRING, 'owner', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'renewer', 'UTF8', None, ),  # 3
+    (2, TType.STRING, 'owner', None, None, ),  # 2
+    (3, TType.STRING, 'renewer', None, None, ),  # 3
 )
 all_structs.append(TGetDelegationTokenResp)
 TGetDelegationTokenResp.thrift_spec = (
     None,  # 0
     (1, TType.STRUCT, 'status', [TStatus, None], None, ),  # 1
-    (2, TType.STRING, 'delegationToken', 'UTF8', None, ),  # 2
+    (2, TType.STRING, 'delegationToken', None, None, ),  # 2
 )
 all_structs.append(TCancelDelegationTokenReq)
 TCancelDelegationTokenReq.thrift_spec = (
     None,  # 0
     (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None, ),  # 1
-    (2, TType.STRING, 'delegationToken', 'UTF8', None, ),  # 2
+    (2, TType.STRING, 'delegationToken', None, None, ),  # 2
 )
 all_structs.append(TCancelDelegationTokenResp)
 TCancelDelegationTokenResp.thrift_spec = (
@@ -6600,7 +6599,7 @@ all_structs.append(TRenewDelegationTokenReq)
 TRenewDelegationTokenReq.thrift_spec = (
     None,  # 0
     (1, TType.STRUCT, 'sessionHandle', [TSessionHandle, None], None, ),  # 1
-    (2, TType.STRING, 'delegationToken', 'UTF8', None, ),  # 2
+    (2, TType.STRING, 'delegationToken', None, None, ),  # 2
 )
 all_structs.append(TRenewDelegationTokenResp)
 TRenewDelegationTokenResp.thrift_spec = (
@@ -6616,7 +6615,7 @@ all_structs.append(TGetLogResp)
 TGetLogResp.thrift_spec = (
     None,  # 0
     (1, TType.STRUCT, 'status', [TStatus, None], None, ),  # 1
-    (2, TType.STRING, 'log', 'UTF8', None, ),  # 2
+    (2, TType.STRING, 'log', None, None, ),  # 2
 )
 fix_spec(all_structs)
 del all_structs

--- a/impala/_thrift_gen/Types/constants.py
+++ b/impala/_thrift_gen/Types/constants.py
@@ -3,12 +3,11 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.TRecursive import fix_spec
 
-import sys
 from .ttypes import *

--- a/impala/_thrift_gen/Types/ttypes.py
+++ b/impala/_thrift_gen/Types/ttypes.py
@@ -3,14 +3,13 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.TRecursive import fix_spec
 
-import sys
 
 from thrift.transport import TTransport
 all_structs = []
@@ -340,12 +339,12 @@ class TStructField(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.comment = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.comment = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -360,11 +359,11 @@ class TStructField(object):
         oprot.writeStructBegin('TStructField')
         if self.name is not None:
             oprot.writeFieldBegin('name', TType.STRING, 1)
-            oprot.writeString(self.name.encode('utf-8') if sys.version_info[0] == 2 else self.name)
+            oprot.writeString(self.name)
             oprot.writeFieldEnd()
         if self.comment is not None:
             oprot.writeFieldBegin('comment', TType.STRING, 2)
-            oprot.writeString(self.comment.encode('utf-8') if sys.version_info[0] == 2 else self.comment)
+            oprot.writeString(self.comment)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -564,7 +563,7 @@ class TNetworkAddress(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.hostname = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.hostname = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
@@ -584,7 +583,7 @@ class TNetworkAddress(object):
         oprot.writeStructBegin('TNetworkAddress')
         if self.hostname is not None:
             oprot.writeFieldBegin('hostname', TType.STRING, 1)
-            oprot.writeString(self.hostname.encode('utf-8') if sys.version_info[0] == 2 else self.hostname)
+            oprot.writeString(self.hostname)
             oprot.writeFieldEnd()
         if self.port is not None:
             oprot.writeFieldBegin('port', TType.I32, 2)
@@ -706,12 +705,12 @@ class TFunctionName(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.function_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.function_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -726,11 +725,11 @@ class TFunctionName(object):
         oprot.writeStructBegin('TFunctionName')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.function_name is not None:
             oprot.writeFieldBegin('function_name', TType.STRING, 2)
-            oprot.writeString(self.function_name.encode('utf-8') if sys.version_info[0] == 2 else self.function_name)
+            oprot.writeString(self.function_name)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -777,17 +776,17 @@ class TScalarFunction(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.symbol = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.symbol = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.prepare_fn_symbol = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.prepare_fn_symbol = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.close_fn_symbol = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.close_fn_symbol = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -802,15 +801,15 @@ class TScalarFunction(object):
         oprot.writeStructBegin('TScalarFunction')
         if self.symbol is not None:
             oprot.writeFieldBegin('symbol', TType.STRING, 1)
-            oprot.writeString(self.symbol.encode('utf-8') if sys.version_info[0] == 2 else self.symbol)
+            oprot.writeString(self.symbol)
             oprot.writeFieldEnd()
         if self.prepare_fn_symbol is not None:
             oprot.writeFieldBegin('prepare_fn_symbol', TType.STRING, 2)
-            oprot.writeString(self.prepare_fn_symbol.encode('utf-8') if sys.version_info[0] == 2 else self.prepare_fn_symbol)
+            oprot.writeString(self.prepare_fn_symbol)
             oprot.writeFieldEnd()
         if self.close_fn_symbol is not None:
             oprot.writeFieldBegin('close_fn_symbol', TType.STRING, 3)
-            oprot.writeString(self.close_fn_symbol.encode('utf-8') if sys.version_info[0] == 2 else self.close_fn_symbol)
+            oprot.writeString(self.close_fn_symbol)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -882,37 +881,37 @@ class TAggregateFunction(object):
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.update_fn_symbol = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.update_fn_symbol = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.init_fn_symbol = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.init_fn_symbol = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.STRING:
-                    self.serialize_fn_symbol = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.serialize_fn_symbol = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 6:
                 if ftype == TType.STRING:
-                    self.merge_fn_symbol = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.merge_fn_symbol = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 7:
                 if ftype == TType.STRING:
-                    self.finalize_fn_symbol = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.finalize_fn_symbol = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 8:
                 if ftype == TType.STRING:
-                    self.get_value_fn_symbol = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.get_value_fn_symbol = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 9:
                 if ftype == TType.STRING:
-                    self.remove_fn_symbol = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.remove_fn_symbol = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 10:
@@ -940,31 +939,31 @@ class TAggregateFunction(object):
             oprot.writeFieldEnd()
         if self.update_fn_symbol is not None:
             oprot.writeFieldBegin('update_fn_symbol', TType.STRING, 3)
-            oprot.writeString(self.update_fn_symbol.encode('utf-8') if sys.version_info[0] == 2 else self.update_fn_symbol)
+            oprot.writeString(self.update_fn_symbol)
             oprot.writeFieldEnd()
         if self.init_fn_symbol is not None:
             oprot.writeFieldBegin('init_fn_symbol', TType.STRING, 4)
-            oprot.writeString(self.init_fn_symbol.encode('utf-8') if sys.version_info[0] == 2 else self.init_fn_symbol)
+            oprot.writeString(self.init_fn_symbol)
             oprot.writeFieldEnd()
         if self.serialize_fn_symbol is not None:
             oprot.writeFieldBegin('serialize_fn_symbol', TType.STRING, 5)
-            oprot.writeString(self.serialize_fn_symbol.encode('utf-8') if sys.version_info[0] == 2 else self.serialize_fn_symbol)
+            oprot.writeString(self.serialize_fn_symbol)
             oprot.writeFieldEnd()
         if self.merge_fn_symbol is not None:
             oprot.writeFieldBegin('merge_fn_symbol', TType.STRING, 6)
-            oprot.writeString(self.merge_fn_symbol.encode('utf-8') if sys.version_info[0] == 2 else self.merge_fn_symbol)
+            oprot.writeString(self.merge_fn_symbol)
             oprot.writeFieldEnd()
         if self.finalize_fn_symbol is not None:
             oprot.writeFieldBegin('finalize_fn_symbol', TType.STRING, 7)
-            oprot.writeString(self.finalize_fn_symbol.encode('utf-8') if sys.version_info[0] == 2 else self.finalize_fn_symbol)
+            oprot.writeString(self.finalize_fn_symbol)
             oprot.writeFieldEnd()
         if self.get_value_fn_symbol is not None:
             oprot.writeFieldBegin('get_value_fn_symbol', TType.STRING, 8)
-            oprot.writeString(self.get_value_fn_symbol.encode('utf-8') if sys.version_info[0] == 2 else self.get_value_fn_symbol)
+            oprot.writeString(self.get_value_fn_symbol)
             oprot.writeFieldEnd()
         if self.remove_fn_symbol is not None:
             oprot.writeFieldBegin('remove_fn_symbol', TType.STRING, 9)
-            oprot.writeString(self.remove_fn_symbol.encode('utf-8') if sys.version_info[0] == 2 else self.remove_fn_symbol)
+            oprot.writeString(self.remove_fn_symbol)
             oprot.writeFieldEnd()
         if self.ignores_distinct is not None:
             oprot.writeFieldBegin('ignores_distinct', TType.BOOL, 10)
@@ -1072,17 +1071,17 @@ class TFunction(object):
                     iprot.skip(ftype)
             elif fid == 6:
                 if ftype == TType.STRING:
-                    self.comment = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.comment = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 7:
                 if ftype == TType.STRING:
-                    self.signature = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.signature = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 8:
                 if ftype == TType.STRING:
-                    self.hdfs_location = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.hdfs_location = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 9:
@@ -1142,15 +1141,15 @@ class TFunction(object):
             oprot.writeFieldEnd()
         if self.comment is not None:
             oprot.writeFieldBegin('comment', TType.STRING, 6)
-            oprot.writeString(self.comment.encode('utf-8') if sys.version_info[0] == 2 else self.comment)
+            oprot.writeString(self.comment)
             oprot.writeFieldEnd()
         if self.signature is not None:
             oprot.writeFieldBegin('signature', TType.STRING, 7)
-            oprot.writeString(self.signature.encode('utf-8') if sys.version_info[0] == 2 else self.signature)
+            oprot.writeString(self.signature)
             oprot.writeFieldEnd()
         if self.hdfs_location is not None:
             oprot.writeFieldBegin('hdfs_location', TType.STRING, 8)
-            oprot.writeString(self.hdfs_location.encode('utf-8') if sys.version_info[0] == 2 else self.hdfs_location)
+            oprot.writeString(self.hdfs_location)
             oprot.writeFieldEnd()
         if self.scalar_fn is not None:
             oprot.writeFieldBegin('scalar_fn', TType.STRUCT, 9)
@@ -1197,8 +1196,8 @@ TScalarType.thrift_spec = (
 all_structs.append(TStructField)
 TStructField.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'comment', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'name', None, None, ),  # 1
+    (2, TType.STRING, 'comment', None, None, ),  # 2
 )
 all_structs.append(TTypeNode)
 TTypeNode.thrift_spec = (
@@ -1215,7 +1214,7 @@ TColumnType.thrift_spec = (
 all_structs.append(TNetworkAddress)
 TNetworkAddress.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'hostname', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'hostname', None, None, ),  # 1
     (2, TType.I32, 'port', None, None, ),  # 2
 )
 all_structs.append(TUniqueId)
@@ -1227,28 +1226,28 @@ TUniqueId.thrift_spec = (
 all_structs.append(TFunctionName)
 TFunctionName.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'function_name', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'function_name', None, None, ),  # 2
 )
 all_structs.append(TScalarFunction)
 TScalarFunction.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'symbol', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'prepare_fn_symbol', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'close_fn_symbol', 'UTF8', None, ),  # 3
+    (1, TType.STRING, 'symbol', None, None, ),  # 1
+    (2, TType.STRING, 'prepare_fn_symbol', None, None, ),  # 2
+    (3, TType.STRING, 'close_fn_symbol', None, None, ),  # 3
 )
 all_structs.append(TAggregateFunction)
 TAggregateFunction.thrift_spec = (
     None,  # 0
     (1, TType.STRUCT, 'intermediate_type', [TColumnType, None], None, ),  # 1
     (2, TType.BOOL, 'is_analytic_only_fn', None, None, ),  # 2
-    (3, TType.STRING, 'update_fn_symbol', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'init_fn_symbol', 'UTF8', None, ),  # 4
-    (5, TType.STRING, 'serialize_fn_symbol', 'UTF8', None, ),  # 5
-    (6, TType.STRING, 'merge_fn_symbol', 'UTF8', None, ),  # 6
-    (7, TType.STRING, 'finalize_fn_symbol', 'UTF8', None, ),  # 7
-    (8, TType.STRING, 'get_value_fn_symbol', 'UTF8', None, ),  # 8
-    (9, TType.STRING, 'remove_fn_symbol', 'UTF8', None, ),  # 9
+    (3, TType.STRING, 'update_fn_symbol', None, None, ),  # 3
+    (4, TType.STRING, 'init_fn_symbol', None, None, ),  # 4
+    (5, TType.STRING, 'serialize_fn_symbol', None, None, ),  # 5
+    (6, TType.STRING, 'merge_fn_symbol', None, None, ),  # 6
+    (7, TType.STRING, 'finalize_fn_symbol', None, None, ),  # 7
+    (8, TType.STRING, 'get_value_fn_symbol', None, None, ),  # 8
+    (9, TType.STRING, 'remove_fn_symbol', None, None, ),  # 9
     (10, TType.BOOL, 'ignores_distinct', None, None, ),  # 10
 )
 all_structs.append(TFunction)
@@ -1259,9 +1258,9 @@ TFunction.thrift_spec = (
     (3, TType.LIST, 'arg_types', (TType.STRUCT, [TColumnType, None], False), None, ),  # 3
     (4, TType.STRUCT, 'ret_type', [TColumnType, None], None, ),  # 4
     (5, TType.BOOL, 'has_var_args', None, None, ),  # 5
-    (6, TType.STRING, 'comment', 'UTF8', None, ),  # 6
-    (7, TType.STRING, 'signature', 'UTF8', None, ),  # 7
-    (8, TType.STRING, 'hdfs_location', 'UTF8', None, ),  # 8
+    (6, TType.STRING, 'comment', None, None, ),  # 6
+    (7, TType.STRING, 'signature', None, None, ),  # 7
+    (8, TType.STRING, 'hdfs_location', None, None, ),  # 8
     (9, TType.STRUCT, 'scalar_fn', [TScalarFunction, None], None, ),  # 9
     (10, TType.STRUCT, 'aggregate_fn', [TAggregateFunction, None], None, ),  # 10
     (11, TType.BOOL, 'is_persistent', None, None, ),  # 11

--- a/impala/_thrift_gen/beeswax/BeeswaxService-remote
+++ b/impala/_thrift_gen/beeswax/BeeswaxService-remote
@@ -4,7 +4,7 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 import sys

--- a/impala/_thrift_gen/beeswax/BeeswaxService.py
+++ b/impala/_thrift_gen/beeswax/BeeswaxService.py
@@ -3,14 +3,13 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.TRecursive import fix_spec
 
-import sys
 import logging
 from .ttypes import *
 from thrift.Thrift import TProcessor
@@ -1050,7 +1049,7 @@ class executeAndWait_args(object):
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.clientCtx = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.clientCtx = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -1069,7 +1068,7 @@ class executeAndWait_args(object):
             oprot.writeFieldEnd()
         if self.clientCtx is not None:
             oprot.writeFieldBegin('clientCtx', TType.STRING, 2)
-            oprot.writeString(self.clientCtx.encode('utf-8') if sys.version_info[0] == 2 else self.clientCtx)
+            oprot.writeString(self.clientCtx)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -1091,7 +1090,7 @@ all_structs.append(executeAndWait_args)
 executeAndWait_args.thrift_spec = (
     None,  # 0
     (1, TType.STRUCT, 'query', [Query, None], None, ),  # 1
-    (2, TType.STRING, 'clientCtx', 'UTF8', None, ),  # 2
+    (2, TType.STRING, 'clientCtx', None, None, ),  # 2
 )
 
 
@@ -1770,7 +1769,7 @@ class echo_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.s = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.s = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -1785,7 +1784,7 @@ class echo_args(object):
         oprot.writeStructBegin('echo_args')
         if self.s is not None:
             oprot.writeFieldBegin('s', TType.STRING, 1)
-            oprot.writeString(self.s.encode('utf-8') if sys.version_info[0] == 2 else self.s)
+            oprot.writeString(self.s)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -1806,7 +1805,7 @@ class echo_args(object):
 all_structs.append(echo_args)
 echo_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 's', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 's', None, None, ),  # 1
 )
 
 
@@ -1831,7 +1830,7 @@ class echo_result(object):
                 break
             if fid == 0:
                 if ftype == TType.STRING:
-                    self.success = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.success = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -1846,7 +1845,7 @@ class echo_result(object):
         oprot.writeStructBegin('echo_result')
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.STRING, 0)
-            oprot.writeString(self.success.encode('utf-8') if sys.version_info[0] == 2 else self.success)
+            oprot.writeString(self.success)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -1866,7 +1865,7 @@ class echo_result(object):
         return not (self == other)
 all_structs.append(echo_result)
 echo_result.thrift_spec = (
-    (0, TType.STRING, 'success', 'UTF8', None, ),  # 0
+    (0, TType.STRING, 'success', None, None, ),  # 0
 )
 
 
@@ -1934,7 +1933,7 @@ class dump_config_result(object):
                 break
             if fid == 0:
                 if ftype == TType.STRING:
-                    self.success = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.success = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -1949,7 +1948,7 @@ class dump_config_result(object):
         oprot.writeStructBegin('dump_config_result')
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.STRING, 0)
-            oprot.writeString(self.success.encode('utf-8') if sys.version_info[0] == 2 else self.success)
+            oprot.writeString(self.success)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -1969,7 +1968,7 @@ class dump_config_result(object):
         return not (self == other)
 all_structs.append(dump_config_result)
 dump_config_result.thrift_spec = (
-    (0, TType.STRING, 'success', 'UTF8', None, ),  # 0
+    (0, TType.STRING, 'success', None, None, ),  # 0
 )
 
 
@@ -1994,7 +1993,7 @@ class get_log_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.context = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.context = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -2009,7 +2008,7 @@ class get_log_args(object):
         oprot.writeStructBegin('get_log_args')
         if self.context is not None:
             oprot.writeFieldBegin('context', TType.STRING, 1)
-            oprot.writeString(self.context.encode('utf-8') if sys.version_info[0] == 2 else self.context)
+            oprot.writeString(self.context)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -2030,7 +2029,7 @@ class get_log_args(object):
 all_structs.append(get_log_args)
 get_log_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'context', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'context', None, None, ),  # 1
 )
 
 
@@ -2057,7 +2056,7 @@ class get_log_result(object):
                 break
             if fid == 0:
                 if ftype == TType.STRING:
-                    self.success = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.success = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 1:
@@ -2078,7 +2077,7 @@ class get_log_result(object):
         oprot.writeStructBegin('get_log_result')
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.STRING, 0)
-            oprot.writeString(self.success.encode('utf-8') if sys.version_info[0] == 2 else self.success)
+            oprot.writeString(self.success)
             oprot.writeFieldEnd()
         if self.error is not None:
             oprot.writeFieldBegin('error', TType.STRUCT, 1)
@@ -2102,7 +2101,7 @@ class get_log_result(object):
         return not (self == other)
 all_structs.append(get_log_result)
 get_log_result.thrift_spec = (
-    (0, TType.STRING, 'success', 'UTF8', None, ),  # 0
+    (0, TType.STRING, 'success', None, None, ),  # 0
     (1, TType.STRUCT, 'error', [QueryNotFoundException, None], None, ),  # 1
 )
 
@@ -2395,7 +2394,7 @@ class clean_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.log_context = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.log_context = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -2410,7 +2409,7 @@ class clean_args(object):
         oprot.writeStructBegin('clean_args')
         if self.log_context is not None:
             oprot.writeFieldBegin('log_context', TType.STRING, 1)
-            oprot.writeString(self.log_context.encode('utf-8') if sys.version_info[0] == 2 else self.log_context)
+            oprot.writeString(self.log_context)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -2431,7 +2430,7 @@ class clean_args(object):
 all_structs.append(clean_args)
 clean_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'log_context', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'log_context', None, None, ),  # 1
 )
 
 

--- a/impala/_thrift_gen/beeswax/constants.py
+++ b/impala/_thrift_gen/beeswax/constants.py
@@ -3,12 +3,11 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.TRecursive import fix_spec
 
-import sys
 from .ttypes import *

--- a/impala/_thrift_gen/beeswax/ttypes.py
+++ b/impala/_thrift_gen/beeswax/ttypes.py
@@ -3,14 +3,13 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.TRecursive import fix_spec
 
-import sys
 import impala._thrift_gen.hive_metastore.ttypes
 
 from thrift.transport import TTransport
@@ -93,7 +92,7 @@ class Query(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.query = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.query = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -101,14 +100,14 @@ class Query(object):
                     self.configuration = []
                     (_etype3, _size0) = iprot.readListBegin()
                     for _i4 in range(_size0):
-                        _elem5 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem5 = iprot.readString()
                         self.configuration.append(_elem5)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.hadoop_user = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.hadoop_user = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -123,18 +122,18 @@ class Query(object):
         oprot.writeStructBegin('Query')
         if self.query is not None:
             oprot.writeFieldBegin('query', TType.STRING, 1)
-            oprot.writeString(self.query.encode('utf-8') if sys.version_info[0] == 2 else self.query)
+            oprot.writeString(self.query)
             oprot.writeFieldEnd()
         if self.configuration is not None:
             oprot.writeFieldBegin('configuration', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.configuration))
             for iter6 in self.configuration:
-                oprot.writeString(iter6.encode('utf-8') if sys.version_info[0] == 2 else iter6)
+                oprot.writeString(iter6)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.hadoop_user is not None:
             oprot.writeFieldBegin('hadoop_user', TType.STRING, 4)
-            oprot.writeString(self.hadoop_user.encode('utf-8') if sys.version_info[0] == 2 else self.hadoop_user)
+            oprot.writeString(self.hadoop_user)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -177,12 +176,12 @@ class QueryHandle(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.id = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.id = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.log_context = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.log_context = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -197,11 +196,11 @@ class QueryHandle(object):
         oprot.writeStructBegin('QueryHandle')
         if self.id is not None:
             oprot.writeFieldBegin('id', TType.STRING, 1)
-            oprot.writeString(self.id.encode('utf-8') if sys.version_info[0] == 2 else self.id)
+            oprot.writeString(self.id)
             oprot.writeFieldEnd()
         if self.log_context is not None:
             oprot.writeFieldBegin('log_context', TType.STRING, 2)
-            oprot.writeString(self.log_context.encode('utf-8') if sys.version_info[0] == 2 else self.log_context)
+            oprot.writeString(self.log_context)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -242,7 +241,7 @@ class QueryExplanation(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.textual = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.textual = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -257,7 +256,7 @@ class QueryExplanation(object):
         oprot.writeStructBegin('QueryExplanation')
         if self.textual is not None:
             oprot.writeFieldBegin('textual', TType.STRING, 1)
-            oprot.writeString(self.textual.encode('utf-8') if sys.version_info[0] == 2 else self.textual)
+            oprot.writeString(self.textual)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -314,7 +313,7 @@ class Results(object):
                     self.columns = []
                     (_etype10, _size7) = iprot.readListBegin()
                     for _i11 in range(_size7):
-                        _elem12 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem12 = iprot.readString()
                         self.columns.append(_elem12)
                     iprot.readListEnd()
                 else:
@@ -324,7 +323,7 @@ class Results(object):
                     self.data = []
                     (_etype16, _size13) = iprot.readListBegin()
                     for _i17 in range(_size13):
-                        _elem18 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem18 = iprot.readString()
                         self.data.append(_elem18)
                     iprot.readListEnd()
                 else:
@@ -357,14 +356,14 @@ class Results(object):
             oprot.writeFieldBegin('columns', TType.LIST, 2)
             oprot.writeListBegin(TType.STRING, len(self.columns))
             for iter19 in self.columns:
-                oprot.writeString(iter19.encode('utf-8') if sys.version_info[0] == 2 else iter19)
+                oprot.writeString(iter19)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.data is not None:
             oprot.writeFieldBegin('data', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.data))
             for iter20 in self.data:
-                oprot.writeString(iter20.encode('utf-8') if sys.version_info[0] == 2 else iter20)
+                oprot.writeString(iter20)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.start_row is not None:
@@ -429,17 +428,17 @@ class ResultsMetadata(object):
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.table_dir = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.table_dir = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.in_tablename = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.in_tablename = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.delim = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.delim = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -458,15 +457,15 @@ class ResultsMetadata(object):
             oprot.writeFieldEnd()
         if self.table_dir is not None:
             oprot.writeFieldBegin('table_dir', TType.STRING, 2)
-            oprot.writeString(self.table_dir.encode('utf-8') if sys.version_info[0] == 2 else self.table_dir)
+            oprot.writeString(self.table_dir)
             oprot.writeFieldEnd()
         if self.in_tablename is not None:
             oprot.writeFieldBegin('in_tablename', TType.STRING, 3)
-            oprot.writeString(self.in_tablename.encode('utf-8') if sys.version_info[0] == 2 else self.in_tablename)
+            oprot.writeString(self.in_tablename)
             oprot.writeFieldEnd()
         if self.delim is not None:
             oprot.writeFieldBegin('delim', TType.STRING, 4)
-            oprot.writeString(self.delim.encode('utf-8') if sys.version_info[0] == 2 else self.delim)
+            oprot.writeString(self.delim)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -515,12 +514,12 @@ class BeeswaxException(TException):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.message = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.message = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.log_context = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.log_context = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -536,7 +535,7 @@ class BeeswaxException(TException):
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.STRING:
-                    self.SQLState = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.SQLState = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -551,11 +550,11 @@ class BeeswaxException(TException):
         oprot.writeStructBegin('BeeswaxException')
         if self.message is not None:
             oprot.writeFieldBegin('message', TType.STRING, 1)
-            oprot.writeString(self.message.encode('utf-8') if sys.version_info[0] == 2 else self.message)
+            oprot.writeString(self.message)
             oprot.writeFieldEnd()
         if self.log_context is not None:
             oprot.writeFieldBegin('log_context', TType.STRING, 2)
-            oprot.writeString(self.log_context.encode('utf-8') if sys.version_info[0] == 2 else self.log_context)
+            oprot.writeString(self.log_context)
             oprot.writeFieldEnd()
         if self.handle is not None:
             oprot.writeFieldBegin('handle', TType.STRUCT, 3)
@@ -567,7 +566,7 @@ class BeeswaxException(TException):
             oprot.writeFieldEnd()
         if self.SQLState is not None:
             oprot.writeFieldBegin('SQLState', TType.STRING, 5)
-            oprot.writeString(self.SQLState.encode('utf-8') if sys.version_info[0] == 2 else self.SQLState)
+            oprot.writeString(self.SQLState)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -662,17 +661,17 @@ class ConfigVariable(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.key = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.key = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.value = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.value = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.description = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.description = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
@@ -692,15 +691,15 @@ class ConfigVariable(object):
         oprot.writeStructBegin('ConfigVariable')
         if self.key is not None:
             oprot.writeFieldBegin('key', TType.STRING, 1)
-            oprot.writeString(self.key.encode('utf-8') if sys.version_info[0] == 2 else self.key)
+            oprot.writeString(self.key)
             oprot.writeFieldEnd()
         if self.value is not None:
             oprot.writeFieldBegin('value', TType.STRING, 2)
-            oprot.writeString(self.value.encode('utf-8') if sys.version_info[0] == 2 else self.value)
+            oprot.writeString(self.value)
             oprot.writeFieldEnd()
         if self.description is not None:
             oprot.writeFieldBegin('description', TType.STRING, 3)
-            oprot.writeString(self.description.encode('utf-8') if sys.version_info[0] == 2 else self.description)
+            oprot.writeString(self.description)
             oprot.writeFieldEnd()
         if self.level is not None:
             oprot.writeFieldBegin('level', TType.I32, 4)
@@ -725,28 +724,28 @@ class ConfigVariable(object):
 all_structs.append(Query)
 Query.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'query', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'query', None, None, ),  # 1
     None,  # 2
-    (3, TType.LIST, 'configuration', (TType.STRING, 'UTF8', False), None, ),  # 3
-    (4, TType.STRING, 'hadoop_user', 'UTF8', None, ),  # 4
+    (3, TType.LIST, 'configuration', (TType.STRING, None, False), None, ),  # 3
+    (4, TType.STRING, 'hadoop_user', None, None, ),  # 4
 )
 all_structs.append(QueryHandle)
 QueryHandle.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'id', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'log_context', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'id', None, None, ),  # 1
+    (2, TType.STRING, 'log_context', None, None, ),  # 2
 )
 all_structs.append(QueryExplanation)
 QueryExplanation.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'textual', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'textual', None, None, ),  # 1
 )
 all_structs.append(Results)
 Results.thrift_spec = (
     None,  # 0
     (1, TType.BOOL, 'ready', None, None, ),  # 1
-    (2, TType.LIST, 'columns', (TType.STRING, 'UTF8', False), None, ),  # 2
-    (3, TType.LIST, 'data', (TType.STRING, 'UTF8', False), None, ),  # 3
+    (2, TType.LIST, 'columns', (TType.STRING, None, False), None, ),  # 2
+    (3, TType.LIST, 'data', (TType.STRING, None, False), None, ),  # 3
     (4, TType.I64, 'start_row', None, None, ),  # 4
     (5, TType.BOOL, 'has_more', None, None, ),  # 5
 )
@@ -754,18 +753,18 @@ all_structs.append(ResultsMetadata)
 ResultsMetadata.thrift_spec = (
     None,  # 0
     (1, TType.STRUCT, 'schema', [impala._thrift_gen.hive_metastore.ttypes.Schema, None], None, ),  # 1
-    (2, TType.STRING, 'table_dir', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'in_tablename', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'delim', 'UTF8', None, ),  # 4
+    (2, TType.STRING, 'table_dir', None, None, ),  # 2
+    (3, TType.STRING, 'in_tablename', None, None, ),  # 3
+    (4, TType.STRING, 'delim', None, None, ),  # 4
 )
 all_structs.append(BeeswaxException)
 BeeswaxException.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'message', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'log_context', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'message', None, None, ),  # 1
+    (2, TType.STRING, 'log_context', None, None, ),  # 2
     (3, TType.STRUCT, 'handle', [QueryHandle, None], None, ),  # 3
     (4, TType.I32, 'errorCode', None, 0, ),  # 4
-    (5, TType.STRING, 'SQLState', 'UTF8', "     ", ),  # 5
+    (5, TType.STRING, 'SQLState', None, "     ", ),  # 5
 )
 all_structs.append(QueryNotFoundException)
 QueryNotFoundException.thrift_spec = (
@@ -773,9 +772,9 @@ QueryNotFoundException.thrift_spec = (
 all_structs.append(ConfigVariable)
 ConfigVariable.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'key', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'value', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'description', 'UTF8', None, ),  # 3
+    (1, TType.STRING, 'key', None, None, ),  # 1
+    (2, TType.STRING, 'value', None, None, ),  # 2
+    (3, TType.STRING, 'description', None, None, ),  # 3
     (4, TType.I32, 'level', None, None, ),  # 4
 )
 fix_spec(all_structs)

--- a/impala/_thrift_gen/fb303/FacebookService-remote
+++ b/impala/_thrift_gen/fb303/FacebookService-remote
@@ -4,7 +4,7 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 import sys

--- a/impala/_thrift_gen/fb303/FacebookService.py
+++ b/impala/_thrift_gen/fb303/FacebookService.py
@@ -3,14 +3,13 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.TRecursive import fix_spec
 
-import sys
 import logging
 from .ttypes import *
 from thrift.Thrift import TProcessor
@@ -865,7 +864,7 @@ class getName_result(object):
                 break
             if fid == 0:
                 if ftype == TType.STRING:
-                    self.success = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.success = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -880,7 +879,7 @@ class getName_result(object):
         oprot.writeStructBegin('getName_result')
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.STRING, 0)
-            oprot.writeString(self.success.encode('utf-8') if sys.version_info[0] == 2 else self.success)
+            oprot.writeString(self.success)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -900,7 +899,7 @@ class getName_result(object):
         return not (self == other)
 all_structs.append(getName_result)
 getName_result.thrift_spec = (
-    (0, TType.STRING, 'success', 'UTF8', None, ),  # 0
+    (0, TType.STRING, 'success', None, None, ),  # 0
 )
 
 
@@ -968,7 +967,7 @@ class getVersion_result(object):
                 break
             if fid == 0:
                 if ftype == TType.STRING:
-                    self.success = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.success = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -983,7 +982,7 @@ class getVersion_result(object):
         oprot.writeStructBegin('getVersion_result')
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.STRING, 0)
-            oprot.writeString(self.success.encode('utf-8') if sys.version_info[0] == 2 else self.success)
+            oprot.writeString(self.success)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -1003,7 +1002,7 @@ class getVersion_result(object):
         return not (self == other)
 all_structs.append(getVersion_result)
 getVersion_result.thrift_spec = (
-    (0, TType.STRING, 'success', 'UTF8', None, ),  # 0
+    (0, TType.STRING, 'success', None, None, ),  # 0
 )
 
 
@@ -1174,7 +1173,7 @@ class getStatusDetails_result(object):
                 break
             if fid == 0:
                 if ftype == TType.STRING:
-                    self.success = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.success = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -1189,7 +1188,7 @@ class getStatusDetails_result(object):
         oprot.writeStructBegin('getStatusDetails_result')
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.STRING, 0)
-            oprot.writeString(self.success.encode('utf-8') if sys.version_info[0] == 2 else self.success)
+            oprot.writeString(self.success)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -1209,7 +1208,7 @@ class getStatusDetails_result(object):
         return not (self == other)
 all_structs.append(getStatusDetails_result)
 getStatusDetails_result.thrift_spec = (
-    (0, TType.STRING, 'success', 'UTF8', None, ),  # 0
+    (0, TType.STRING, 'success', None, None, ),  # 0
 )
 
 
@@ -1280,7 +1279,7 @@ class getCounters_result(object):
                     self.success = {}
                     (_ktype1, _vtype2, _size0) = iprot.readMapBegin()
                     for _i4 in range(_size0):
-                        _key5 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key5 = iprot.readString()
                         _val6 = iprot.readI64()
                         self.success[_key5] = _val6
                     iprot.readMapEnd()
@@ -1300,7 +1299,7 @@ class getCounters_result(object):
             oprot.writeFieldBegin('success', TType.MAP, 0)
             oprot.writeMapBegin(TType.STRING, TType.I64, len(self.success))
             for kiter7, viter8 in self.success.items():
-                oprot.writeString(kiter7.encode('utf-8') if sys.version_info[0] == 2 else kiter7)
+                oprot.writeString(kiter7)
                 oprot.writeI64(viter8)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
@@ -1322,7 +1321,7 @@ class getCounters_result(object):
         return not (self == other)
 all_structs.append(getCounters_result)
 getCounters_result.thrift_spec = (
-    (0, TType.MAP, 'success', (TType.STRING, 'UTF8', TType.I64, None, False), None, ),  # 0
+    (0, TType.MAP, 'success', (TType.STRING, None, TType.I64, None, False), None, ),  # 0
 )
 
 
@@ -1347,7 +1346,7 @@ class getCounter_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.key = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.key = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -1362,7 +1361,7 @@ class getCounter_args(object):
         oprot.writeStructBegin('getCounter_args')
         if self.key is not None:
             oprot.writeFieldBegin('key', TType.STRING, 1)
-            oprot.writeString(self.key.encode('utf-8') if sys.version_info[0] == 2 else self.key)
+            oprot.writeString(self.key)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -1383,7 +1382,7 @@ class getCounter_args(object):
 all_structs.append(getCounter_args)
 getCounter_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'key', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'key', None, None, ),  # 1
 )
 
 
@@ -1470,12 +1469,12 @@ class setOption_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.key = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.key = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.value = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.value = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -1490,11 +1489,11 @@ class setOption_args(object):
         oprot.writeStructBegin('setOption_args')
         if self.key is not None:
             oprot.writeFieldBegin('key', TType.STRING, 1)
-            oprot.writeString(self.key.encode('utf-8') if sys.version_info[0] == 2 else self.key)
+            oprot.writeString(self.key)
             oprot.writeFieldEnd()
         if self.value is not None:
             oprot.writeFieldBegin('value', TType.STRING, 2)
-            oprot.writeString(self.value.encode('utf-8') if sys.version_info[0] == 2 else self.value)
+            oprot.writeString(self.value)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -1515,8 +1514,8 @@ class setOption_args(object):
 all_structs.append(setOption_args)
 setOption_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'key', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'value', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'key', None, None, ),  # 1
+    (2, TType.STRING, 'value', None, None, ),  # 2
 )
 
 
@@ -1584,7 +1583,7 @@ class getOption_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.key = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.key = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -1599,7 +1598,7 @@ class getOption_args(object):
         oprot.writeStructBegin('getOption_args')
         if self.key is not None:
             oprot.writeFieldBegin('key', TType.STRING, 1)
-            oprot.writeString(self.key.encode('utf-8') if sys.version_info[0] == 2 else self.key)
+            oprot.writeString(self.key)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -1620,7 +1619,7 @@ class getOption_args(object):
 all_structs.append(getOption_args)
 getOption_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'key', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'key', None, None, ),  # 1
 )
 
 
@@ -1645,7 +1644,7 @@ class getOption_result(object):
                 break
             if fid == 0:
                 if ftype == TType.STRING:
-                    self.success = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.success = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -1660,7 +1659,7 @@ class getOption_result(object):
         oprot.writeStructBegin('getOption_result')
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.STRING, 0)
-            oprot.writeString(self.success.encode('utf-8') if sys.version_info[0] == 2 else self.success)
+            oprot.writeString(self.success)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -1680,7 +1679,7 @@ class getOption_result(object):
         return not (self == other)
 all_structs.append(getOption_result)
 getOption_result.thrift_spec = (
-    (0, TType.STRING, 'success', 'UTF8', None, ),  # 0
+    (0, TType.STRING, 'success', None, None, ),  # 0
 )
 
 
@@ -1751,8 +1750,8 @@ class getOptions_result(object):
                     self.success = {}
                     (_ktype10, _vtype11, _size9) = iprot.readMapBegin()
                     for _i13 in range(_size9):
-                        _key14 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val15 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key14 = iprot.readString()
+                        _val15 = iprot.readString()
                         self.success[_key14] = _val15
                     iprot.readMapEnd()
                 else:
@@ -1771,8 +1770,8 @@ class getOptions_result(object):
             oprot.writeFieldBegin('success', TType.MAP, 0)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.success))
             for kiter16, viter17 in self.success.items():
-                oprot.writeString(kiter16.encode('utf-8') if sys.version_info[0] == 2 else kiter16)
-                oprot.writeString(viter17.encode('utf-8') if sys.version_info[0] == 2 else viter17)
+                oprot.writeString(kiter16)
+                oprot.writeString(viter17)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -1793,7 +1792,7 @@ class getOptions_result(object):
         return not (self == other)
 all_structs.append(getOptions_result)
 getOptions_result.thrift_spec = (
-    (0, TType.MAP, 'success', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 0
+    (0, TType.MAP, 'success', (TType.STRING, None, TType.STRING, None, False), None, ),  # 0
 )
 
 
@@ -1879,7 +1878,7 @@ class getCpuProfile_result(object):
                 break
             if fid == 0:
                 if ftype == TType.STRING:
-                    self.success = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.success = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -1894,7 +1893,7 @@ class getCpuProfile_result(object):
         oprot.writeStructBegin('getCpuProfile_result')
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.STRING, 0)
-            oprot.writeString(self.success.encode('utf-8') if sys.version_info[0] == 2 else self.success)
+            oprot.writeString(self.success)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -1914,7 +1913,7 @@ class getCpuProfile_result(object):
         return not (self == other)
 all_structs.append(getCpuProfile_result)
 getCpuProfile_result.thrift_spec = (
-    (0, TType.STRING, 'success', 'UTF8', None, ),  # 0
+    (0, TType.STRING, 'success', None, None, ),  # 0
 )
 
 

--- a/impala/_thrift_gen/fb303/constants.py
+++ b/impala/_thrift_gen/fb303/constants.py
@@ -3,12 +3,11 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.TRecursive import fix_spec
 
-import sys
 from .ttypes import *

--- a/impala/_thrift_gen/fb303/ttypes.py
+++ b/impala/_thrift_gen/fb303/ttypes.py
@@ -3,14 +3,13 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.TRecursive import fix_spec
 
-import sys
 
 from thrift.transport import TTransport
 all_structs = []

--- a/impala/_thrift_gen/hive_metastore/ThriftHiveMetastore-remote
+++ b/impala/_thrift_gen/hive_metastore/ThriftHiveMetastore-remote
@@ -4,7 +4,7 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 import sys

--- a/impala/_thrift_gen/hive_metastore/ThriftHiveMetastore.py
+++ b/impala/_thrift_gen/hive_metastore/ThriftHiveMetastore.py
@@ -3,14 +3,13 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.TRecursive import fix_spec
 
-import sys
 import impala._thrift_gen.fb303.FacebookService
 import logging
 from .ttypes import *
@@ -11162,7 +11161,7 @@ class getMetaConf_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.key = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.key = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -11177,7 +11176,7 @@ class getMetaConf_args(object):
         oprot.writeStructBegin('getMetaConf_args')
         if self.key is not None:
             oprot.writeFieldBegin('key', TType.STRING, 1)
-            oprot.writeString(self.key.encode('utf-8') if sys.version_info[0] == 2 else self.key)
+            oprot.writeString(self.key)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -11198,7 +11197,7 @@ class getMetaConf_args(object):
 all_structs.append(getMetaConf_args)
 getMetaConf_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'key', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'key', None, None, ),  # 1
 )
 
 
@@ -11225,7 +11224,7 @@ class getMetaConf_result(object):
                 break
             if fid == 0:
                 if ftype == TType.STRING:
-                    self.success = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.success = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 1:
@@ -11246,7 +11245,7 @@ class getMetaConf_result(object):
         oprot.writeStructBegin('getMetaConf_result')
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.STRING, 0)
-            oprot.writeString(self.success.encode('utf-8') if sys.version_info[0] == 2 else self.success)
+            oprot.writeString(self.success)
             oprot.writeFieldEnd()
         if self.o1 is not None:
             oprot.writeFieldBegin('o1', TType.STRUCT, 1)
@@ -11270,7 +11269,7 @@ class getMetaConf_result(object):
         return not (self == other)
 all_structs.append(getMetaConf_result)
 getMetaConf_result.thrift_spec = (
-    (0, TType.STRING, 'success', 'UTF8', None, ),  # 0
+    (0, TType.STRING, 'success', None, None, ),  # 0
     (1, TType.STRUCT, 'o1', [MetaException, None], None, ),  # 1
 )
 
@@ -11298,12 +11297,12 @@ class setMetaConf_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.key = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.key = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.value = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.value = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -11318,11 +11317,11 @@ class setMetaConf_args(object):
         oprot.writeStructBegin('setMetaConf_args')
         if self.key is not None:
             oprot.writeFieldBegin('key', TType.STRING, 1)
-            oprot.writeString(self.key.encode('utf-8') if sys.version_info[0] == 2 else self.key)
+            oprot.writeString(self.key)
             oprot.writeFieldEnd()
         if self.value is not None:
             oprot.writeFieldBegin('value', TType.STRING, 2)
-            oprot.writeString(self.value.encode('utf-8') if sys.version_info[0] == 2 else self.value)
+            oprot.writeString(self.value)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -11343,8 +11342,8 @@ class setMetaConf_args(object):
 all_structs.append(setMetaConf_args)
 setMetaConf_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'key', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'value', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'key', None, None, ),  # 1
+    (2, TType.STRING, 'value', None, None, ),  # 2
 )
 
 
@@ -11581,7 +11580,7 @@ class get_database_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -11596,7 +11595,7 @@ class get_database_args(object):
         oprot.writeStructBegin('get_database_args')
         if self.name is not None:
             oprot.writeFieldBegin('name', TType.STRING, 1)
-            oprot.writeString(self.name.encode('utf-8') if sys.version_info[0] == 2 else self.name)
+            oprot.writeString(self.name)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -11617,7 +11616,7 @@ class get_database_args(object):
 all_structs.append(get_database_args)
 get_database_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'name', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'name', None, None, ),  # 1
 )
 
 
@@ -11733,7 +11732,7 @@ class drop_database_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
@@ -11758,7 +11757,7 @@ class drop_database_args(object):
         oprot.writeStructBegin('drop_database_args')
         if self.name is not None:
             oprot.writeFieldBegin('name', TType.STRING, 1)
-            oprot.writeString(self.name.encode('utf-8') if sys.version_info[0] == 2 else self.name)
+            oprot.writeString(self.name)
             oprot.writeFieldEnd()
         if self.deleteData is not None:
             oprot.writeFieldBegin('deleteData', TType.BOOL, 2)
@@ -11787,7 +11786,7 @@ class drop_database_args(object):
 all_structs.append(drop_database_args)
 drop_database_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'name', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'name', None, None, ),  # 1
     (2, TType.BOOL, 'deleteData', None, None, ),  # 2
     (3, TType.BOOL, 'cascade', None, None, ),  # 3
 )
@@ -11902,7 +11901,7 @@ class get_databases_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.pattern = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.pattern = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -11917,7 +11916,7 @@ class get_databases_args(object):
         oprot.writeStructBegin('get_databases_args')
         if self.pattern is not None:
             oprot.writeFieldBegin('pattern', TType.STRING, 1)
-            oprot.writeString(self.pattern.encode('utf-8') if sys.version_info[0] == 2 else self.pattern)
+            oprot.writeString(self.pattern)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -11938,7 +11937,7 @@ class get_databases_args(object):
 all_structs.append(get_databases_args)
 get_databases_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'pattern', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'pattern', None, None, ),  # 1
 )
 
 
@@ -11968,7 +11967,7 @@ class get_databases_result(object):
                     self.success = []
                     (_etype597, _size594) = iprot.readListBegin()
                     for _i598 in range(_size594):
-                        _elem599 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem599 = iprot.readString()
                         self.success.append(_elem599)
                     iprot.readListEnd()
                 else:
@@ -11993,7 +11992,7 @@ class get_databases_result(object):
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
             for iter600 in self.success:
-                oprot.writeString(iter600.encode('utf-8') if sys.version_info[0] == 2 else iter600)
+                oprot.writeString(iter600)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -12018,7 +12017,7 @@ class get_databases_result(object):
         return not (self == other)
 all_structs.append(get_databases_result)
 get_databases_result.thrift_spec = (
-    (0, TType.LIST, 'success', (TType.STRING, 'UTF8', False), None, ),  # 0
+    (0, TType.LIST, 'success', (TType.STRING, None, False), None, ),  # 0
     (1, TType.STRUCT, 'o1', [MetaException, None], None, ),  # 1
 )
 
@@ -12092,7 +12091,7 @@ class get_all_databases_result(object):
                     self.success = []
                     (_etype604, _size601) = iprot.readListBegin()
                     for _i605 in range(_size601):
-                        _elem606 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem606 = iprot.readString()
                         self.success.append(_elem606)
                     iprot.readListEnd()
                 else:
@@ -12117,7 +12116,7 @@ class get_all_databases_result(object):
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
             for iter607 in self.success:
-                oprot.writeString(iter607.encode('utf-8') if sys.version_info[0] == 2 else iter607)
+                oprot.writeString(iter607)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -12142,7 +12141,7 @@ class get_all_databases_result(object):
         return not (self == other)
 all_structs.append(get_all_databases_result)
 get_all_databases_result.thrift_spec = (
-    (0, TType.LIST, 'success', (TType.STRING, 'UTF8', False), None, ),  # 0
+    (0, TType.LIST, 'success', (TType.STRING, None, False), None, ),  # 0
     (1, TType.STRUCT, 'o1', [MetaException, None], None, ),  # 1
 )
 
@@ -12170,7 +12169,7 @@ class alter_database_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.dbname = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbname = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
@@ -12191,7 +12190,7 @@ class alter_database_args(object):
         oprot.writeStructBegin('alter_database_args')
         if self.dbname is not None:
             oprot.writeFieldBegin('dbname', TType.STRING, 1)
-            oprot.writeString(self.dbname.encode('utf-8') if sys.version_info[0] == 2 else self.dbname)
+            oprot.writeString(self.dbname)
             oprot.writeFieldEnd()
         if self.db is not None:
             oprot.writeFieldBegin('db', TType.STRUCT, 2)
@@ -12216,7 +12215,7 @@ class alter_database_args(object):
 all_structs.append(alter_database_args)
 alter_database_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'dbname', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'dbname', None, None, ),  # 1
     (2, TType.STRUCT, 'db', [Database, None], None, ),  # 2
 )
 
@@ -12317,7 +12316,7 @@ class get_type_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -12332,7 +12331,7 @@ class get_type_args(object):
         oprot.writeStructBegin('get_type_args')
         if self.name is not None:
             oprot.writeFieldBegin('name', TType.STRING, 1)
-            oprot.writeString(self.name.encode('utf-8') if sys.version_info[0] == 2 else self.name)
+            oprot.writeString(self.name)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -12353,7 +12352,7 @@ class get_type_args(object):
 all_structs.append(get_type_args)
 get_type_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'name', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'name', None, None, ),  # 1
 )
 
 
@@ -12626,7 +12625,7 @@ class drop_type_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.type = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.type = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -12641,7 +12640,7 @@ class drop_type_args(object):
         oprot.writeStructBegin('drop_type_args')
         if self.type is not None:
             oprot.writeFieldBegin('type', TType.STRING, 1)
-            oprot.writeString(self.type.encode('utf-8') if sys.version_info[0] == 2 else self.type)
+            oprot.writeString(self.type)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -12662,7 +12661,7 @@ class drop_type_args(object):
 all_structs.append(drop_type_args)
 drop_type_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'type', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'type', None, None, ),  # 1
 )
 
 
@@ -12773,7 +12772,7 @@ class get_type_all_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -12788,7 +12787,7 @@ class get_type_all_args(object):
         oprot.writeStructBegin('get_type_all_args')
         if self.name is not None:
             oprot.writeFieldBegin('name', TType.STRING, 1)
-            oprot.writeString(self.name.encode('utf-8') if sys.version_info[0] == 2 else self.name)
+            oprot.writeString(self.name)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -12809,7 +12808,7 @@ class get_type_all_args(object):
 all_structs.append(get_type_all_args)
 get_type_all_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'name', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'name', None, None, ),  # 1
 )
 
 
@@ -12839,7 +12838,7 @@ class get_type_all_result(object):
                     self.success = {}
                     (_ktype609, _vtype610, _size608) = iprot.readMapBegin()
                     for _i612 in range(_size608):
-                        _key613 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key613 = iprot.readString()
                         _val614 = Type()
                         _val614.read(iprot)
                         self.success[_key613] = _val614
@@ -12866,7 +12865,7 @@ class get_type_all_result(object):
             oprot.writeFieldBegin('success', TType.MAP, 0)
             oprot.writeMapBegin(TType.STRING, TType.STRUCT, len(self.success))
             for kiter615, viter616 in self.success.items():
-                oprot.writeString(kiter615.encode('utf-8') if sys.version_info[0] == 2 else kiter615)
+                oprot.writeString(kiter615)
                 viter616.write(oprot)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
@@ -12892,7 +12891,7 @@ class get_type_all_result(object):
         return not (self == other)
 all_structs.append(get_type_all_result)
 get_type_all_result.thrift_spec = (
-    (0, TType.MAP, 'success', (TType.STRING, 'UTF8', TType.STRUCT, [Type, None], False), None, ),  # 0
+    (0, TType.MAP, 'success', (TType.STRING, None, TType.STRUCT, [Type, None], False), None, ),  # 0
     (1, TType.STRUCT, 'o2', [MetaException, None], None, ),  # 1
 )
 
@@ -12920,12 +12919,12 @@ class get_fields_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.table_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.table_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -12940,11 +12939,11 @@ class get_fields_args(object):
         oprot.writeStructBegin('get_fields_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.table_name is not None:
             oprot.writeFieldBegin('table_name', TType.STRING, 2)
-            oprot.writeString(self.table_name.encode('utf-8') if sys.version_info[0] == 2 else self.table_name)
+            oprot.writeString(self.table_name)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -12965,8 +12964,8 @@ class get_fields_args(object):
 all_structs.append(get_fields_args)
 get_fields_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'table_name', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'table_name', None, None, ),  # 2
 )
 
 
@@ -13103,12 +13102,12 @@ class get_fields_with_environment_context_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.table_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.table_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -13129,11 +13128,11 @@ class get_fields_with_environment_context_args(object):
         oprot.writeStructBegin('get_fields_with_environment_context_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.table_name is not None:
             oprot.writeFieldBegin('table_name', TType.STRING, 2)
-            oprot.writeString(self.table_name.encode('utf-8') if sys.version_info[0] == 2 else self.table_name)
+            oprot.writeString(self.table_name)
             oprot.writeFieldEnd()
         if self.environment_context is not None:
             oprot.writeFieldBegin('environment_context', TType.STRUCT, 3)
@@ -13158,8 +13157,8 @@ class get_fields_with_environment_context_args(object):
 all_structs.append(get_fields_with_environment_context_args)
 get_fields_with_environment_context_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'table_name', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'table_name', None, None, ),  # 2
     (3, TType.STRUCT, 'environment_context', [EnvironmentContext, None], None, ),  # 3
 )
 
@@ -13295,12 +13294,12 @@ class get_schema_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.table_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.table_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -13315,11 +13314,11 @@ class get_schema_args(object):
         oprot.writeStructBegin('get_schema_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.table_name is not None:
             oprot.writeFieldBegin('table_name', TType.STRING, 2)
-            oprot.writeString(self.table_name.encode('utf-8') if sys.version_info[0] == 2 else self.table_name)
+            oprot.writeString(self.table_name)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -13340,8 +13339,8 @@ class get_schema_args(object):
 all_structs.append(get_schema_args)
 get_schema_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'table_name', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'table_name', None, None, ),  # 2
 )
 
 
@@ -13478,12 +13477,12 @@ class get_schema_with_environment_context_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.table_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.table_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -13504,11 +13503,11 @@ class get_schema_with_environment_context_args(object):
         oprot.writeStructBegin('get_schema_with_environment_context_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.table_name is not None:
             oprot.writeFieldBegin('table_name', TType.STRING, 2)
-            oprot.writeString(self.table_name.encode('utf-8') if sys.version_info[0] == 2 else self.table_name)
+            oprot.writeString(self.table_name)
             oprot.writeFieldEnd()
         if self.environment_context is not None:
             oprot.writeFieldBegin('environment_context', TType.STRUCT, 3)
@@ -13533,8 +13532,8 @@ class get_schema_with_environment_context_args(object):
 all_structs.append(get_schema_with_environment_context_args)
 get_schema_with_environment_context_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'table_name', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'table_name', None, None, ),  # 2
     (3, TType.STRUCT, 'environment_context', [EnvironmentContext, None], None, ),  # 3
 )
 
@@ -14627,12 +14626,12 @@ class drop_table_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.dbname = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbname = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -14652,11 +14651,11 @@ class drop_table_args(object):
         oprot.writeStructBegin('drop_table_args')
         if self.dbname is not None:
             oprot.writeFieldBegin('dbname', TType.STRING, 1)
-            oprot.writeString(self.dbname.encode('utf-8') if sys.version_info[0] == 2 else self.dbname)
+            oprot.writeString(self.dbname)
             oprot.writeFieldEnd()
         if self.name is not None:
             oprot.writeFieldBegin('name', TType.STRING, 2)
-            oprot.writeString(self.name.encode('utf-8') if sys.version_info[0] == 2 else self.name)
+            oprot.writeString(self.name)
             oprot.writeFieldEnd()
         if self.deleteData is not None:
             oprot.writeFieldBegin('deleteData', TType.BOOL, 3)
@@ -14681,8 +14680,8 @@ class drop_table_args(object):
 all_structs.append(drop_table_args)
 drop_table_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'dbname', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'name', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'dbname', None, None, ),  # 1
+    (2, TType.STRING, 'name', None, None, ),  # 2
     (3, TType.BOOL, 'deleteData', None, None, ),  # 3
 )
 
@@ -14789,12 +14788,12 @@ class drop_table_with_environment_context_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.dbname = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbname = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -14820,11 +14819,11 @@ class drop_table_with_environment_context_args(object):
         oprot.writeStructBegin('drop_table_with_environment_context_args')
         if self.dbname is not None:
             oprot.writeFieldBegin('dbname', TType.STRING, 1)
-            oprot.writeString(self.dbname.encode('utf-8') if sys.version_info[0] == 2 else self.dbname)
+            oprot.writeString(self.dbname)
             oprot.writeFieldEnd()
         if self.name is not None:
             oprot.writeFieldBegin('name', TType.STRING, 2)
-            oprot.writeString(self.name.encode('utf-8') if sys.version_info[0] == 2 else self.name)
+            oprot.writeString(self.name)
             oprot.writeFieldEnd()
         if self.deleteData is not None:
             oprot.writeFieldBegin('deleteData', TType.BOOL, 3)
@@ -14853,8 +14852,8 @@ class drop_table_with_environment_context_args(object):
 all_structs.append(drop_table_with_environment_context_args)
 drop_table_with_environment_context_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'dbname', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'name', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'dbname', None, None, ),  # 1
+    (2, TType.STRING, 'name', None, None, ),  # 2
     (3, TType.BOOL, 'deleteData', None, None, ),  # 3
     (4, TType.STRUCT, 'environment_context', [EnvironmentContext, None], None, ),  # 4
 )
@@ -14958,12 +14957,12 @@ class get_tables_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.pattern = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.pattern = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -14978,11 +14977,11 @@ class get_tables_args(object):
         oprot.writeStructBegin('get_tables_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.pattern is not None:
             oprot.writeFieldBegin('pattern', TType.STRING, 2)
-            oprot.writeString(self.pattern.encode('utf-8') if sys.version_info[0] == 2 else self.pattern)
+            oprot.writeString(self.pattern)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -15003,8 +15002,8 @@ class get_tables_args(object):
 all_structs.append(get_tables_args)
 get_tables_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'pattern', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'pattern', None, None, ),  # 2
 )
 
 
@@ -15034,7 +15033,7 @@ class get_tables_result(object):
                     self.success = []
                     (_etype662, _size659) = iprot.readListBegin()
                     for _i663 in range(_size659):
-                        _elem664 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem664 = iprot.readString()
                         self.success.append(_elem664)
                     iprot.readListEnd()
                 else:
@@ -15059,7 +15058,7 @@ class get_tables_result(object):
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
             for iter665 in self.success:
-                oprot.writeString(iter665.encode('utf-8') if sys.version_info[0] == 2 else iter665)
+                oprot.writeString(iter665)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -15084,7 +15083,7 @@ class get_tables_result(object):
         return not (self == other)
 all_structs.append(get_tables_result)
 get_tables_result.thrift_spec = (
-    (0, TType.LIST, 'success', (TType.STRING, 'UTF8', False), None, ),  # 0
+    (0, TType.LIST, 'success', (TType.STRING, None, False), None, ),  # 0
     (1, TType.STRUCT, 'o1', [MetaException, None], None, ),  # 1
 )
 
@@ -15114,12 +15113,12 @@ class get_table_meta_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_patterns = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_patterns = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_patterns = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_patterns = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -15127,7 +15126,7 @@ class get_table_meta_args(object):
                     self.tbl_types = []
                     (_etype669, _size666) = iprot.readListBegin()
                     for _i670 in range(_size666):
-                        _elem671 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem671 = iprot.readString()
                         self.tbl_types.append(_elem671)
                     iprot.readListEnd()
                 else:
@@ -15144,17 +15143,17 @@ class get_table_meta_args(object):
         oprot.writeStructBegin('get_table_meta_args')
         if self.db_patterns is not None:
             oprot.writeFieldBegin('db_patterns', TType.STRING, 1)
-            oprot.writeString(self.db_patterns.encode('utf-8') if sys.version_info[0] == 2 else self.db_patterns)
+            oprot.writeString(self.db_patterns)
             oprot.writeFieldEnd()
         if self.tbl_patterns is not None:
             oprot.writeFieldBegin('tbl_patterns', TType.STRING, 2)
-            oprot.writeString(self.tbl_patterns.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_patterns)
+            oprot.writeString(self.tbl_patterns)
             oprot.writeFieldEnd()
         if self.tbl_types is not None:
             oprot.writeFieldBegin('tbl_types', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.tbl_types))
             for iter672 in self.tbl_types:
-                oprot.writeString(iter672.encode('utf-8') if sys.version_info[0] == 2 else iter672)
+                oprot.writeString(iter672)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -15176,9 +15175,9 @@ class get_table_meta_args(object):
 all_structs.append(get_table_meta_args)
 get_table_meta_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_patterns', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_patterns', 'UTF8', None, ),  # 2
-    (3, TType.LIST, 'tbl_types', (TType.STRING, 'UTF8', False), None, ),  # 3
+    (1, TType.STRING, 'db_patterns', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_patterns', None, None, ),  # 2
+    (3, TType.LIST, 'tbl_types', (TType.STRING, None, False), None, ),  # 3
 )
 
 
@@ -15285,7 +15284,7 @@ class get_all_tables_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -15300,7 +15299,7 @@ class get_all_tables_args(object):
         oprot.writeStructBegin('get_all_tables_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -15321,7 +15320,7 @@ class get_all_tables_args(object):
 all_structs.append(get_all_tables_args)
 get_all_tables_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
 )
 
 
@@ -15351,7 +15350,7 @@ class get_all_tables_result(object):
                     self.success = []
                     (_etype683, _size680) = iprot.readListBegin()
                     for _i684 in range(_size680):
-                        _elem685 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem685 = iprot.readString()
                         self.success.append(_elem685)
                     iprot.readListEnd()
                 else:
@@ -15376,7 +15375,7 @@ class get_all_tables_result(object):
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
             for iter686 in self.success:
-                oprot.writeString(iter686.encode('utf-8') if sys.version_info[0] == 2 else iter686)
+                oprot.writeString(iter686)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -15401,7 +15400,7 @@ class get_all_tables_result(object):
         return not (self == other)
 all_structs.append(get_all_tables_result)
 get_all_tables_result.thrift_spec = (
-    (0, TType.LIST, 'success', (TType.STRING, 'UTF8', False), None, ),  # 0
+    (0, TType.LIST, 'success', (TType.STRING, None, False), None, ),  # 0
     (1, TType.STRUCT, 'o1', [MetaException, None], None, ),  # 1
 )
 
@@ -15429,12 +15428,12 @@ class get_table_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.dbname = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbname = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -15449,11 +15448,11 @@ class get_table_args(object):
         oprot.writeStructBegin('get_table_args')
         if self.dbname is not None:
             oprot.writeFieldBegin('dbname', TType.STRING, 1)
-            oprot.writeString(self.dbname.encode('utf-8') if sys.version_info[0] == 2 else self.dbname)
+            oprot.writeString(self.dbname)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -15474,8 +15473,8 @@ class get_table_args(object):
 all_structs.append(get_table_args)
 get_table_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'dbname', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'dbname', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
 )
 
 
@@ -15589,7 +15588,7 @@ class get_table_objects_by_name_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.dbname = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbname = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
@@ -15597,7 +15596,7 @@ class get_table_objects_by_name_args(object):
                     self.tbl_names = []
                     (_etype690, _size687) = iprot.readListBegin()
                     for _i691 in range(_size687):
-                        _elem692 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem692 = iprot.readString()
                         self.tbl_names.append(_elem692)
                     iprot.readListEnd()
                 else:
@@ -15614,13 +15613,13 @@ class get_table_objects_by_name_args(object):
         oprot.writeStructBegin('get_table_objects_by_name_args')
         if self.dbname is not None:
             oprot.writeFieldBegin('dbname', TType.STRING, 1)
-            oprot.writeString(self.dbname.encode('utf-8') if sys.version_info[0] == 2 else self.dbname)
+            oprot.writeString(self.dbname)
             oprot.writeFieldEnd()
         if self.tbl_names is not None:
             oprot.writeFieldBegin('tbl_names', TType.LIST, 2)
             oprot.writeListBegin(TType.STRING, len(self.tbl_names))
             for iter693 in self.tbl_names:
-                oprot.writeString(iter693.encode('utf-8') if sys.version_info[0] == 2 else iter693)
+                oprot.writeString(iter693)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -15642,8 +15641,8 @@ class get_table_objects_by_name_args(object):
 all_structs.append(get_table_objects_by_name_args)
 get_table_objects_by_name_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'dbname', 'UTF8', None, ),  # 1
-    (2, TType.LIST, 'tbl_names', (TType.STRING, 'UTF8', False), None, ),  # 2
+    (1, TType.STRING, 'dbname', None, None, ),  # 1
+    (2, TType.LIST, 'tbl_names', (TType.STRING, None, False), None, ),  # 2
 )
 
 
@@ -15780,12 +15779,12 @@ class get_table_names_by_filter_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.dbname = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbname = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.filter = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.filter = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -15805,11 +15804,11 @@ class get_table_names_by_filter_args(object):
         oprot.writeStructBegin('get_table_names_by_filter_args')
         if self.dbname is not None:
             oprot.writeFieldBegin('dbname', TType.STRING, 1)
-            oprot.writeString(self.dbname.encode('utf-8') if sys.version_info[0] == 2 else self.dbname)
+            oprot.writeString(self.dbname)
             oprot.writeFieldEnd()
         if self.filter is not None:
             oprot.writeFieldBegin('filter', TType.STRING, 2)
-            oprot.writeString(self.filter.encode('utf-8') if sys.version_info[0] == 2 else self.filter)
+            oprot.writeString(self.filter)
             oprot.writeFieldEnd()
         if self.max_tables is not None:
             oprot.writeFieldBegin('max_tables', TType.I16, 3)
@@ -15834,8 +15833,8 @@ class get_table_names_by_filter_args(object):
 all_structs.append(get_table_names_by_filter_args)
 get_table_names_by_filter_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'dbname', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'filter', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'dbname', None, None, ),  # 1
+    (2, TType.STRING, 'filter', None, None, ),  # 2
     (3, TType.I16, 'max_tables', None, -1, ),  # 3
 )
 
@@ -15870,7 +15869,7 @@ class get_table_names_by_filter_result(object):
                     self.success = []
                     (_etype704, _size701) = iprot.readListBegin()
                     for _i705 in range(_size701):
-                        _elem706 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem706 = iprot.readString()
                         self.success.append(_elem706)
                     iprot.readListEnd()
                 else:
@@ -15907,7 +15906,7 @@ class get_table_names_by_filter_result(object):
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
             for iter707 in self.success:
-                oprot.writeString(iter707.encode('utf-8') if sys.version_info[0] == 2 else iter707)
+                oprot.writeString(iter707)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -15940,7 +15939,7 @@ class get_table_names_by_filter_result(object):
         return not (self == other)
 all_structs.append(get_table_names_by_filter_result)
 get_table_names_by_filter_result.thrift_spec = (
-    (0, TType.LIST, 'success', (TType.STRING, 'UTF8', False), None, ),  # 0
+    (0, TType.LIST, 'success', (TType.STRING, None, False), None, ),  # 0
     (1, TType.STRUCT, 'o1', [MetaException, None], None, ),  # 1
     (2, TType.STRUCT, 'o2', [InvalidOperationException, None], None, ),  # 2
     (3, TType.STRUCT, 'o3', [UnknownDBException, None], None, ),  # 3
@@ -15972,12 +15971,12 @@ class alter_table_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.dbname = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbname = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -15998,11 +15997,11 @@ class alter_table_args(object):
         oprot.writeStructBegin('alter_table_args')
         if self.dbname is not None:
             oprot.writeFieldBegin('dbname', TType.STRING, 1)
-            oprot.writeString(self.dbname.encode('utf-8') if sys.version_info[0] == 2 else self.dbname)
+            oprot.writeString(self.dbname)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.new_tbl is not None:
             oprot.writeFieldBegin('new_tbl', TType.STRUCT, 3)
@@ -16027,8 +16026,8 @@ class alter_table_args(object):
 all_structs.append(alter_table_args)
 alter_table_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'dbname', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'dbname', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
     (3, TType.STRUCT, 'new_tbl', [Table, None], None, ),  # 3
 )
 
@@ -16135,12 +16134,12 @@ class alter_table_with_environment_context_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.dbname = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbname = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -16167,11 +16166,11 @@ class alter_table_with_environment_context_args(object):
         oprot.writeStructBegin('alter_table_with_environment_context_args')
         if self.dbname is not None:
             oprot.writeFieldBegin('dbname', TType.STRING, 1)
-            oprot.writeString(self.dbname.encode('utf-8') if sys.version_info[0] == 2 else self.dbname)
+            oprot.writeString(self.dbname)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.new_tbl is not None:
             oprot.writeFieldBegin('new_tbl', TType.STRUCT, 3)
@@ -16200,8 +16199,8 @@ class alter_table_with_environment_context_args(object):
 all_structs.append(alter_table_with_environment_context_args)
 alter_table_with_environment_context_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'dbname', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'dbname', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
     (3, TType.STRUCT, 'new_tbl', [Table, None], None, ),  # 3
     (4, TType.STRUCT, 'environment_context', [EnvironmentContext, None], None, ),  # 4
 )
@@ -16309,12 +16308,12 @@ class alter_table_with_cascade_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.dbname = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbname = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -16340,11 +16339,11 @@ class alter_table_with_cascade_args(object):
         oprot.writeStructBegin('alter_table_with_cascade_args')
         if self.dbname is not None:
             oprot.writeFieldBegin('dbname', TType.STRING, 1)
-            oprot.writeString(self.dbname.encode('utf-8') if sys.version_info[0] == 2 else self.dbname)
+            oprot.writeString(self.dbname)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.new_tbl is not None:
             oprot.writeFieldBegin('new_tbl', TType.STRUCT, 3)
@@ -16373,8 +16372,8 @@ class alter_table_with_cascade_args(object):
 all_structs.append(alter_table_with_cascade_args)
 alter_table_with_cascade_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'dbname', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'dbname', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
     (3, TType.STRUCT, 'new_tbl', [Table, None], None, ),  # 3
     (4, TType.BOOL, 'cascade', None, None, ),  # 4
 )
@@ -17155,12 +17154,12 @@ class append_partition_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -17168,7 +17167,7 @@ class append_partition_args(object):
                     self.part_vals = []
                     (_etype725, _size722) = iprot.readListBegin()
                     for _i726 in range(_size722):
-                        _elem727 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem727 = iprot.readString()
                         self.part_vals.append(_elem727)
                     iprot.readListEnd()
                 else:
@@ -17185,17 +17184,17 @@ class append_partition_args(object):
         oprot.writeStructBegin('append_partition_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.part_vals is not None:
             oprot.writeFieldBegin('part_vals', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.part_vals))
             for iter728 in self.part_vals:
-                oprot.writeString(iter728.encode('utf-8') if sys.version_info[0] == 2 else iter728)
+                oprot.writeString(iter728)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -17217,9 +17216,9 @@ class append_partition_args(object):
 all_structs.append(append_partition_args)
 append_partition_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.LIST, 'part_vals', (TType.STRING, 'UTF8', False), None, ),  # 3
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
+    (3, TType.LIST, 'part_vals', (TType.STRING, None, False), None, ),  # 3
 )
 
 
@@ -17512,12 +17511,12 @@ class append_partition_with_environment_context_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -17525,7 +17524,7 @@ class append_partition_with_environment_context_args(object):
                     self.part_vals = []
                     (_etype732, _size729) = iprot.readListBegin()
                     for _i733 in range(_size729):
-                        _elem734 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem734 = iprot.readString()
                         self.part_vals.append(_elem734)
                     iprot.readListEnd()
                 else:
@@ -17548,17 +17547,17 @@ class append_partition_with_environment_context_args(object):
         oprot.writeStructBegin('append_partition_with_environment_context_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.part_vals is not None:
             oprot.writeFieldBegin('part_vals', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.part_vals))
             for iter735 in self.part_vals:
-                oprot.writeString(iter735.encode('utf-8') if sys.version_info[0] == 2 else iter735)
+                oprot.writeString(iter735)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.environment_context is not None:
@@ -17584,9 +17583,9 @@ class append_partition_with_environment_context_args(object):
 all_structs.append(append_partition_with_environment_context_args)
 append_partition_with_environment_context_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.LIST, 'part_vals', (TType.STRING, 'UTF8', False), None, ),  # 3
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
+    (3, TType.LIST, 'part_vals', (TType.STRING, None, False), None, ),  # 3
     (4, TType.STRUCT, 'environment_context', [EnvironmentContext, None], None, ),  # 4
 )
 
@@ -17716,17 +17715,17 @@ class append_partition_by_name_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.part_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.part_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -17741,15 +17740,15 @@ class append_partition_by_name_args(object):
         oprot.writeStructBegin('append_partition_by_name_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.part_name is not None:
             oprot.writeFieldBegin('part_name', TType.STRING, 3)
-            oprot.writeString(self.part_name.encode('utf-8') if sys.version_info[0] == 2 else self.part_name)
+            oprot.writeString(self.part_name)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -17770,9 +17769,9 @@ class append_partition_by_name_args(object):
 all_structs.append(append_partition_by_name_args)
 append_partition_by_name_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'part_name', 'UTF8', None, ),  # 3
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
+    (3, TType.STRING, 'part_name', None, None, ),  # 3
 )
 
 
@@ -17903,17 +17902,17 @@ class append_partition_by_name_with_environment_context_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.part_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.part_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
@@ -17934,15 +17933,15 @@ class append_partition_by_name_with_environment_context_args(object):
         oprot.writeStructBegin('append_partition_by_name_with_environment_context_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.part_name is not None:
             oprot.writeFieldBegin('part_name', TType.STRING, 3)
-            oprot.writeString(self.part_name.encode('utf-8') if sys.version_info[0] == 2 else self.part_name)
+            oprot.writeString(self.part_name)
             oprot.writeFieldEnd()
         if self.environment_context is not None:
             oprot.writeFieldBegin('environment_context', TType.STRUCT, 4)
@@ -17967,9 +17966,9 @@ class append_partition_by_name_with_environment_context_args(object):
 all_structs.append(append_partition_by_name_with_environment_context_args)
 append_partition_by_name_with_environment_context_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'part_name', 'UTF8', None, ),  # 3
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
+    (3, TType.STRING, 'part_name', None, None, ),  # 3
     (4, TType.STRUCT, 'environment_context', [EnvironmentContext, None], None, ),  # 4
 )
 
@@ -18101,12 +18100,12 @@ class drop_partition_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -18114,7 +18113,7 @@ class drop_partition_args(object):
                     self.part_vals = []
                     (_etype739, _size736) = iprot.readListBegin()
                     for _i740 in range(_size736):
-                        _elem741 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem741 = iprot.readString()
                         self.part_vals.append(_elem741)
                     iprot.readListEnd()
                 else:
@@ -18136,17 +18135,17 @@ class drop_partition_args(object):
         oprot.writeStructBegin('drop_partition_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.part_vals is not None:
             oprot.writeFieldBegin('part_vals', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.part_vals))
             for iter742 in self.part_vals:
-                oprot.writeString(iter742.encode('utf-8') if sys.version_info[0] == 2 else iter742)
+                oprot.writeString(iter742)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.deleteData is not None:
@@ -18172,9 +18171,9 @@ class drop_partition_args(object):
 all_structs.append(drop_partition_args)
 drop_partition_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.LIST, 'part_vals', (TType.STRING, 'UTF8', False), None, ),  # 3
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
+    (3, TType.LIST, 'part_vals', (TType.STRING, None, False), None, ),  # 3
     (4, TType.BOOL, 'deleteData', None, None, ),  # 4
 )
 
@@ -18294,12 +18293,12 @@ class drop_partition_with_environment_context_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -18307,7 +18306,7 @@ class drop_partition_with_environment_context_args(object):
                     self.part_vals = []
                     (_etype746, _size743) = iprot.readListBegin()
                     for _i747 in range(_size743):
-                        _elem748 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem748 = iprot.readString()
                         self.part_vals.append(_elem748)
                     iprot.readListEnd()
                 else:
@@ -18335,17 +18334,17 @@ class drop_partition_with_environment_context_args(object):
         oprot.writeStructBegin('drop_partition_with_environment_context_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.part_vals is not None:
             oprot.writeFieldBegin('part_vals', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.part_vals))
             for iter749 in self.part_vals:
-                oprot.writeString(iter749.encode('utf-8') if sys.version_info[0] == 2 else iter749)
+                oprot.writeString(iter749)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.deleteData is not None:
@@ -18375,9 +18374,9 @@ class drop_partition_with_environment_context_args(object):
 all_structs.append(drop_partition_with_environment_context_args)
 drop_partition_with_environment_context_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.LIST, 'part_vals', (TType.STRING, 'UTF8', False), None, ),  # 3
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
+    (3, TType.LIST, 'part_vals', (TType.STRING, None, False), None, ),  # 3
     (4, TType.BOOL, 'deleteData', None, None, ),  # 4
     (5, TType.STRUCT, 'environment_context', [EnvironmentContext, None], None, ),  # 5
 )
@@ -18496,17 +18495,17 @@ class drop_partition_by_name_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.part_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.part_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
@@ -18526,15 +18525,15 @@ class drop_partition_by_name_args(object):
         oprot.writeStructBegin('drop_partition_by_name_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.part_name is not None:
             oprot.writeFieldBegin('part_name', TType.STRING, 3)
-            oprot.writeString(self.part_name.encode('utf-8') if sys.version_info[0] == 2 else self.part_name)
+            oprot.writeString(self.part_name)
             oprot.writeFieldEnd()
         if self.deleteData is not None:
             oprot.writeFieldBegin('deleteData', TType.BOOL, 4)
@@ -18559,9 +18558,9 @@ class drop_partition_by_name_args(object):
 all_structs.append(drop_partition_by_name_args)
 drop_partition_by_name_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'part_name', 'UTF8', None, ),  # 3
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
+    (3, TType.STRING, 'part_name', None, None, ),  # 3
     (4, TType.BOOL, 'deleteData', None, None, ),  # 4
 )
 
@@ -18681,17 +18680,17 @@ class drop_partition_by_name_with_environment_context_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.part_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.part_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
@@ -18717,15 +18716,15 @@ class drop_partition_by_name_with_environment_context_args(object):
         oprot.writeStructBegin('drop_partition_by_name_with_environment_context_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.part_name is not None:
             oprot.writeFieldBegin('part_name', TType.STRING, 3)
-            oprot.writeString(self.part_name.encode('utf-8') if sys.version_info[0] == 2 else self.part_name)
+            oprot.writeString(self.part_name)
             oprot.writeFieldEnd()
         if self.deleteData is not None:
             oprot.writeFieldBegin('deleteData', TType.BOOL, 4)
@@ -18754,9 +18753,9 @@ class drop_partition_by_name_with_environment_context_args(object):
 all_structs.append(drop_partition_by_name_with_environment_context_args)
 drop_partition_by_name_with_environment_context_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'part_name', 'UTF8', None, ),  # 3
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
+    (3, TType.STRING, 'part_name', None, None, ),  # 3
     (4, TType.BOOL, 'deleteData', None, None, ),  # 4
     (5, TType.STRUCT, 'environment_context', [EnvironmentContext, None], None, ),  # 5
 )
@@ -19022,12 +19021,12 @@ class get_partition_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -19035,7 +19034,7 @@ class get_partition_args(object):
                     self.part_vals = []
                     (_etype753, _size750) = iprot.readListBegin()
                     for _i754 in range(_size750):
-                        _elem755 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem755 = iprot.readString()
                         self.part_vals.append(_elem755)
                     iprot.readListEnd()
                 else:
@@ -19052,17 +19051,17 @@ class get_partition_args(object):
         oprot.writeStructBegin('get_partition_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.part_vals is not None:
             oprot.writeFieldBegin('part_vals', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.part_vals))
             for iter756 in self.part_vals:
-                oprot.writeString(iter756.encode('utf-8') if sys.version_info[0] == 2 else iter756)
+                oprot.writeString(iter756)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -19084,9 +19083,9 @@ class get_partition_args(object):
 all_structs.append(get_partition_args)
 get_partition_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.LIST, 'part_vals', (TType.STRING, 'UTF8', False), None, ),  # 3
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
+    (3, TType.LIST, 'part_vals', (TType.STRING, None, False), None, ),  # 3
 )
 
 
@@ -19209,30 +19208,30 @@ class exchange_partition_args(object):
                     self.partitionSpecs = {}
                     (_ktype758, _vtype759, _size757) = iprot.readMapBegin()
                     for _i761 in range(_size757):
-                        _key762 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val763 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key762 = iprot.readString()
+                        _val763 = iprot.readString()
                         self.partitionSpecs[_key762] = _val763
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.source_db = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.source_db = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.source_table_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.source_table_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.dest_db = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dest_db = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.STRING:
-                    self.dest_table_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dest_table_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -19249,25 +19248,25 @@ class exchange_partition_args(object):
             oprot.writeFieldBegin('partitionSpecs', TType.MAP, 1)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.partitionSpecs))
             for kiter764, viter765 in self.partitionSpecs.items():
-                oprot.writeString(kiter764.encode('utf-8') if sys.version_info[0] == 2 else kiter764)
-                oprot.writeString(viter765.encode('utf-8') if sys.version_info[0] == 2 else viter765)
+                oprot.writeString(kiter764)
+                oprot.writeString(viter765)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.source_db is not None:
             oprot.writeFieldBegin('source_db', TType.STRING, 2)
-            oprot.writeString(self.source_db.encode('utf-8') if sys.version_info[0] == 2 else self.source_db)
+            oprot.writeString(self.source_db)
             oprot.writeFieldEnd()
         if self.source_table_name is not None:
             oprot.writeFieldBegin('source_table_name', TType.STRING, 3)
-            oprot.writeString(self.source_table_name.encode('utf-8') if sys.version_info[0] == 2 else self.source_table_name)
+            oprot.writeString(self.source_table_name)
             oprot.writeFieldEnd()
         if self.dest_db is not None:
             oprot.writeFieldBegin('dest_db', TType.STRING, 4)
-            oprot.writeString(self.dest_db.encode('utf-8') if sys.version_info[0] == 2 else self.dest_db)
+            oprot.writeString(self.dest_db)
             oprot.writeFieldEnd()
         if self.dest_table_name is not None:
             oprot.writeFieldBegin('dest_table_name', TType.STRING, 5)
-            oprot.writeString(self.dest_table_name.encode('utf-8') if sys.version_info[0] == 2 else self.dest_table_name)
+            oprot.writeString(self.dest_table_name)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -19288,11 +19287,11 @@ class exchange_partition_args(object):
 all_structs.append(exchange_partition_args)
 exchange_partition_args.thrift_spec = (
     None,  # 0
-    (1, TType.MAP, 'partitionSpecs', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 1
-    (2, TType.STRING, 'source_db', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'source_table_name', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'dest_db', 'UTF8', None, ),  # 4
-    (5, TType.STRING, 'dest_table_name', 'UTF8', None, ),  # 5
+    (1, TType.MAP, 'partitionSpecs', (TType.STRING, None, TType.STRING, None, False), None, ),  # 1
+    (2, TType.STRING, 'source_db', None, None, ),  # 2
+    (3, TType.STRING, 'source_table_name', None, None, ),  # 3
+    (4, TType.STRING, 'dest_db', None, None, ),  # 4
+    (5, TType.STRING, 'dest_table_name', None, None, ),  # 5
 )
 
 
@@ -19441,30 +19440,30 @@ class exchange_partitions_args(object):
                     self.partitionSpecs = {}
                     (_ktype767, _vtype768, _size766) = iprot.readMapBegin()
                     for _i770 in range(_size766):
-                        _key771 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val772 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key771 = iprot.readString()
+                        _val772 = iprot.readString()
                         self.partitionSpecs[_key771] = _val772
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.source_db = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.source_db = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.source_table_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.source_table_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.dest_db = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dest_db = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.STRING:
-                    self.dest_table_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dest_table_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -19481,25 +19480,25 @@ class exchange_partitions_args(object):
             oprot.writeFieldBegin('partitionSpecs', TType.MAP, 1)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.partitionSpecs))
             for kiter773, viter774 in self.partitionSpecs.items():
-                oprot.writeString(kiter773.encode('utf-8') if sys.version_info[0] == 2 else kiter773)
-                oprot.writeString(viter774.encode('utf-8') if sys.version_info[0] == 2 else viter774)
+                oprot.writeString(kiter773)
+                oprot.writeString(viter774)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.source_db is not None:
             oprot.writeFieldBegin('source_db', TType.STRING, 2)
-            oprot.writeString(self.source_db.encode('utf-8') if sys.version_info[0] == 2 else self.source_db)
+            oprot.writeString(self.source_db)
             oprot.writeFieldEnd()
         if self.source_table_name is not None:
             oprot.writeFieldBegin('source_table_name', TType.STRING, 3)
-            oprot.writeString(self.source_table_name.encode('utf-8') if sys.version_info[0] == 2 else self.source_table_name)
+            oprot.writeString(self.source_table_name)
             oprot.writeFieldEnd()
         if self.dest_db is not None:
             oprot.writeFieldBegin('dest_db', TType.STRING, 4)
-            oprot.writeString(self.dest_db.encode('utf-8') if sys.version_info[0] == 2 else self.dest_db)
+            oprot.writeString(self.dest_db)
             oprot.writeFieldEnd()
         if self.dest_table_name is not None:
             oprot.writeFieldBegin('dest_table_name', TType.STRING, 5)
-            oprot.writeString(self.dest_table_name.encode('utf-8') if sys.version_info[0] == 2 else self.dest_table_name)
+            oprot.writeString(self.dest_table_name)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -19520,11 +19519,11 @@ class exchange_partitions_args(object):
 all_structs.append(exchange_partitions_args)
 exchange_partitions_args.thrift_spec = (
     None,  # 0
-    (1, TType.MAP, 'partitionSpecs', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 1
-    (2, TType.STRING, 'source_db', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'source_table_name', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'dest_db', 'UTF8', None, ),  # 4
-    (5, TType.STRING, 'dest_table_name', 'UTF8', None, ),  # 5
+    (1, TType.MAP, 'partitionSpecs', (TType.STRING, None, TType.STRING, None, False), None, ),  # 1
+    (2, TType.STRING, 'source_db', None, None, ),  # 2
+    (3, TType.STRING, 'source_table_name', None, None, ),  # 3
+    (4, TType.STRING, 'dest_db', None, None, ),  # 4
+    (5, TType.STRING, 'dest_table_name', None, None, ),  # 5
 )
 
 
@@ -19678,12 +19677,12 @@ class get_partition_with_auth_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -19691,14 +19690,14 @@ class get_partition_with_auth_args(object):
                     self.part_vals = []
                     (_etype785, _size782) = iprot.readListBegin()
                     for _i786 in range(_size782):
-                        _elem787 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem787 = iprot.readString()
                         self.part_vals.append(_elem787)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.user_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.user_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 5:
@@ -19706,7 +19705,7 @@ class get_partition_with_auth_args(object):
                     self.group_names = []
                     (_etype791, _size788) = iprot.readListBegin()
                     for _i792 in range(_size788):
-                        _elem793 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem793 = iprot.readString()
                         self.group_names.append(_elem793)
                     iprot.readListEnd()
                 else:
@@ -19723,28 +19722,28 @@ class get_partition_with_auth_args(object):
         oprot.writeStructBegin('get_partition_with_auth_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.part_vals is not None:
             oprot.writeFieldBegin('part_vals', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.part_vals))
             for iter794 in self.part_vals:
-                oprot.writeString(iter794.encode('utf-8') if sys.version_info[0] == 2 else iter794)
+                oprot.writeString(iter794)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.user_name is not None:
             oprot.writeFieldBegin('user_name', TType.STRING, 4)
-            oprot.writeString(self.user_name.encode('utf-8') if sys.version_info[0] == 2 else self.user_name)
+            oprot.writeString(self.user_name)
             oprot.writeFieldEnd()
         if self.group_names is not None:
             oprot.writeFieldBegin('group_names', TType.LIST, 5)
             oprot.writeListBegin(TType.STRING, len(self.group_names))
             for iter795 in self.group_names:
-                oprot.writeString(iter795.encode('utf-8') if sys.version_info[0] == 2 else iter795)
+                oprot.writeString(iter795)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -19766,11 +19765,11 @@ class get_partition_with_auth_args(object):
 all_structs.append(get_partition_with_auth_args)
 get_partition_with_auth_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.LIST, 'part_vals', (TType.STRING, 'UTF8', False), None, ),  # 3
-    (4, TType.STRING, 'user_name', 'UTF8', None, ),  # 4
-    (5, TType.LIST, 'group_names', (TType.STRING, 'UTF8', False), None, ),  # 5
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
+    (3, TType.LIST, 'part_vals', (TType.STRING, None, False), None, ),  # 3
+    (4, TType.STRING, 'user_name', None, None, ),  # 4
+    (5, TType.LIST, 'group_names', (TType.STRING, None, False), None, ),  # 5
 )
 
 
@@ -19886,17 +19885,17 @@ class get_partition_by_name_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.part_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.part_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -19911,15 +19910,15 @@ class get_partition_by_name_args(object):
         oprot.writeStructBegin('get_partition_by_name_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.part_name is not None:
             oprot.writeFieldBegin('part_name', TType.STRING, 3)
-            oprot.writeString(self.part_name.encode('utf-8') if sys.version_info[0] == 2 else self.part_name)
+            oprot.writeString(self.part_name)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -19940,9 +19939,9 @@ class get_partition_by_name_args(object):
 all_structs.append(get_partition_by_name_args)
 get_partition_by_name_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'part_name', 'UTF8', None, ),  # 3
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
+    (3, TType.STRING, 'part_name', None, None, ),  # 3
 )
 
 
@@ -20058,12 +20057,12 @@ class get_partitions_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -20083,11 +20082,11 @@ class get_partitions_args(object):
         oprot.writeStructBegin('get_partitions_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.max_parts is not None:
             oprot.writeFieldBegin('max_parts', TType.I16, 3)
@@ -20112,8 +20111,8 @@ class get_partitions_args(object):
 all_structs.append(get_partitions_args)
 get_partitions_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
     (3, TType.I16, 'max_parts', None, -1, ),  # 3
 )
 
@@ -20242,12 +20241,12 @@ class get_partitions_with_auth_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -20257,7 +20256,7 @@ class get_partitions_with_auth_args(object):
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.user_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.user_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 5:
@@ -20265,7 +20264,7 @@ class get_partitions_with_auth_args(object):
                     self.group_names = []
                     (_etype806, _size803) = iprot.readListBegin()
                     for _i807 in range(_size803):
-                        _elem808 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem808 = iprot.readString()
                         self.group_names.append(_elem808)
                     iprot.readListEnd()
                 else:
@@ -20282,11 +20281,11 @@ class get_partitions_with_auth_args(object):
         oprot.writeStructBegin('get_partitions_with_auth_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.max_parts is not None:
             oprot.writeFieldBegin('max_parts', TType.I16, 3)
@@ -20294,13 +20293,13 @@ class get_partitions_with_auth_args(object):
             oprot.writeFieldEnd()
         if self.user_name is not None:
             oprot.writeFieldBegin('user_name', TType.STRING, 4)
-            oprot.writeString(self.user_name.encode('utf-8') if sys.version_info[0] == 2 else self.user_name)
+            oprot.writeString(self.user_name)
             oprot.writeFieldEnd()
         if self.group_names is not None:
             oprot.writeFieldBegin('group_names', TType.LIST, 5)
             oprot.writeListBegin(TType.STRING, len(self.group_names))
             for iter809 in self.group_names:
-                oprot.writeString(iter809.encode('utf-8') if sys.version_info[0] == 2 else iter809)
+                oprot.writeString(iter809)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -20322,11 +20321,11 @@ class get_partitions_with_auth_args(object):
 all_structs.append(get_partitions_with_auth_args)
 get_partitions_with_auth_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
     (3, TType.I16, 'max_parts', None, -1, ),  # 3
-    (4, TType.STRING, 'user_name', 'UTF8', None, ),  # 4
-    (5, TType.LIST, 'group_names', (TType.STRING, 'UTF8', False), None, ),  # 5
+    (4, TType.STRING, 'user_name', None, None, ),  # 4
+    (5, TType.LIST, 'group_names', (TType.STRING, None, False), None, ),  # 5
 )
 
 
@@ -20450,12 +20449,12 @@ class get_partitions_pspec_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -20475,11 +20474,11 @@ class get_partitions_pspec_args(object):
         oprot.writeStructBegin('get_partitions_pspec_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.max_parts is not None:
             oprot.writeFieldBegin('max_parts', TType.I32, 3)
@@ -20504,8 +20503,8 @@ class get_partitions_pspec_args(object):
 all_structs.append(get_partitions_pspec_args)
 get_partitions_pspec_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
     (3, TType.I32, 'max_parts', None, -1, ),  # 3
 )
 
@@ -20630,12 +20629,12 @@ class get_partition_names_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -20655,11 +20654,11 @@ class get_partition_names_args(object):
         oprot.writeStructBegin('get_partition_names_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.max_parts is not None:
             oprot.writeFieldBegin('max_parts', TType.I16, 3)
@@ -20684,8 +20683,8 @@ class get_partition_names_args(object):
 all_structs.append(get_partition_names_args)
 get_partition_names_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
     (3, TType.I16, 'max_parts', None, -1, ),  # 3
 )
 
@@ -20718,7 +20717,7 @@ class get_partition_names_result(object):
                     self.success = []
                     (_etype827, _size824) = iprot.readListBegin()
                     for _i828 in range(_size824):
-                        _elem829 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem829 = iprot.readString()
                         self.success.append(_elem829)
                     iprot.readListEnd()
                 else:
@@ -20749,7 +20748,7 @@ class get_partition_names_result(object):
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
             for iter830 in self.success:
-                oprot.writeString(iter830.encode('utf-8') if sys.version_info[0] == 2 else iter830)
+                oprot.writeString(iter830)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -20778,7 +20777,7 @@ class get_partition_names_result(object):
         return not (self == other)
 all_structs.append(get_partition_names_result)
 get_partition_names_result.thrift_spec = (
-    (0, TType.LIST, 'success', (TType.STRING, 'UTF8', False), None, ),  # 0
+    (0, TType.LIST, 'success', (TType.STRING, None, False), None, ),  # 0
     (1, TType.STRUCT, 'o1', [NoSuchObjectException, None], None, ),  # 1
     (2, TType.STRUCT, 'o2', [MetaException, None], None, ),  # 2
 )
@@ -20811,12 +20810,12 @@ class get_partitions_ps_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -20824,7 +20823,7 @@ class get_partitions_ps_args(object):
                     self.part_vals = []
                     (_etype834, _size831) = iprot.readListBegin()
                     for _i835 in range(_size831):
-                        _elem836 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem836 = iprot.readString()
                         self.part_vals.append(_elem836)
                     iprot.readListEnd()
                 else:
@@ -20846,17 +20845,17 @@ class get_partitions_ps_args(object):
         oprot.writeStructBegin('get_partitions_ps_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.part_vals is not None:
             oprot.writeFieldBegin('part_vals', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.part_vals))
             for iter837 in self.part_vals:
-                oprot.writeString(iter837.encode('utf-8') if sys.version_info[0] == 2 else iter837)
+                oprot.writeString(iter837)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.max_parts is not None:
@@ -20882,9 +20881,9 @@ class get_partitions_ps_args(object):
 all_structs.append(get_partitions_ps_args)
 get_partitions_ps_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.LIST, 'part_vals', (TType.STRING, 'UTF8', False), None, ),  # 3
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
+    (3, TType.LIST, 'part_vals', (TType.STRING, None, False), None, ),  # 3
     (4, TType.I16, 'max_parts', None, -1, ),  # 4
 )
 
@@ -21015,12 +21014,12 @@ class get_partitions_ps_with_auth_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -21028,7 +21027,7 @@ class get_partitions_ps_with_auth_args(object):
                     self.part_vals = []
                     (_etype848, _size845) = iprot.readListBegin()
                     for _i849 in range(_size845):
-                        _elem850 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem850 = iprot.readString()
                         self.part_vals.append(_elem850)
                     iprot.readListEnd()
                 else:
@@ -21040,7 +21039,7 @@ class get_partitions_ps_with_auth_args(object):
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.STRING:
-                    self.user_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.user_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 6:
@@ -21048,7 +21047,7 @@ class get_partitions_ps_with_auth_args(object):
                     self.group_names = []
                     (_etype854, _size851) = iprot.readListBegin()
                     for _i855 in range(_size851):
-                        _elem856 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem856 = iprot.readString()
                         self.group_names.append(_elem856)
                     iprot.readListEnd()
                 else:
@@ -21065,17 +21064,17 @@ class get_partitions_ps_with_auth_args(object):
         oprot.writeStructBegin('get_partitions_ps_with_auth_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.part_vals is not None:
             oprot.writeFieldBegin('part_vals', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.part_vals))
             for iter857 in self.part_vals:
-                oprot.writeString(iter857.encode('utf-8') if sys.version_info[0] == 2 else iter857)
+                oprot.writeString(iter857)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.max_parts is not None:
@@ -21084,13 +21083,13 @@ class get_partitions_ps_with_auth_args(object):
             oprot.writeFieldEnd()
         if self.user_name is not None:
             oprot.writeFieldBegin('user_name', TType.STRING, 5)
-            oprot.writeString(self.user_name.encode('utf-8') if sys.version_info[0] == 2 else self.user_name)
+            oprot.writeString(self.user_name)
             oprot.writeFieldEnd()
         if self.group_names is not None:
             oprot.writeFieldBegin('group_names', TType.LIST, 6)
             oprot.writeListBegin(TType.STRING, len(self.group_names))
             for iter858 in self.group_names:
-                oprot.writeString(iter858.encode('utf-8') if sys.version_info[0] == 2 else iter858)
+                oprot.writeString(iter858)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -21112,12 +21111,12 @@ class get_partitions_ps_with_auth_args(object):
 all_structs.append(get_partitions_ps_with_auth_args)
 get_partitions_ps_with_auth_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.LIST, 'part_vals', (TType.STRING, 'UTF8', False), None, ),  # 3
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
+    (3, TType.LIST, 'part_vals', (TType.STRING, None, False), None, ),  # 3
     (4, TType.I16, 'max_parts', None, -1, ),  # 4
-    (5, TType.STRING, 'user_name', 'UTF8', None, ),  # 5
-    (6, TType.LIST, 'group_names', (TType.STRING, 'UTF8', False), None, ),  # 6
+    (5, TType.STRING, 'user_name', None, None, ),  # 5
+    (6, TType.LIST, 'group_names', (TType.STRING, None, False), None, ),  # 6
 )
 
 
@@ -21243,12 +21242,12 @@ class get_partition_names_ps_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -21256,7 +21255,7 @@ class get_partition_names_ps_args(object):
                     self.part_vals = []
                     (_etype869, _size866) = iprot.readListBegin()
                     for _i870 in range(_size866):
-                        _elem871 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem871 = iprot.readString()
                         self.part_vals.append(_elem871)
                     iprot.readListEnd()
                 else:
@@ -21278,17 +21277,17 @@ class get_partition_names_ps_args(object):
         oprot.writeStructBegin('get_partition_names_ps_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.part_vals is not None:
             oprot.writeFieldBegin('part_vals', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.part_vals))
             for iter872 in self.part_vals:
-                oprot.writeString(iter872.encode('utf-8') if sys.version_info[0] == 2 else iter872)
+                oprot.writeString(iter872)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.max_parts is not None:
@@ -21314,9 +21313,9 @@ class get_partition_names_ps_args(object):
 all_structs.append(get_partition_names_ps_args)
 get_partition_names_ps_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.LIST, 'part_vals', (TType.STRING, 'UTF8', False), None, ),  # 3
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
+    (3, TType.LIST, 'part_vals', (TType.STRING, None, False), None, ),  # 3
     (4, TType.I16, 'max_parts', None, -1, ),  # 4
 )
 
@@ -21349,7 +21348,7 @@ class get_partition_names_ps_result(object):
                     self.success = []
                     (_etype876, _size873) = iprot.readListBegin()
                     for _i877 in range(_size873):
-                        _elem878 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem878 = iprot.readString()
                         self.success.append(_elem878)
                     iprot.readListEnd()
                 else:
@@ -21380,7 +21379,7 @@ class get_partition_names_ps_result(object):
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
             for iter879 in self.success:
-                oprot.writeString(iter879.encode('utf-8') if sys.version_info[0] == 2 else iter879)
+                oprot.writeString(iter879)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -21409,7 +21408,7 @@ class get_partition_names_ps_result(object):
         return not (self == other)
 all_structs.append(get_partition_names_ps_result)
 get_partition_names_ps_result.thrift_spec = (
-    (0, TType.LIST, 'success', (TType.STRING, 'UTF8', False), None, ),  # 0
+    (0, TType.LIST, 'success', (TType.STRING, None, False), None, ),  # 0
     (1, TType.STRUCT, 'o1', [MetaException, None], None, ),  # 1
     (2, TType.STRUCT, 'o2', [NoSuchObjectException, None], None, ),  # 2
 )
@@ -21442,17 +21441,17 @@ class get_partitions_by_filter_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.filter = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.filter = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
@@ -21472,15 +21471,15 @@ class get_partitions_by_filter_args(object):
         oprot.writeStructBegin('get_partitions_by_filter_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.filter is not None:
             oprot.writeFieldBegin('filter', TType.STRING, 3)
-            oprot.writeString(self.filter.encode('utf-8') if sys.version_info[0] == 2 else self.filter)
+            oprot.writeString(self.filter)
             oprot.writeFieldEnd()
         if self.max_parts is not None:
             oprot.writeFieldBegin('max_parts', TType.I16, 4)
@@ -21505,9 +21504,9 @@ class get_partitions_by_filter_args(object):
 all_structs.append(get_partitions_by_filter_args)
 get_partitions_by_filter_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'filter', 'UTF8', None, ),  # 3
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
+    (3, TType.STRING, 'filter', None, None, ),  # 3
     (4, TType.I16, 'max_parts', None, -1, ),  # 4
 )
 
@@ -21634,17 +21633,17 @@ class get_part_specs_by_filter_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.filter = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.filter = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
@@ -21664,15 +21663,15 @@ class get_part_specs_by_filter_args(object):
         oprot.writeStructBegin('get_part_specs_by_filter_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.filter is not None:
             oprot.writeFieldBegin('filter', TType.STRING, 3)
-            oprot.writeString(self.filter.encode('utf-8') if sys.version_info[0] == 2 else self.filter)
+            oprot.writeString(self.filter)
             oprot.writeFieldEnd()
         if self.max_parts is not None:
             oprot.writeFieldBegin('max_parts', TType.I32, 4)
@@ -21697,9 +21696,9 @@ class get_part_specs_by_filter_args(object):
 all_structs.append(get_part_specs_by_filter_args)
 get_part_specs_by_filter_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'filter', 'UTF8', None, ),  # 3
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
+    (3, TType.STRING, 'filter', None, None, ),  # 3
     (4, TType.I32, 'max_parts', None, -1, ),  # 4
 )
 
@@ -21973,17 +21972,17 @@ class get_num_partitions_by_filter_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.filter = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.filter = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -21998,15 +21997,15 @@ class get_num_partitions_by_filter_args(object):
         oprot.writeStructBegin('get_num_partitions_by_filter_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.filter is not None:
             oprot.writeFieldBegin('filter', TType.STRING, 3)
-            oprot.writeString(self.filter.encode('utf-8') if sys.version_info[0] == 2 else self.filter)
+            oprot.writeString(self.filter)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -22027,9 +22026,9 @@ class get_num_partitions_by_filter_args(object):
 all_structs.append(get_num_partitions_by_filter_args)
 get_num_partitions_by_filter_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'filter', 'UTF8', None, ),  # 3
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
+    (3, TType.STRING, 'filter', None, None, ),  # 3
 )
 
 
@@ -22144,12 +22143,12 @@ class get_partitions_by_names_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -22157,7 +22156,7 @@ class get_partitions_by_names_args(object):
                     self.names = []
                     (_etype897, _size894) = iprot.readListBegin()
                     for _i898 in range(_size894):
-                        _elem899 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem899 = iprot.readString()
                         self.names.append(_elem899)
                     iprot.readListEnd()
                 else:
@@ -22174,17 +22173,17 @@ class get_partitions_by_names_args(object):
         oprot.writeStructBegin('get_partitions_by_names_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.names is not None:
             oprot.writeFieldBegin('names', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.names))
             for iter900 in self.names:
-                oprot.writeString(iter900.encode('utf-8') if sys.version_info[0] == 2 else iter900)
+                oprot.writeString(iter900)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -22206,9 +22205,9 @@ class get_partitions_by_names_args(object):
 all_structs.append(get_partitions_by_names_args)
 get_partitions_by_names_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.LIST, 'names', (TType.STRING, 'UTF8', False), None, ),  # 3
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
+    (3, TType.LIST, 'names', (TType.STRING, None, False), None, ),  # 3
 )
 
 
@@ -22332,12 +22331,12 @@ class alter_partition_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -22358,11 +22357,11 @@ class alter_partition_args(object):
         oprot.writeStructBegin('alter_partition_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.new_part is not None:
             oprot.writeFieldBegin('new_part', TType.STRUCT, 3)
@@ -22387,8 +22386,8 @@ class alter_partition_args(object):
 all_structs.append(alter_partition_args)
 alter_partition_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
     (3, TType.STRUCT, 'new_part', [Partition, None], None, ),  # 3
 )
 
@@ -22493,12 +22492,12 @@ class alter_partitions_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -22524,11 +22523,11 @@ class alter_partitions_args(object):
         oprot.writeStructBegin('alter_partitions_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.new_parts is not None:
             oprot.writeFieldBegin('new_parts', TType.LIST, 3)
@@ -22556,8 +22555,8 @@ class alter_partitions_args(object):
 all_structs.append(alter_partitions_args)
 alter_partitions_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
     (3, TType.LIST, 'new_parts', (TType.STRUCT, [Partition, None], False), None, ),  # 3
 )
 
@@ -22664,12 +22663,12 @@ class alter_partitions_with_environment_context_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -22701,11 +22700,11 @@ class alter_partitions_with_environment_context_args(object):
         oprot.writeStructBegin('alter_partitions_with_environment_context_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.new_parts is not None:
             oprot.writeFieldBegin('new_parts', TType.LIST, 3)
@@ -22737,8 +22736,8 @@ class alter_partitions_with_environment_context_args(object):
 all_structs.append(alter_partitions_with_environment_context_args)
 alter_partitions_with_environment_context_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
     (3, TType.LIST, 'new_parts', (TType.STRUCT, [Partition, None], False), None, ),  # 3
     (4, TType.STRUCT, 'environment_context', [EnvironmentContext, None], None, ),  # 4
 )
@@ -22846,12 +22845,12 @@ class alter_partition_with_environment_context_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -22878,11 +22877,11 @@ class alter_partition_with_environment_context_args(object):
         oprot.writeStructBegin('alter_partition_with_environment_context_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.new_part is not None:
             oprot.writeFieldBegin('new_part', TType.STRUCT, 3)
@@ -22911,8 +22910,8 @@ class alter_partition_with_environment_context_args(object):
 all_structs.append(alter_partition_with_environment_context_args)
 alter_partition_with_environment_context_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
     (3, TType.STRUCT, 'new_part', [Partition, None], None, ),  # 3
     (4, TType.STRUCT, 'environment_context', [EnvironmentContext, None], None, ),  # 4
 )
@@ -23020,12 +23019,12 @@ class rename_partition_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -23033,7 +23032,7 @@ class rename_partition_args(object):
                     self.part_vals = []
                     (_etype925, _size922) = iprot.readListBegin()
                     for _i926 in range(_size922):
-                        _elem927 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem927 = iprot.readString()
                         self.part_vals.append(_elem927)
                     iprot.readListEnd()
                 else:
@@ -23056,17 +23055,17 @@ class rename_partition_args(object):
         oprot.writeStructBegin('rename_partition_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.part_vals is not None:
             oprot.writeFieldBegin('part_vals', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.part_vals))
             for iter928 in self.part_vals:
-                oprot.writeString(iter928.encode('utf-8') if sys.version_info[0] == 2 else iter928)
+                oprot.writeString(iter928)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.new_part is not None:
@@ -23092,9 +23091,9 @@ class rename_partition_args(object):
 all_structs.append(rename_partition_args)
 rename_partition_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.LIST, 'part_vals', (TType.STRING, 'UTF8', False), None, ),  # 3
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
+    (3, TType.LIST, 'part_vals', (TType.STRING, None, False), None, ),  # 3
     (4, TType.STRUCT, 'new_part', [Partition, None], None, ),  # 4
 )
 
@@ -23200,7 +23199,7 @@ class partition_name_has_valid_characters_args(object):
                     self.part_vals = []
                     (_etype932, _size929) = iprot.readListBegin()
                     for _i933 in range(_size929):
-                        _elem934 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem934 = iprot.readString()
                         self.part_vals.append(_elem934)
                     iprot.readListEnd()
                 else:
@@ -23224,7 +23223,7 @@ class partition_name_has_valid_characters_args(object):
             oprot.writeFieldBegin('part_vals', TType.LIST, 1)
             oprot.writeListBegin(TType.STRING, len(self.part_vals))
             for iter935 in self.part_vals:
-                oprot.writeString(iter935.encode('utf-8') if sys.version_info[0] == 2 else iter935)
+                oprot.writeString(iter935)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.throw_exception is not None:
@@ -23250,7 +23249,7 @@ class partition_name_has_valid_characters_args(object):
 all_structs.append(partition_name_has_valid_characters_args)
 partition_name_has_valid_characters_args.thrift_spec = (
     None,  # 0
-    (1, TType.LIST, 'part_vals', (TType.STRING, 'UTF8', False), None, ),  # 1
+    (1, TType.LIST, 'part_vals', (TType.STRING, None, False), None, ),  # 1
     (2, TType.BOOL, 'throw_exception', None, None, ),  # 2
 )
 
@@ -23351,12 +23350,12 @@ class get_config_value_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.defaultValue = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.defaultValue = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -23371,11 +23370,11 @@ class get_config_value_args(object):
         oprot.writeStructBegin('get_config_value_args')
         if self.name is not None:
             oprot.writeFieldBegin('name', TType.STRING, 1)
-            oprot.writeString(self.name.encode('utf-8') if sys.version_info[0] == 2 else self.name)
+            oprot.writeString(self.name)
             oprot.writeFieldEnd()
         if self.defaultValue is not None:
             oprot.writeFieldBegin('defaultValue', TType.STRING, 2)
-            oprot.writeString(self.defaultValue.encode('utf-8') if sys.version_info[0] == 2 else self.defaultValue)
+            oprot.writeString(self.defaultValue)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -23396,8 +23395,8 @@ class get_config_value_args(object):
 all_structs.append(get_config_value_args)
 get_config_value_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'defaultValue', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'name', None, None, ),  # 1
+    (2, TType.STRING, 'defaultValue', None, None, ),  # 2
 )
 
 
@@ -23424,7 +23423,7 @@ class get_config_value_result(object):
                 break
             if fid == 0:
                 if ftype == TType.STRING:
-                    self.success = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.success = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 1:
@@ -23445,7 +23444,7 @@ class get_config_value_result(object):
         oprot.writeStructBegin('get_config_value_result')
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.STRING, 0)
-            oprot.writeString(self.success.encode('utf-8') if sys.version_info[0] == 2 else self.success)
+            oprot.writeString(self.success)
             oprot.writeFieldEnd()
         if self.o1 is not None:
             oprot.writeFieldBegin('o1', TType.STRUCT, 1)
@@ -23469,7 +23468,7 @@ class get_config_value_result(object):
         return not (self == other)
 all_structs.append(get_config_value_result)
 get_config_value_result.thrift_spec = (
-    (0, TType.STRING, 'success', 'UTF8', None, ),  # 0
+    (0, TType.STRING, 'success', None, None, ),  # 0
     (1, TType.STRUCT, 'o1', [ConfigValSecurityException, None], None, ),  # 1
 )
 
@@ -23495,7 +23494,7 @@ class partition_name_to_vals_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.part_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.part_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -23510,7 +23509,7 @@ class partition_name_to_vals_args(object):
         oprot.writeStructBegin('partition_name_to_vals_args')
         if self.part_name is not None:
             oprot.writeFieldBegin('part_name', TType.STRING, 1)
-            oprot.writeString(self.part_name.encode('utf-8') if sys.version_info[0] == 2 else self.part_name)
+            oprot.writeString(self.part_name)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -23531,7 +23530,7 @@ class partition_name_to_vals_args(object):
 all_structs.append(partition_name_to_vals_args)
 partition_name_to_vals_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'part_name', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'part_name', None, None, ),  # 1
 )
 
 
@@ -23561,7 +23560,7 @@ class partition_name_to_vals_result(object):
                     self.success = []
                     (_etype939, _size936) = iprot.readListBegin()
                     for _i940 in range(_size936):
-                        _elem941 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem941 = iprot.readString()
                         self.success.append(_elem941)
                     iprot.readListEnd()
                 else:
@@ -23586,7 +23585,7 @@ class partition_name_to_vals_result(object):
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
             for iter942 in self.success:
-                oprot.writeString(iter942.encode('utf-8') if sys.version_info[0] == 2 else iter942)
+                oprot.writeString(iter942)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -23611,7 +23610,7 @@ class partition_name_to_vals_result(object):
         return not (self == other)
 all_structs.append(partition_name_to_vals_result)
 partition_name_to_vals_result.thrift_spec = (
-    (0, TType.LIST, 'success', (TType.STRING, 'UTF8', False), None, ),  # 0
+    (0, TType.LIST, 'success', (TType.STRING, None, False), None, ),  # 0
     (1, TType.STRUCT, 'o1', [MetaException, None], None, ),  # 1
 )
 
@@ -23637,7 +23636,7 @@ class partition_name_to_spec_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.part_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.part_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -23652,7 +23651,7 @@ class partition_name_to_spec_args(object):
         oprot.writeStructBegin('partition_name_to_spec_args')
         if self.part_name is not None:
             oprot.writeFieldBegin('part_name', TType.STRING, 1)
-            oprot.writeString(self.part_name.encode('utf-8') if sys.version_info[0] == 2 else self.part_name)
+            oprot.writeString(self.part_name)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -23673,7 +23672,7 @@ class partition_name_to_spec_args(object):
 all_structs.append(partition_name_to_spec_args)
 partition_name_to_spec_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'part_name', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'part_name', None, None, ),  # 1
 )
 
 
@@ -23703,8 +23702,8 @@ class partition_name_to_spec_result(object):
                     self.success = {}
                     (_ktype944, _vtype945, _size943) = iprot.readMapBegin()
                     for _i947 in range(_size943):
-                        _key948 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val949 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key948 = iprot.readString()
+                        _val949 = iprot.readString()
                         self.success[_key948] = _val949
                     iprot.readMapEnd()
                 else:
@@ -23729,8 +23728,8 @@ class partition_name_to_spec_result(object):
             oprot.writeFieldBegin('success', TType.MAP, 0)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.success))
             for kiter950, viter951 in self.success.items():
-                oprot.writeString(kiter950.encode('utf-8') if sys.version_info[0] == 2 else kiter950)
-                oprot.writeString(viter951.encode('utf-8') if sys.version_info[0] == 2 else viter951)
+                oprot.writeString(kiter950)
+                oprot.writeString(viter951)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -23755,7 +23754,7 @@ class partition_name_to_spec_result(object):
         return not (self == other)
 all_structs.append(partition_name_to_spec_result)
 partition_name_to_spec_result.thrift_spec = (
-    (0, TType.MAP, 'success', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 0
+    (0, TType.MAP, 'success', (TType.STRING, None, TType.STRING, None, False), None, ),  # 0
     (1, TType.STRUCT, 'o1', [MetaException, None], None, ),  # 1
 )
 
@@ -23787,12 +23786,12 @@ class markPartitionForEvent_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -23800,8 +23799,8 @@ class markPartitionForEvent_args(object):
                     self.part_vals = {}
                     (_ktype953, _vtype954, _size952) = iprot.readMapBegin()
                     for _i956 in range(_size952):
-                        _key957 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val958 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key957 = iprot.readString()
+                        _val958 = iprot.readString()
                         self.part_vals[_key957] = _val958
                     iprot.readMapEnd()
                 else:
@@ -23823,18 +23822,18 @@ class markPartitionForEvent_args(object):
         oprot.writeStructBegin('markPartitionForEvent_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.part_vals is not None:
             oprot.writeFieldBegin('part_vals', TType.MAP, 3)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.part_vals))
             for kiter959, viter960 in self.part_vals.items():
-                oprot.writeString(kiter959.encode('utf-8') if sys.version_info[0] == 2 else kiter959)
-                oprot.writeString(viter960.encode('utf-8') if sys.version_info[0] == 2 else viter960)
+                oprot.writeString(kiter959)
+                oprot.writeString(viter960)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.eventType is not None:
@@ -23860,9 +23859,9 @@ class markPartitionForEvent_args(object):
 all_structs.append(markPartitionForEvent_args)
 markPartitionForEvent_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.MAP, 'part_vals', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 3
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
+    (3, TType.MAP, 'part_vals', (TType.STRING, None, TType.STRING, None, False), None, ),  # 3
     (4, TType.I32, 'eventType', None, None, ),  # 4
 )
 
@@ -24021,12 +24020,12 @@ class isPartitionMarkedForEvent_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -24034,8 +24033,8 @@ class isPartitionMarkedForEvent_args(object):
                     self.part_vals = {}
                     (_ktype962, _vtype963, _size961) = iprot.readMapBegin()
                     for _i965 in range(_size961):
-                        _key966 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val967 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key966 = iprot.readString()
+                        _val967 = iprot.readString()
                         self.part_vals[_key966] = _val967
                     iprot.readMapEnd()
                 else:
@@ -24057,18 +24056,18 @@ class isPartitionMarkedForEvent_args(object):
         oprot.writeStructBegin('isPartitionMarkedForEvent_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.part_vals is not None:
             oprot.writeFieldBegin('part_vals', TType.MAP, 3)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.part_vals))
             for kiter968, viter969 in self.part_vals.items():
-                oprot.writeString(kiter968.encode('utf-8') if sys.version_info[0] == 2 else kiter968)
-                oprot.writeString(viter969.encode('utf-8') if sys.version_info[0] == 2 else viter969)
+                oprot.writeString(kiter968)
+                oprot.writeString(viter969)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.eventType is not None:
@@ -24094,9 +24093,9 @@ class isPartitionMarkedForEvent_args(object):
 all_structs.append(isPartitionMarkedForEvent_args)
 isPartitionMarkedForEvent_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.MAP, 'part_vals', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 3
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
+    (3, TType.MAP, 'part_vals', (TType.STRING, None, TType.STRING, None, False), None, ),  # 3
     (4, TType.I32, 'eventType', None, None, ),  # 4
 )
 
@@ -24441,17 +24440,17 @@ class alter_index_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.dbname = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbname = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.base_tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.base_tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.idx_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.idx_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
@@ -24472,15 +24471,15 @@ class alter_index_args(object):
         oprot.writeStructBegin('alter_index_args')
         if self.dbname is not None:
             oprot.writeFieldBegin('dbname', TType.STRING, 1)
-            oprot.writeString(self.dbname.encode('utf-8') if sys.version_info[0] == 2 else self.dbname)
+            oprot.writeString(self.dbname)
             oprot.writeFieldEnd()
         if self.base_tbl_name is not None:
             oprot.writeFieldBegin('base_tbl_name', TType.STRING, 2)
-            oprot.writeString(self.base_tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.base_tbl_name)
+            oprot.writeString(self.base_tbl_name)
             oprot.writeFieldEnd()
         if self.idx_name is not None:
             oprot.writeFieldBegin('idx_name', TType.STRING, 3)
-            oprot.writeString(self.idx_name.encode('utf-8') if sys.version_info[0] == 2 else self.idx_name)
+            oprot.writeString(self.idx_name)
             oprot.writeFieldEnd()
         if self.new_idx is not None:
             oprot.writeFieldBegin('new_idx', TType.STRUCT, 4)
@@ -24505,9 +24504,9 @@ class alter_index_args(object):
 all_structs.append(alter_index_args)
 alter_index_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'dbname', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'base_tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'idx_name', 'UTF8', None, ),  # 3
+    (1, TType.STRING, 'dbname', None, None, ),  # 1
+    (2, TType.STRING, 'base_tbl_name', None, None, ),  # 2
+    (3, TType.STRING, 'idx_name', None, None, ),  # 3
     (4, TType.STRUCT, 'new_idx', [Index, None], None, ),  # 4
 )
 
@@ -24614,17 +24613,17 @@ class drop_index_by_name_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.index_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.index_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
@@ -24644,15 +24643,15 @@ class drop_index_by_name_args(object):
         oprot.writeStructBegin('drop_index_by_name_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.index_name is not None:
             oprot.writeFieldBegin('index_name', TType.STRING, 3)
-            oprot.writeString(self.index_name.encode('utf-8') if sys.version_info[0] == 2 else self.index_name)
+            oprot.writeString(self.index_name)
             oprot.writeFieldEnd()
         if self.deleteData is not None:
             oprot.writeFieldBegin('deleteData', TType.BOOL, 4)
@@ -24677,9 +24676,9 @@ class drop_index_by_name_args(object):
 all_structs.append(drop_index_by_name_args)
 drop_index_by_name_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'index_name', 'UTF8', None, ),  # 3
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
+    (3, TType.STRING, 'index_name', None, None, ),  # 3
     (4, TType.BOOL, 'deleteData', None, None, ),  # 4
 )
 
@@ -24795,17 +24794,17 @@ class get_index_by_name_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.index_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.index_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -24820,15 +24819,15 @@ class get_index_by_name_args(object):
         oprot.writeStructBegin('get_index_by_name_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.index_name is not None:
             oprot.writeFieldBegin('index_name', TType.STRING, 3)
-            oprot.writeString(self.index_name.encode('utf-8') if sys.version_info[0] == 2 else self.index_name)
+            oprot.writeString(self.index_name)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -24849,9 +24848,9 @@ class get_index_by_name_args(object):
 all_structs.append(get_index_by_name_args)
 get_index_by_name_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'index_name', 'UTF8', None, ),  # 3
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
+    (3, TType.STRING, 'index_name', None, None, ),  # 3
 )
 
 
@@ -24967,12 +24966,12 @@ class get_indexes_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -24992,11 +24991,11 @@ class get_indexes_args(object):
         oprot.writeStructBegin('get_indexes_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.max_indexes is not None:
             oprot.writeFieldBegin('max_indexes', TType.I16, 3)
@@ -25021,8 +25020,8 @@ class get_indexes_args(object):
 all_structs.append(get_indexes_args)
 get_indexes_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
     (3, TType.I16, 'max_indexes', None, -1, ),  # 3
 )
 
@@ -25147,12 +25146,12 @@ class get_index_names_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -25172,11 +25171,11 @@ class get_index_names_args(object):
         oprot.writeStructBegin('get_index_names_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.max_indexes is not None:
             oprot.writeFieldBegin('max_indexes', TType.I16, 3)
@@ -25201,8 +25200,8 @@ class get_index_names_args(object):
 all_structs.append(get_index_names_args)
 get_index_names_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
     (3, TType.I16, 'max_indexes', None, -1, ),  # 3
 )
 
@@ -25233,7 +25232,7 @@ class get_index_names_result(object):
                     self.success = []
                     (_etype980, _size977) = iprot.readListBegin()
                     for _i981 in range(_size977):
-                        _elem982 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem982 = iprot.readString()
                         self.success.append(_elem982)
                     iprot.readListEnd()
                 else:
@@ -25258,7 +25257,7 @@ class get_index_names_result(object):
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
             for iter983 in self.success:
-                oprot.writeString(iter983.encode('utf-8') if sys.version_info[0] == 2 else iter983)
+                oprot.writeString(iter983)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o2 is not None:
@@ -25283,7 +25282,7 @@ class get_index_names_result(object):
         return not (self == other)
 all_structs.append(get_index_names_result)
 get_index_names_result.thrift_spec = (
-    (0, TType.LIST, 'success', (TType.STRING, 'UTF8', False), None, ),  # 0
+    (0, TType.LIST, 'success', (TType.STRING, None, False), None, ),  # 0
     (1, TType.STRUCT, 'o2', [MetaException, None], None, ),  # 1
 )
 
@@ -25959,17 +25958,17 @@ class get_table_column_statistics_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.col_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.col_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -25984,15 +25983,15 @@ class get_table_column_statistics_args(object):
         oprot.writeStructBegin('get_table_column_statistics_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.col_name is not None:
             oprot.writeFieldBegin('col_name', TType.STRING, 3)
-            oprot.writeString(self.col_name.encode('utf-8') if sys.version_info[0] == 2 else self.col_name)
+            oprot.writeString(self.col_name)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -26013,9 +26012,9 @@ class get_table_column_statistics_args(object):
 all_structs.append(get_table_column_statistics_args)
 get_table_column_statistics_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'col_name', 'UTF8', None, ),  # 3
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
+    (3, TType.STRING, 'col_name', None, None, ),  # 3
 )
 
 
@@ -26159,22 +26158,22 @@ class get_partition_column_statistics_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.part_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.part_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.col_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.col_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -26189,19 +26188,19 @@ class get_partition_column_statistics_args(object):
         oprot.writeStructBegin('get_partition_column_statistics_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.part_name is not None:
             oprot.writeFieldBegin('part_name', TType.STRING, 3)
-            oprot.writeString(self.part_name.encode('utf-8') if sys.version_info[0] == 2 else self.part_name)
+            oprot.writeString(self.part_name)
             oprot.writeFieldEnd()
         if self.col_name is not None:
             oprot.writeFieldBegin('col_name', TType.STRING, 4)
-            oprot.writeString(self.col_name.encode('utf-8') if sys.version_info[0] == 2 else self.col_name)
+            oprot.writeString(self.col_name)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -26222,10 +26221,10 @@ class get_partition_column_statistics_args(object):
 all_structs.append(get_partition_column_statistics_args)
 get_partition_column_statistics_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'part_name', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'col_name', 'UTF8', None, ),  # 4
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
+    (3, TType.STRING, 'part_name', None, None, ),  # 3
+    (4, TType.STRING, 'col_name', None, None, ),  # 4
 )
 
 
@@ -26990,22 +26989,22 @@ class delete_partition_column_statistics_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.part_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.part_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.col_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.col_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -27020,19 +27019,19 @@ class delete_partition_column_statistics_args(object):
         oprot.writeStructBegin('delete_partition_column_statistics_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.part_name is not None:
             oprot.writeFieldBegin('part_name', TType.STRING, 3)
-            oprot.writeString(self.part_name.encode('utf-8') if sys.version_info[0] == 2 else self.part_name)
+            oprot.writeString(self.part_name)
             oprot.writeFieldEnd()
         if self.col_name is not None:
             oprot.writeFieldBegin('col_name', TType.STRING, 4)
-            oprot.writeString(self.col_name.encode('utf-8') if sys.version_info[0] == 2 else self.col_name)
+            oprot.writeString(self.col_name)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -27053,10 +27052,10 @@ class delete_partition_column_statistics_args(object):
 all_structs.append(delete_partition_column_statistics_args)
 delete_partition_column_statistics_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'part_name', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'col_name', 'UTF8', None, ),  # 4
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
+    (3, TType.STRING, 'part_name', None, None, ),  # 3
+    (4, TType.STRING, 'col_name', None, None, ),  # 4
 )
 
 
@@ -27197,17 +27196,17 @@ class delete_table_column_statistics_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.col_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.col_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -27222,15 +27221,15 @@ class delete_table_column_statistics_args(object):
         oprot.writeStructBegin('delete_table_column_statistics_args')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         if self.col_name is not None:
             oprot.writeFieldBegin('col_name', TType.STRING, 3)
-            oprot.writeString(self.col_name.encode('utf-8') if sys.version_info[0] == 2 else self.col_name)
+            oprot.writeString(self.col_name)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -27251,9 +27250,9 @@ class delete_table_column_statistics_args(object):
 all_structs.append(delete_table_column_statistics_args)
 delete_table_column_statistics_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'col_name', 'UTF8', None, ),  # 3
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
+    (3, TType.STRING, 'col_name', None, None, ),  # 3
 )
 
 
@@ -27555,12 +27554,12 @@ class drop_function_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.dbName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.funcName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.funcName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -27575,11 +27574,11 @@ class drop_function_args(object):
         oprot.writeStructBegin('drop_function_args')
         if self.dbName is not None:
             oprot.writeFieldBegin('dbName', TType.STRING, 1)
-            oprot.writeString(self.dbName.encode('utf-8') if sys.version_info[0] == 2 else self.dbName)
+            oprot.writeString(self.dbName)
             oprot.writeFieldEnd()
         if self.funcName is not None:
             oprot.writeFieldBegin('funcName', TType.STRING, 2)
-            oprot.writeString(self.funcName.encode('utf-8') if sys.version_info[0] == 2 else self.funcName)
+            oprot.writeString(self.funcName)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -27600,8 +27599,8 @@ class drop_function_args(object):
 all_structs.append(drop_function_args)
 drop_function_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'dbName', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'funcName', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'dbName', None, None, ),  # 1
+    (2, TType.STRING, 'funcName', None, None, ),  # 2
 )
 
 
@@ -27705,12 +27704,12 @@ class alter_function_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.dbName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.funcName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.funcName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -27731,11 +27730,11 @@ class alter_function_args(object):
         oprot.writeStructBegin('alter_function_args')
         if self.dbName is not None:
             oprot.writeFieldBegin('dbName', TType.STRING, 1)
-            oprot.writeString(self.dbName.encode('utf-8') if sys.version_info[0] == 2 else self.dbName)
+            oprot.writeString(self.dbName)
             oprot.writeFieldEnd()
         if self.funcName is not None:
             oprot.writeFieldBegin('funcName', TType.STRING, 2)
-            oprot.writeString(self.funcName.encode('utf-8') if sys.version_info[0] == 2 else self.funcName)
+            oprot.writeString(self.funcName)
             oprot.writeFieldEnd()
         if self.newFunc is not None:
             oprot.writeFieldBegin('newFunc', TType.STRUCT, 3)
@@ -27760,8 +27759,8 @@ class alter_function_args(object):
 all_structs.append(alter_function_args)
 alter_function_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'dbName', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'funcName', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'dbName', None, None, ),  # 1
+    (2, TType.STRING, 'funcName', None, None, ),  # 2
     (3, TType.STRUCT, 'newFunc', [Function, None], None, ),  # 3
 )
 
@@ -27864,12 +27863,12 @@ class get_functions_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.dbName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.pattern = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.pattern = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -27884,11 +27883,11 @@ class get_functions_args(object):
         oprot.writeStructBegin('get_functions_args')
         if self.dbName is not None:
             oprot.writeFieldBegin('dbName', TType.STRING, 1)
-            oprot.writeString(self.dbName.encode('utf-8') if sys.version_info[0] == 2 else self.dbName)
+            oprot.writeString(self.dbName)
             oprot.writeFieldEnd()
         if self.pattern is not None:
             oprot.writeFieldBegin('pattern', TType.STRING, 2)
-            oprot.writeString(self.pattern.encode('utf-8') if sys.version_info[0] == 2 else self.pattern)
+            oprot.writeString(self.pattern)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -27909,8 +27908,8 @@ class get_functions_args(object):
 all_structs.append(get_functions_args)
 get_functions_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'dbName', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'pattern', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'dbName', None, None, ),  # 1
+    (2, TType.STRING, 'pattern', None, None, ),  # 2
 )
 
 
@@ -27940,7 +27939,7 @@ class get_functions_result(object):
                     self.success = []
                     (_etype987, _size984) = iprot.readListBegin()
                     for _i988 in range(_size984):
-                        _elem989 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem989 = iprot.readString()
                         self.success.append(_elem989)
                     iprot.readListEnd()
                 else:
@@ -27965,7 +27964,7 @@ class get_functions_result(object):
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
             for iter990 in self.success:
-                oprot.writeString(iter990.encode('utf-8') if sys.version_info[0] == 2 else iter990)
+                oprot.writeString(iter990)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -27990,7 +27989,7 @@ class get_functions_result(object):
         return not (self == other)
 all_structs.append(get_functions_result)
 get_functions_result.thrift_spec = (
-    (0, TType.LIST, 'success', (TType.STRING, 'UTF8', False), None, ),  # 0
+    (0, TType.LIST, 'success', (TType.STRING, None, False), None, ),  # 0
     (1, TType.STRUCT, 'o1', [MetaException, None], None, ),  # 1
 )
 
@@ -28018,12 +28017,12 @@ class get_function_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.dbName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.funcName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.funcName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -28038,11 +28037,11 @@ class get_function_args(object):
         oprot.writeStructBegin('get_function_args')
         if self.dbName is not None:
             oprot.writeFieldBegin('dbName', TType.STRING, 1)
-            oprot.writeString(self.dbName.encode('utf-8') if sys.version_info[0] == 2 else self.dbName)
+            oprot.writeString(self.dbName)
             oprot.writeFieldEnd()
         if self.funcName is not None:
             oprot.writeFieldBegin('funcName', TType.STRING, 2)
-            oprot.writeString(self.funcName.encode('utf-8') if sys.version_info[0] == 2 else self.funcName)
+            oprot.writeString(self.funcName)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -28063,8 +28062,8 @@ class get_function_args(object):
 all_structs.append(get_function_args)
 get_function_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'dbName', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'funcName', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'dbName', None, None, ),  # 1
+    (2, TType.STRING, 'funcName', None, None, ),  # 2
 )
 
 
@@ -28428,7 +28427,7 @@ class drop_role_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.role_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.role_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -28443,7 +28442,7 @@ class drop_role_args(object):
         oprot.writeStructBegin('drop_role_args')
         if self.role_name is not None:
             oprot.writeFieldBegin('role_name', TType.STRING, 1)
-            oprot.writeString(self.role_name.encode('utf-8') if sys.version_info[0] == 2 else self.role_name)
+            oprot.writeString(self.role_name)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -28464,7 +28463,7 @@ class drop_role_args(object):
 all_structs.append(drop_role_args)
 drop_role_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'role_name', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'role_name', None, None, ),  # 1
 )
 
 
@@ -28610,7 +28609,7 @@ class get_role_names_result(object):
                     self.success = []
                     (_etype994, _size991) = iprot.readListBegin()
                     for _i995 in range(_size991):
-                        _elem996 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem996 = iprot.readString()
                         self.success.append(_elem996)
                     iprot.readListEnd()
                 else:
@@ -28635,7 +28634,7 @@ class get_role_names_result(object):
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
             for iter997 in self.success:
-                oprot.writeString(iter997.encode('utf-8') if sys.version_info[0] == 2 else iter997)
+                oprot.writeString(iter997)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -28660,7 +28659,7 @@ class get_role_names_result(object):
         return not (self == other)
 all_structs.append(get_role_names_result)
 get_role_names_result.thrift_spec = (
-    (0, TType.LIST, 'success', (TType.STRING, 'UTF8', False), None, ),  # 0
+    (0, TType.LIST, 'success', (TType.STRING, None, False), None, ),  # 0
     (1, TType.STRUCT, 'o1', [MetaException, None], None, ),  # 1
 )
 
@@ -28696,12 +28695,12 @@ class grant_role_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.role_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.role_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.principal_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.principal_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -28711,7 +28710,7 @@ class grant_role_args(object):
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.grantor = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.grantor = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 5:
@@ -28736,11 +28735,11 @@ class grant_role_args(object):
         oprot.writeStructBegin('grant_role_args')
         if self.role_name is not None:
             oprot.writeFieldBegin('role_name', TType.STRING, 1)
-            oprot.writeString(self.role_name.encode('utf-8') if sys.version_info[0] == 2 else self.role_name)
+            oprot.writeString(self.role_name)
             oprot.writeFieldEnd()
         if self.principal_name is not None:
             oprot.writeFieldBegin('principal_name', TType.STRING, 2)
-            oprot.writeString(self.principal_name.encode('utf-8') if sys.version_info[0] == 2 else self.principal_name)
+            oprot.writeString(self.principal_name)
             oprot.writeFieldEnd()
         if self.principal_type is not None:
             oprot.writeFieldBegin('principal_type', TType.I32, 3)
@@ -28748,7 +28747,7 @@ class grant_role_args(object):
             oprot.writeFieldEnd()
         if self.grantor is not None:
             oprot.writeFieldBegin('grantor', TType.STRING, 4)
-            oprot.writeString(self.grantor.encode('utf-8') if sys.version_info[0] == 2 else self.grantor)
+            oprot.writeString(self.grantor)
             oprot.writeFieldEnd()
         if self.grantorType is not None:
             oprot.writeFieldBegin('grantorType', TType.I32, 5)
@@ -28777,10 +28776,10 @@ class grant_role_args(object):
 all_structs.append(grant_role_args)
 grant_role_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'role_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'principal_name', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'role_name', None, None, ),  # 1
+    (2, TType.STRING, 'principal_name', None, None, ),  # 2
     (3, TType.I32, 'principal_type', None, None, ),  # 3
-    (4, TType.STRING, 'grantor', 'UTF8', None, ),  # 4
+    (4, TType.STRING, 'grantor', None, None, ),  # 4
     (5, TType.I32, 'grantorType', None, None, ),  # 5
     (6, TType.BOOL, 'grant_option', None, None, ),  # 6
 )
@@ -28884,12 +28883,12 @@ class revoke_role_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.role_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.role_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.principal_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.principal_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -28909,11 +28908,11 @@ class revoke_role_args(object):
         oprot.writeStructBegin('revoke_role_args')
         if self.role_name is not None:
             oprot.writeFieldBegin('role_name', TType.STRING, 1)
-            oprot.writeString(self.role_name.encode('utf-8') if sys.version_info[0] == 2 else self.role_name)
+            oprot.writeString(self.role_name)
             oprot.writeFieldEnd()
         if self.principal_name is not None:
             oprot.writeFieldBegin('principal_name', TType.STRING, 2)
-            oprot.writeString(self.principal_name.encode('utf-8') if sys.version_info[0] == 2 else self.principal_name)
+            oprot.writeString(self.principal_name)
             oprot.writeFieldEnd()
         if self.principal_type is not None:
             oprot.writeFieldBegin('principal_type', TType.I32, 3)
@@ -28938,8 +28937,8 @@ class revoke_role_args(object):
 all_structs.append(revoke_role_args)
 revoke_role_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'role_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'principal_name', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'role_name', None, None, ),  # 1
+    (2, TType.STRING, 'principal_name', None, None, ),  # 2
     (3, TType.I32, 'principal_type', None, None, ),  # 3
 )
 
@@ -29040,7 +29039,7 @@ class list_roles_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.principal_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.principal_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
@@ -29060,7 +29059,7 @@ class list_roles_args(object):
         oprot.writeStructBegin('list_roles_args')
         if self.principal_name is not None:
             oprot.writeFieldBegin('principal_name', TType.STRING, 1)
-            oprot.writeString(self.principal_name.encode('utf-8') if sys.version_info[0] == 2 else self.principal_name)
+            oprot.writeString(self.principal_name)
             oprot.writeFieldEnd()
         if self.principal_type is not None:
             oprot.writeFieldBegin('principal_type', TType.I32, 2)
@@ -29085,7 +29084,7 @@ class list_roles_args(object):
 all_structs.append(list_roles_args)
 list_roles_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'principal_name', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'principal_name', None, None, ),  # 1
     (2, TType.I32, 'principal_type', None, None, ),  # 2
 )
 
@@ -29611,7 +29610,7 @@ class get_privilege_set_args(object):
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.user_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.user_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -29619,7 +29618,7 @@ class get_privilege_set_args(object):
                     self.group_names = []
                     (_etype1008, _size1005) = iprot.readListBegin()
                     for _i1009 in range(_size1005):
-                        _elem1010 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem1010 = iprot.readString()
                         self.group_names.append(_elem1010)
                     iprot.readListEnd()
                 else:
@@ -29640,13 +29639,13 @@ class get_privilege_set_args(object):
             oprot.writeFieldEnd()
         if self.user_name is not None:
             oprot.writeFieldBegin('user_name', TType.STRING, 2)
-            oprot.writeString(self.user_name.encode('utf-8') if sys.version_info[0] == 2 else self.user_name)
+            oprot.writeString(self.user_name)
             oprot.writeFieldEnd()
         if self.group_names is not None:
             oprot.writeFieldBegin('group_names', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.group_names))
             for iter1011 in self.group_names:
-                oprot.writeString(iter1011.encode('utf-8') if sys.version_info[0] == 2 else iter1011)
+                oprot.writeString(iter1011)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -29669,8 +29668,8 @@ all_structs.append(get_privilege_set_args)
 get_privilege_set_args.thrift_spec = (
     None,  # 0
     (1, TType.STRUCT, 'hiveObject', [HiveObjectRef, None], None, ),  # 1
-    (2, TType.STRING, 'user_name', 'UTF8', None, ),  # 2
-    (3, TType.LIST, 'group_names', (TType.STRING, 'UTF8', False), None, ),  # 3
+    (2, TType.STRING, 'user_name', None, None, ),  # 2
+    (3, TType.LIST, 'group_names', (TType.STRING, None, False), None, ),  # 3
 )
 
 
@@ -29773,7 +29772,7 @@ class list_privileges_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.principal_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.principal_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
@@ -29799,7 +29798,7 @@ class list_privileges_args(object):
         oprot.writeStructBegin('list_privileges_args')
         if self.principal_name is not None:
             oprot.writeFieldBegin('principal_name', TType.STRING, 1)
-            oprot.writeString(self.principal_name.encode('utf-8') if sys.version_info[0] == 2 else self.principal_name)
+            oprot.writeString(self.principal_name)
             oprot.writeFieldEnd()
         if self.principal_type is not None:
             oprot.writeFieldBegin('principal_type', TType.I32, 2)
@@ -29828,7 +29827,7 @@ class list_privileges_args(object):
 all_structs.append(list_privileges_args)
 list_privileges_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'principal_name', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'principal_name', None, None, ),  # 1
     (2, TType.I32, 'principal_type', None, None, ),  # 2
     (3, TType.STRUCT, 'hiveObject', [HiveObjectRef, None], None, ),  # 3
 )
@@ -30345,7 +30344,7 @@ class set_ugi_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.user_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.user_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
@@ -30353,7 +30352,7 @@ class set_ugi_args(object):
                     self.group_names = []
                     (_etype1022, _size1019) = iprot.readListBegin()
                     for _i1023 in range(_size1019):
-                        _elem1024 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem1024 = iprot.readString()
                         self.group_names.append(_elem1024)
                     iprot.readListEnd()
                 else:
@@ -30370,13 +30369,13 @@ class set_ugi_args(object):
         oprot.writeStructBegin('set_ugi_args')
         if self.user_name is not None:
             oprot.writeFieldBegin('user_name', TType.STRING, 1)
-            oprot.writeString(self.user_name.encode('utf-8') if sys.version_info[0] == 2 else self.user_name)
+            oprot.writeString(self.user_name)
             oprot.writeFieldEnd()
         if self.group_names is not None:
             oprot.writeFieldBegin('group_names', TType.LIST, 2)
             oprot.writeListBegin(TType.STRING, len(self.group_names))
             for iter1025 in self.group_names:
-                oprot.writeString(iter1025.encode('utf-8') if sys.version_info[0] == 2 else iter1025)
+                oprot.writeString(iter1025)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -30398,8 +30397,8 @@ class set_ugi_args(object):
 all_structs.append(set_ugi_args)
 set_ugi_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'user_name', 'UTF8', None, ),  # 1
-    (2, TType.LIST, 'group_names', (TType.STRING, 'UTF8', False), None, ),  # 2
+    (1, TType.STRING, 'user_name', None, None, ),  # 1
+    (2, TType.LIST, 'group_names', (TType.STRING, None, False), None, ),  # 2
 )
 
 
@@ -30429,7 +30428,7 @@ class set_ugi_result(object):
                     self.success = []
                     (_etype1029, _size1026) = iprot.readListBegin()
                     for _i1030 in range(_size1026):
-                        _elem1031 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem1031 = iprot.readString()
                         self.success.append(_elem1031)
                     iprot.readListEnd()
                 else:
@@ -30454,7 +30453,7 @@ class set_ugi_result(object):
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
             for iter1032 in self.success:
-                oprot.writeString(iter1032.encode('utf-8') if sys.version_info[0] == 2 else iter1032)
+                oprot.writeString(iter1032)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.o1 is not None:
@@ -30479,7 +30478,7 @@ class set_ugi_result(object):
         return not (self == other)
 all_structs.append(set_ugi_result)
 set_ugi_result.thrift_spec = (
-    (0, TType.LIST, 'success', (TType.STRING, 'UTF8', False), None, ),  # 0
+    (0, TType.LIST, 'success', (TType.STRING, None, False), None, ),  # 0
     (1, TType.STRUCT, 'o1', [MetaException, None], None, ),  # 1
 )
 
@@ -30507,12 +30506,12 @@ class get_delegation_token_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.token_owner = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.token_owner = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.renewer_kerberos_principal_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.renewer_kerberos_principal_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -30527,11 +30526,11 @@ class get_delegation_token_args(object):
         oprot.writeStructBegin('get_delegation_token_args')
         if self.token_owner is not None:
             oprot.writeFieldBegin('token_owner', TType.STRING, 1)
-            oprot.writeString(self.token_owner.encode('utf-8') if sys.version_info[0] == 2 else self.token_owner)
+            oprot.writeString(self.token_owner)
             oprot.writeFieldEnd()
         if self.renewer_kerberos_principal_name is not None:
             oprot.writeFieldBegin('renewer_kerberos_principal_name', TType.STRING, 2)
-            oprot.writeString(self.renewer_kerberos_principal_name.encode('utf-8') if sys.version_info[0] == 2 else self.renewer_kerberos_principal_name)
+            oprot.writeString(self.renewer_kerberos_principal_name)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -30552,8 +30551,8 @@ class get_delegation_token_args(object):
 all_structs.append(get_delegation_token_args)
 get_delegation_token_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'token_owner', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'renewer_kerberos_principal_name', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'token_owner', None, None, ),  # 1
+    (2, TType.STRING, 'renewer_kerberos_principal_name', None, None, ),  # 2
 )
 
 
@@ -30580,7 +30579,7 @@ class get_delegation_token_result(object):
                 break
             if fid == 0:
                 if ftype == TType.STRING:
-                    self.success = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.success = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 1:
@@ -30601,7 +30600,7 @@ class get_delegation_token_result(object):
         oprot.writeStructBegin('get_delegation_token_result')
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.STRING, 0)
-            oprot.writeString(self.success.encode('utf-8') if sys.version_info[0] == 2 else self.success)
+            oprot.writeString(self.success)
             oprot.writeFieldEnd()
         if self.o1 is not None:
             oprot.writeFieldBegin('o1', TType.STRUCT, 1)
@@ -30625,7 +30624,7 @@ class get_delegation_token_result(object):
         return not (self == other)
 all_structs.append(get_delegation_token_result)
 get_delegation_token_result.thrift_spec = (
-    (0, TType.STRING, 'success', 'UTF8', None, ),  # 0
+    (0, TType.STRING, 'success', None, None, ),  # 0
     (1, TType.STRUCT, 'o1', [MetaException, None], None, ),  # 1
 )
 
@@ -30651,7 +30650,7 @@ class renew_delegation_token_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.token_str_form = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.token_str_form = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -30666,7 +30665,7 @@ class renew_delegation_token_args(object):
         oprot.writeStructBegin('renew_delegation_token_args')
         if self.token_str_form is not None:
             oprot.writeFieldBegin('token_str_form', TType.STRING, 1)
-            oprot.writeString(self.token_str_form.encode('utf-8') if sys.version_info[0] == 2 else self.token_str_form)
+            oprot.writeString(self.token_str_form)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -30687,7 +30686,7 @@ class renew_delegation_token_args(object):
 all_structs.append(renew_delegation_token_args)
 renew_delegation_token_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'token_str_form', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'token_str_form', None, None, ),  # 1
 )
 
 
@@ -30785,7 +30784,7 @@ class cancel_delegation_token_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.token_str_form = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.token_str_form = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -30800,7 +30799,7 @@ class cancel_delegation_token_args(object):
         oprot.writeStructBegin('cancel_delegation_token_args')
         if self.token_str_form is not None:
             oprot.writeFieldBegin('token_str_form', TType.STRING, 1)
-            oprot.writeString(self.token_str_form.encode('utf-8') if sys.version_info[0] == 2 else self.token_str_form)
+            oprot.writeString(self.token_str_form)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -30821,7 +30820,7 @@ class cancel_delegation_token_args(object):
 all_structs.append(cancel_delegation_token_args)
 cancel_delegation_token_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'token_str_form', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'token_str_form', None, None, ),  # 1
 )
 
 
@@ -30910,12 +30909,12 @@ class add_token_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.token_identifier = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.token_identifier = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.delegation_token = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.delegation_token = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -30930,11 +30929,11 @@ class add_token_args(object):
         oprot.writeStructBegin('add_token_args')
         if self.token_identifier is not None:
             oprot.writeFieldBegin('token_identifier', TType.STRING, 1)
-            oprot.writeString(self.token_identifier.encode('utf-8') if sys.version_info[0] == 2 else self.token_identifier)
+            oprot.writeString(self.token_identifier)
             oprot.writeFieldEnd()
         if self.delegation_token is not None:
             oprot.writeFieldBegin('delegation_token', TType.STRING, 2)
-            oprot.writeString(self.delegation_token.encode('utf-8') if sys.version_info[0] == 2 else self.delegation_token)
+            oprot.writeString(self.delegation_token)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -30955,8 +30954,8 @@ class add_token_args(object):
 all_structs.append(add_token_args)
 add_token_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'token_identifier', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'delegation_token', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'token_identifier', None, None, ),  # 1
+    (2, TType.STRING, 'delegation_token', None, None, ),  # 2
 )
 
 
@@ -31041,7 +31040,7 @@ class remove_token_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.token_identifier = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.token_identifier = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -31056,7 +31055,7 @@ class remove_token_args(object):
         oprot.writeStructBegin('remove_token_args')
         if self.token_identifier is not None:
             oprot.writeFieldBegin('token_identifier', TType.STRING, 1)
-            oprot.writeString(self.token_identifier.encode('utf-8') if sys.version_info[0] == 2 else self.token_identifier)
+            oprot.writeString(self.token_identifier)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -31077,7 +31076,7 @@ class remove_token_args(object):
 all_structs.append(remove_token_args)
 remove_token_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'token_identifier', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'token_identifier', None, None, ),  # 1
 )
 
 
@@ -31162,7 +31161,7 @@ class get_token_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.token_identifier = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.token_identifier = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -31177,7 +31176,7 @@ class get_token_args(object):
         oprot.writeStructBegin('get_token_args')
         if self.token_identifier is not None:
             oprot.writeFieldBegin('token_identifier', TType.STRING, 1)
-            oprot.writeString(self.token_identifier.encode('utf-8') if sys.version_info[0] == 2 else self.token_identifier)
+            oprot.writeString(self.token_identifier)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -31198,7 +31197,7 @@ class get_token_args(object):
 all_structs.append(get_token_args)
 get_token_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'token_identifier', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'token_identifier', None, None, ),  # 1
 )
 
 
@@ -31223,7 +31222,7 @@ class get_token_result(object):
                 break
             if fid == 0:
                 if ftype == TType.STRING:
-                    self.success = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.success = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -31238,7 +31237,7 @@ class get_token_result(object):
         oprot.writeStructBegin('get_token_result')
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.STRING, 0)
-            oprot.writeString(self.success.encode('utf-8') if sys.version_info[0] == 2 else self.success)
+            oprot.writeString(self.success)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -31258,7 +31257,7 @@ class get_token_result(object):
         return not (self == other)
 all_structs.append(get_token_result)
 get_token_result.thrift_spec = (
-    (0, TType.STRING, 'success', 'UTF8', None, ),  # 0
+    (0, TType.STRING, 'success', None, None, ),  # 0
 )
 
 
@@ -31329,7 +31328,7 @@ class get_all_token_identifiers_result(object):
                     self.success = []
                     (_etype1036, _size1033) = iprot.readListBegin()
                     for _i1037 in range(_size1033):
-                        _elem1038 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem1038 = iprot.readString()
                         self.success.append(_elem1038)
                     iprot.readListEnd()
                 else:
@@ -31348,7 +31347,7 @@ class get_all_token_identifiers_result(object):
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
             for iter1039 in self.success:
-                oprot.writeString(iter1039.encode('utf-8') if sys.version_info[0] == 2 else iter1039)
+                oprot.writeString(iter1039)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -31369,7 +31368,7 @@ class get_all_token_identifiers_result(object):
         return not (self == other)
 all_structs.append(get_all_token_identifiers_result)
 get_all_token_identifiers_result.thrift_spec = (
-    (0, TType.LIST, 'success', (TType.STRING, 'UTF8', False), None, ),  # 0
+    (0, TType.LIST, 'success', (TType.STRING, None, False), None, ),  # 0
 )
 
 
@@ -31394,7 +31393,7 @@ class add_master_key_args(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.key = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.key = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -31409,7 +31408,7 @@ class add_master_key_args(object):
         oprot.writeStructBegin('add_master_key_args')
         if self.key is not None:
             oprot.writeFieldBegin('key', TType.STRING, 1)
-            oprot.writeString(self.key.encode('utf-8') if sys.version_info[0] == 2 else self.key)
+            oprot.writeString(self.key)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -31430,7 +31429,7 @@ class add_master_key_args(object):
 all_structs.append(add_master_key_args)
 add_master_key_args.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'key', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'key', None, None, ),  # 1
 )
 
 
@@ -31535,7 +31534,7 @@ class update_master_key_args(object):
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.key = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.key = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -31554,7 +31553,7 @@ class update_master_key_args(object):
             oprot.writeFieldEnd()
         if self.key is not None:
             oprot.writeFieldBegin('key', TType.STRING, 2)
-            oprot.writeString(self.key.encode('utf-8') if sys.version_info[0] == 2 else self.key)
+            oprot.writeString(self.key)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -31576,7 +31575,7 @@ all_structs.append(update_master_key_args)
 update_master_key_args.thrift_spec = (
     None,  # 0
     (1, TType.I32, 'seq_number', None, None, ),  # 1
-    (2, TType.STRING, 'key', 'UTF8', None, ),  # 2
+    (2, TType.STRING, 'key', None, None, ),  # 2
 )
 
 
@@ -31843,7 +31842,7 @@ class get_master_keys_result(object):
                     self.success = []
                     (_etype1043, _size1040) = iprot.readListBegin()
                     for _i1044 in range(_size1040):
-                        _elem1045 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem1045 = iprot.readString()
                         self.success.append(_elem1045)
                     iprot.readListEnd()
                 else:
@@ -31862,7 +31861,7 @@ class get_master_keys_result(object):
             oprot.writeFieldBegin('success', TType.LIST, 0)
             oprot.writeListBegin(TType.STRING, len(self.success))
             for iter1046 in self.success:
-                oprot.writeString(iter1046.encode('utf-8') if sys.version_info[0] == 2 else iter1046)
+                oprot.writeString(iter1046)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -31883,7 +31882,7 @@ class get_master_keys_result(object):
         return not (self == other)
 all_structs.append(get_master_keys_result)
 get_master_keys_result.thrift_spec = (
-    (0, TType.LIST, 'success', (TType.STRING, 'UTF8', False), None, ),  # 0
+    (0, TType.LIST, 'success', (TType.STRING, None, False), None, ),  # 0
 )
 
 
@@ -34929,7 +34928,7 @@ class get_metastore_db_uuid_result(object):
                 break
             if fid == 0:
                 if ftype == TType.STRING:
-                    self.success = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.success = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 1:
@@ -34950,7 +34949,7 @@ class get_metastore_db_uuid_result(object):
         oprot.writeStructBegin('get_metastore_db_uuid_result')
         if self.success is not None:
             oprot.writeFieldBegin('success', TType.STRING, 0)
-            oprot.writeString(self.success.encode('utf-8') if sys.version_info[0] == 2 else self.success)
+            oprot.writeString(self.success)
             oprot.writeFieldEnd()
         if self.o1 is not None:
             oprot.writeFieldBegin('o1', TType.STRUCT, 1)
@@ -34974,7 +34973,7 @@ class get_metastore_db_uuid_result(object):
         return not (self == other)
 all_structs.append(get_metastore_db_uuid_result)
 get_metastore_db_uuid_result.thrift_spec = (
-    (0, TType.STRING, 'success', 'UTF8', None, ),  # 0
+    (0, TType.STRING, 'success', None, None, ),  # 0
     (1, TType.STRUCT, 'o1', [MetaException, None], None, ),  # 1
 )
 

--- a/impala/_thrift_gen/hive_metastore/constants.py
+++ b/impala/_thrift_gen/hive_metastore/constants.py
@@ -3,14 +3,13 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.TRecursive import fix_spec
 
-import sys
 from .ttypes import *
 DDL_TIME = "transient_lastDdlTime"
 HIVE_FILTER_FIELD_OWNER = "hive_filter_field_owner__"

--- a/impala/_thrift_gen/hive_metastore/ttypes.py
+++ b/impala/_thrift_gen/hive_metastore/ttypes.py
@@ -3,14 +3,13 @@
 #
 # DO NOT EDIT UNLESS YOU ARE SURE THAT YOU KNOW WHAT YOU ARE DOING
 #
-#  options string: py:new_style
+#  options string: py:new_style,no_utf8strings
 #
 
 from thrift.Thrift import TType, TMessageType, TFrozenDict, TException, TApplicationException
 from thrift.protocol.TProtocol import TProtocolException
 from thrift.TRecursive import fix_spec
 
-import sys
 import impala._thrift_gen.fb303.ttypes
 
 from thrift.transport import TTransport
@@ -304,12 +303,12 @@ class Version(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.version = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.version = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.comments = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.comments = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -324,11 +323,11 @@ class Version(object):
         oprot.writeStructBegin('Version')
         if self.version is not None:
             oprot.writeFieldBegin('version', TType.STRING, 1)
-            oprot.writeString(self.version.encode('utf-8') if sys.version_info[0] == 2 else self.version)
+            oprot.writeString(self.version)
             oprot.writeFieldEnd()
         if self.comments is not None:
             oprot.writeFieldBegin('comments', TType.STRING, 2)
-            oprot.writeString(self.comments.encode('utf-8') if sys.version_info[0] == 2 else self.comments)
+            oprot.writeString(self.comments)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -373,17 +372,17 @@ class FieldSchema(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.type = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.type = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.comment = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.comment = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -398,15 +397,15 @@ class FieldSchema(object):
         oprot.writeStructBegin('FieldSchema')
         if self.name is not None:
             oprot.writeFieldBegin('name', TType.STRING, 1)
-            oprot.writeString(self.name.encode('utf-8') if sys.version_info[0] == 2 else self.name)
+            oprot.writeString(self.name)
             oprot.writeFieldEnd()
         if self.type is not None:
             oprot.writeFieldBegin('type', TType.STRING, 2)
-            oprot.writeString(self.type.encode('utf-8') if sys.version_info[0] == 2 else self.type)
+            oprot.writeString(self.type)
             oprot.writeFieldEnd()
         if self.comment is not None:
             oprot.writeFieldBegin('comment', TType.STRING, 3)
-            oprot.writeString(self.comment.encode('utf-8') if sys.version_info[0] == 2 else self.comment)
+            oprot.writeString(self.comment)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -461,17 +460,17 @@ class SQLPrimaryKey(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.table_db = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.table_db = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.table_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.table_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.column_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.column_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
@@ -481,7 +480,7 @@ class SQLPrimaryKey(object):
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.STRING:
-                    self.pk_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.pk_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 6:
@@ -511,15 +510,15 @@ class SQLPrimaryKey(object):
         oprot.writeStructBegin('SQLPrimaryKey')
         if self.table_db is not None:
             oprot.writeFieldBegin('table_db', TType.STRING, 1)
-            oprot.writeString(self.table_db.encode('utf-8') if sys.version_info[0] == 2 else self.table_db)
+            oprot.writeString(self.table_db)
             oprot.writeFieldEnd()
         if self.table_name is not None:
             oprot.writeFieldBegin('table_name', TType.STRING, 2)
-            oprot.writeString(self.table_name.encode('utf-8') if sys.version_info[0] == 2 else self.table_name)
+            oprot.writeString(self.table_name)
             oprot.writeFieldEnd()
         if self.column_name is not None:
             oprot.writeFieldBegin('column_name', TType.STRING, 3)
-            oprot.writeString(self.column_name.encode('utf-8') if sys.version_info[0] == 2 else self.column_name)
+            oprot.writeString(self.column_name)
             oprot.writeFieldEnd()
         if self.key_seq is not None:
             oprot.writeFieldBegin('key_seq', TType.I32, 4)
@@ -527,7 +526,7 @@ class SQLPrimaryKey(object):
             oprot.writeFieldEnd()
         if self.pk_name is not None:
             oprot.writeFieldBegin('pk_name', TType.STRING, 5)
-            oprot.writeString(self.pk_name.encode('utf-8') if sys.version_info[0] == 2 else self.pk_name)
+            oprot.writeString(self.pk_name)
             oprot.writeFieldEnd()
         if self.enable_cstr is not None:
             oprot.writeFieldBegin('enable_cstr', TType.BOOL, 6)
@@ -606,32 +605,32 @@ class SQLForeignKey(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.pktable_db = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.pktable_db = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.pktable_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.pktable_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.pkcolumn_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.pkcolumn_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.fktable_db = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.fktable_db = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.STRING:
-                    self.fktable_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.fktable_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 6:
                 if ftype == TType.STRING:
-                    self.fkcolumn_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.fkcolumn_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 7:
@@ -651,12 +650,12 @@ class SQLForeignKey(object):
                     iprot.skip(ftype)
             elif fid == 10:
                 if ftype == TType.STRING:
-                    self.fk_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.fk_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 11:
                 if ftype == TType.STRING:
-                    self.pk_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.pk_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 12:
@@ -686,27 +685,27 @@ class SQLForeignKey(object):
         oprot.writeStructBegin('SQLForeignKey')
         if self.pktable_db is not None:
             oprot.writeFieldBegin('pktable_db', TType.STRING, 1)
-            oprot.writeString(self.pktable_db.encode('utf-8') if sys.version_info[0] == 2 else self.pktable_db)
+            oprot.writeString(self.pktable_db)
             oprot.writeFieldEnd()
         if self.pktable_name is not None:
             oprot.writeFieldBegin('pktable_name', TType.STRING, 2)
-            oprot.writeString(self.pktable_name.encode('utf-8') if sys.version_info[0] == 2 else self.pktable_name)
+            oprot.writeString(self.pktable_name)
             oprot.writeFieldEnd()
         if self.pkcolumn_name is not None:
             oprot.writeFieldBegin('pkcolumn_name', TType.STRING, 3)
-            oprot.writeString(self.pkcolumn_name.encode('utf-8') if sys.version_info[0] == 2 else self.pkcolumn_name)
+            oprot.writeString(self.pkcolumn_name)
             oprot.writeFieldEnd()
         if self.fktable_db is not None:
             oprot.writeFieldBegin('fktable_db', TType.STRING, 4)
-            oprot.writeString(self.fktable_db.encode('utf-8') if sys.version_info[0] == 2 else self.fktable_db)
+            oprot.writeString(self.fktable_db)
             oprot.writeFieldEnd()
         if self.fktable_name is not None:
             oprot.writeFieldBegin('fktable_name', TType.STRING, 5)
-            oprot.writeString(self.fktable_name.encode('utf-8') if sys.version_info[0] == 2 else self.fktable_name)
+            oprot.writeString(self.fktable_name)
             oprot.writeFieldEnd()
         if self.fkcolumn_name is not None:
             oprot.writeFieldBegin('fkcolumn_name', TType.STRING, 6)
-            oprot.writeString(self.fkcolumn_name.encode('utf-8') if sys.version_info[0] == 2 else self.fkcolumn_name)
+            oprot.writeString(self.fkcolumn_name)
             oprot.writeFieldEnd()
         if self.key_seq is not None:
             oprot.writeFieldBegin('key_seq', TType.I32, 7)
@@ -722,11 +721,11 @@ class SQLForeignKey(object):
             oprot.writeFieldEnd()
         if self.fk_name is not None:
             oprot.writeFieldBegin('fk_name', TType.STRING, 10)
-            oprot.writeString(self.fk_name.encode('utf-8') if sys.version_info[0] == 2 else self.fk_name)
+            oprot.writeString(self.fk_name)
             oprot.writeFieldEnd()
         if self.pk_name is not None:
             oprot.writeFieldBegin('pk_name', TType.STRING, 11)
-            oprot.writeString(self.pk_name.encode('utf-8') if sys.version_info[0] == 2 else self.pk_name)
+            oprot.writeString(self.pk_name)
             oprot.writeFieldEnd()
         if self.enable_cstr is not None:
             oprot.writeFieldBegin('enable_cstr', TType.BOOL, 12)
@@ -785,17 +784,17 @@ class Type(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.type1 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.type1 = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.type2 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.type2 = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
@@ -821,15 +820,15 @@ class Type(object):
         oprot.writeStructBegin('Type')
         if self.name is not None:
             oprot.writeFieldBegin('name', TType.STRING, 1)
-            oprot.writeString(self.name.encode('utf-8') if sys.version_info[0] == 2 else self.name)
+            oprot.writeString(self.name)
             oprot.writeFieldEnd()
         if self.type1 is not None:
             oprot.writeFieldBegin('type1', TType.STRING, 2)
-            oprot.writeString(self.type1.encode('utf-8') if sys.version_info[0] == 2 else self.type1)
+            oprot.writeString(self.type1)
             oprot.writeFieldEnd()
         if self.type2 is not None:
             oprot.writeFieldBegin('type2', TType.STRING, 3)
-            oprot.writeString(self.type2.encode('utf-8') if sys.version_info[0] == 2 else self.type2)
+            oprot.writeString(self.type2)
             oprot.writeFieldEnd()
         if self.fields is not None:
             oprot.writeFieldBegin('fields', TType.LIST, 4)
@@ -890,12 +889,12 @@ class HiveObjectRef(object):
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.dbName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.objectName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.objectName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
@@ -903,14 +902,14 @@ class HiveObjectRef(object):
                     self.partValues = []
                     (_etype10, _size7) = iprot.readListBegin()
                     for _i11 in range(_size7):
-                        _elem12 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem12 = iprot.readString()
                         self.partValues.append(_elem12)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.STRING:
-                    self.columnName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.columnName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -929,22 +928,22 @@ class HiveObjectRef(object):
             oprot.writeFieldEnd()
         if self.dbName is not None:
             oprot.writeFieldBegin('dbName', TType.STRING, 2)
-            oprot.writeString(self.dbName.encode('utf-8') if sys.version_info[0] == 2 else self.dbName)
+            oprot.writeString(self.dbName)
             oprot.writeFieldEnd()
         if self.objectName is not None:
             oprot.writeFieldBegin('objectName', TType.STRING, 3)
-            oprot.writeString(self.objectName.encode('utf-8') if sys.version_info[0] == 2 else self.objectName)
+            oprot.writeString(self.objectName)
             oprot.writeFieldEnd()
         if self.partValues is not None:
             oprot.writeFieldBegin('partValues', TType.LIST, 4)
             oprot.writeListBegin(TType.STRING, len(self.partValues))
             for iter13 in self.partValues:
-                oprot.writeString(iter13.encode('utf-8') if sys.version_info[0] == 2 else iter13)
+                oprot.writeString(iter13)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.columnName is not None:
             oprot.writeFieldBegin('columnName', TType.STRING, 5)
-            oprot.writeString(self.columnName.encode('utf-8') if sys.version_info[0] == 2 else self.columnName)
+            oprot.writeString(self.columnName)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -993,7 +992,7 @@ class PrivilegeGrantInfo(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.privilege = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.privilege = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
@@ -1003,7 +1002,7 @@ class PrivilegeGrantInfo(object):
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.grantor = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.grantor = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
@@ -1028,7 +1027,7 @@ class PrivilegeGrantInfo(object):
         oprot.writeStructBegin('PrivilegeGrantInfo')
         if self.privilege is not None:
             oprot.writeFieldBegin('privilege', TType.STRING, 1)
-            oprot.writeString(self.privilege.encode('utf-8') if sys.version_info[0] == 2 else self.privilege)
+            oprot.writeString(self.privilege)
             oprot.writeFieldEnd()
         if self.createTime is not None:
             oprot.writeFieldBegin('createTime', TType.I32, 2)
@@ -1036,7 +1035,7 @@ class PrivilegeGrantInfo(object):
             oprot.writeFieldEnd()
         if self.grantor is not None:
             oprot.writeFieldBegin('grantor', TType.STRING, 3)
-            oprot.writeString(self.grantor.encode('utf-8') if sys.version_info[0] == 2 else self.grantor)
+            oprot.writeString(self.grantor)
             oprot.writeFieldEnd()
         if self.grantorType is not None:
             oprot.writeFieldBegin('grantorType', TType.I32, 4)
@@ -1097,7 +1096,7 @@ class HiveObjectPrivilege(object):
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.principalName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.principalName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -1127,7 +1126,7 @@ class HiveObjectPrivilege(object):
             oprot.writeFieldEnd()
         if self.principalName is not None:
             oprot.writeFieldBegin('principalName', TType.STRING, 2)
-            oprot.writeString(self.principalName.encode('utf-8') if sys.version_info[0] == 2 else self.principalName)
+            oprot.writeString(self.principalName)
             oprot.writeFieldEnd()
         if self.principalType is not None:
             oprot.writeFieldBegin('principalType', TType.I32, 3)
@@ -1248,7 +1247,7 @@ class PrincipalPrivilegeSet(object):
                     self.userPrivileges = {}
                     (_ktype22, _vtype23, _size21) = iprot.readMapBegin()
                     for _i25 in range(_size21):
-                        _key26 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key26 = iprot.readString()
                         _val27 = []
                         (_etype31, _size28) = iprot.readListBegin()
                         for _i32 in range(_size28):
@@ -1265,7 +1264,7 @@ class PrincipalPrivilegeSet(object):
                     self.groupPrivileges = {}
                     (_ktype35, _vtype36, _size34) = iprot.readMapBegin()
                     for _i38 in range(_size34):
-                        _key39 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key39 = iprot.readString()
                         _val40 = []
                         (_etype44, _size41) = iprot.readListBegin()
                         for _i45 in range(_size41):
@@ -1282,7 +1281,7 @@ class PrincipalPrivilegeSet(object):
                     self.rolePrivileges = {}
                     (_ktype48, _vtype49, _size47) = iprot.readMapBegin()
                     for _i51 in range(_size47):
-                        _key52 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key52 = iprot.readString()
                         _val53 = []
                         (_etype57, _size54) = iprot.readListBegin()
                         for _i58 in range(_size54):
@@ -1308,7 +1307,7 @@ class PrincipalPrivilegeSet(object):
             oprot.writeFieldBegin('userPrivileges', TType.MAP, 1)
             oprot.writeMapBegin(TType.STRING, TType.LIST, len(self.userPrivileges))
             for kiter60, viter61 in self.userPrivileges.items():
-                oprot.writeString(kiter60.encode('utf-8') if sys.version_info[0] == 2 else kiter60)
+                oprot.writeString(kiter60)
                 oprot.writeListBegin(TType.STRUCT, len(viter61))
                 for iter62 in viter61:
                     iter62.write(oprot)
@@ -1319,7 +1318,7 @@ class PrincipalPrivilegeSet(object):
             oprot.writeFieldBegin('groupPrivileges', TType.MAP, 2)
             oprot.writeMapBegin(TType.STRING, TType.LIST, len(self.groupPrivileges))
             for kiter63, viter64 in self.groupPrivileges.items():
-                oprot.writeString(kiter63.encode('utf-8') if sys.version_info[0] == 2 else kiter63)
+                oprot.writeString(kiter63)
                 oprot.writeListBegin(TType.STRUCT, len(viter64))
                 for iter65 in viter64:
                     iter65.write(oprot)
@@ -1330,7 +1329,7 @@ class PrincipalPrivilegeSet(object):
             oprot.writeFieldBegin('rolePrivileges', TType.MAP, 3)
             oprot.writeMapBegin(TType.STRING, TType.LIST, len(self.rolePrivileges))
             for kiter66, viter67 in self.rolePrivileges.items():
-                oprot.writeString(kiter66.encode('utf-8') if sys.version_info[0] == 2 else kiter66)
+                oprot.writeString(kiter66)
                 oprot.writeListBegin(TType.STRUCT, len(viter67))
                 for iter68 in viter67:
                     iter68.write(oprot)
@@ -1515,7 +1514,7 @@ class Role(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.roleName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.roleName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
@@ -1525,7 +1524,7 @@ class Role(object):
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.ownerName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.ownerName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -1540,7 +1539,7 @@ class Role(object):
         oprot.writeStructBegin('Role')
         if self.roleName is not None:
             oprot.writeFieldBegin('roleName', TType.STRING, 1)
-            oprot.writeString(self.roleName.encode('utf-8') if sys.version_info[0] == 2 else self.roleName)
+            oprot.writeString(self.roleName)
             oprot.writeFieldEnd()
         if self.createTime is not None:
             oprot.writeFieldBegin('createTime', TType.I32, 2)
@@ -1548,7 +1547,7 @@ class Role(object):
             oprot.writeFieldEnd()
         if self.ownerName is not None:
             oprot.writeFieldBegin('ownerName', TType.STRING, 3)
-            oprot.writeString(self.ownerName.encode('utf-8') if sys.version_info[0] == 2 else self.ownerName)
+            oprot.writeString(self.ownerName)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -1601,12 +1600,12 @@ class RolePrincipalGrant(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.roleName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.roleName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.principalName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.principalName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -1626,7 +1625,7 @@ class RolePrincipalGrant(object):
                     iprot.skip(ftype)
             elif fid == 6:
                 if ftype == TType.STRING:
-                    self.grantorName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.grantorName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 7:
@@ -1646,11 +1645,11 @@ class RolePrincipalGrant(object):
         oprot.writeStructBegin('RolePrincipalGrant')
         if self.roleName is not None:
             oprot.writeFieldBegin('roleName', TType.STRING, 1)
-            oprot.writeString(self.roleName.encode('utf-8') if sys.version_info[0] == 2 else self.roleName)
+            oprot.writeString(self.roleName)
             oprot.writeFieldEnd()
         if self.principalName is not None:
             oprot.writeFieldBegin('principalName', TType.STRING, 2)
-            oprot.writeString(self.principalName.encode('utf-8') if sys.version_info[0] == 2 else self.principalName)
+            oprot.writeString(self.principalName)
             oprot.writeFieldEnd()
         if self.principalType is not None:
             oprot.writeFieldBegin('principalType', TType.I32, 3)
@@ -1666,7 +1665,7 @@ class RolePrincipalGrant(object):
             oprot.writeFieldEnd()
         if self.grantorName is not None:
             oprot.writeFieldBegin('grantorName', TType.STRING, 6)
-            oprot.writeString(self.grantorName.encode('utf-8') if sys.version_info[0] == 2 else self.grantorName)
+            oprot.writeString(self.grantorName)
             oprot.writeFieldEnd()
         if self.grantorPrincipalType is not None:
             oprot.writeFieldBegin('grantorPrincipalType', TType.I32, 7)
@@ -1713,7 +1712,7 @@ class GetRoleGrantsForPrincipalRequest(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.principal_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.principal_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
@@ -1733,7 +1732,7 @@ class GetRoleGrantsForPrincipalRequest(object):
         oprot.writeStructBegin('GetRoleGrantsForPrincipalRequest')
         if self.principal_name is not None:
             oprot.writeFieldBegin('principal_name', TType.STRING, 1)
-            oprot.writeString(self.principal_name.encode('utf-8') if sys.version_info[0] == 2 else self.principal_name)
+            oprot.writeString(self.principal_name)
             oprot.writeFieldEnd()
         if self.principal_type is not None:
             oprot.writeFieldBegin('principal_type', TType.I32, 2)
@@ -1849,7 +1848,7 @@ class GetPrincipalsInRoleRequest(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.roleName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.roleName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -1864,7 +1863,7 @@ class GetPrincipalsInRoleRequest(object):
         oprot.writeStructBegin('GetPrincipalsInRoleRequest')
         if self.roleName is not None:
             oprot.writeFieldBegin('roleName', TType.STRING, 1)
-            oprot.writeString(self.roleName.encode('utf-8') if sys.version_info[0] == 2 else self.roleName)
+            oprot.writeString(self.roleName)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -1991,12 +1990,12 @@ class GrantRevokeRoleRequest(object):
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.roleName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.roleName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.principalName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.principalName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
@@ -2006,7 +2005,7 @@ class GrantRevokeRoleRequest(object):
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.STRING:
-                    self.grantor = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.grantor = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 6:
@@ -2035,11 +2034,11 @@ class GrantRevokeRoleRequest(object):
             oprot.writeFieldEnd()
         if self.roleName is not None:
             oprot.writeFieldBegin('roleName', TType.STRING, 2)
-            oprot.writeString(self.roleName.encode('utf-8') if sys.version_info[0] == 2 else self.roleName)
+            oprot.writeString(self.roleName)
             oprot.writeFieldEnd()
         if self.principalName is not None:
             oprot.writeFieldBegin('principalName', TType.STRING, 3)
-            oprot.writeString(self.principalName.encode('utf-8') if sys.version_info[0] == 2 else self.principalName)
+            oprot.writeString(self.principalName)
             oprot.writeFieldEnd()
         if self.principalType is not None:
             oprot.writeFieldBegin('principalType', TType.I32, 4)
@@ -2047,7 +2046,7 @@ class GrantRevokeRoleRequest(object):
             oprot.writeFieldEnd()
         if self.grantor is not None:
             oprot.writeFieldBegin('grantor', TType.STRING, 5)
-            oprot.writeString(self.grantor.encode('utf-8') if sys.version_info[0] == 2 else self.grantor)
+            oprot.writeString(self.grantor)
             oprot.writeFieldEnd()
         if self.grantorType is not None:
             oprot.writeFieldBegin('grantorType', TType.I32, 6)
@@ -2166,17 +2165,17 @@ class Database(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.description = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.description = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.locationUri = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.locationUri = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
@@ -2184,8 +2183,8 @@ class Database(object):
                     self.parameters = {}
                     (_ktype84, _vtype85, _size83) = iprot.readMapBegin()
                     for _i87 in range(_size83):
-                        _key88 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val89 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key88 = iprot.readString()
+                        _val89 = iprot.readString()
                         self.parameters[_key88] = _val89
                     iprot.readMapEnd()
                 else:
@@ -2198,7 +2197,7 @@ class Database(object):
                     iprot.skip(ftype)
             elif fid == 6:
                 if ftype == TType.STRING:
-                    self.ownerName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.ownerName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 7:
@@ -2223,22 +2222,22 @@ class Database(object):
         oprot.writeStructBegin('Database')
         if self.name is not None:
             oprot.writeFieldBegin('name', TType.STRING, 1)
-            oprot.writeString(self.name.encode('utf-8') if sys.version_info[0] == 2 else self.name)
+            oprot.writeString(self.name)
             oprot.writeFieldEnd()
         if self.description is not None:
             oprot.writeFieldBegin('description', TType.STRING, 2)
-            oprot.writeString(self.description.encode('utf-8') if sys.version_info[0] == 2 else self.description)
+            oprot.writeString(self.description)
             oprot.writeFieldEnd()
         if self.locationUri is not None:
             oprot.writeFieldBegin('locationUri', TType.STRING, 3)
-            oprot.writeString(self.locationUri.encode('utf-8') if sys.version_info[0] == 2 else self.locationUri)
+            oprot.writeString(self.locationUri)
             oprot.writeFieldEnd()
         if self.parameters is not None:
             oprot.writeFieldBegin('parameters', TType.MAP, 4)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.parameters))
             for kiter90, viter91 in self.parameters.items():
-                oprot.writeString(kiter90.encode('utf-8') if sys.version_info[0] == 2 else kiter90)
-                oprot.writeString(viter91.encode('utf-8') if sys.version_info[0] == 2 else viter91)
+                oprot.writeString(kiter90)
+                oprot.writeString(viter91)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.privileges is not None:
@@ -2247,7 +2246,7 @@ class Database(object):
             oprot.writeFieldEnd()
         if self.ownerName is not None:
             oprot.writeFieldBegin('ownerName', TType.STRING, 6)
-            oprot.writeString(self.ownerName.encode('utf-8') if sys.version_info[0] == 2 else self.ownerName)
+            oprot.writeString(self.ownerName)
             oprot.writeFieldEnd()
         if self.ownerType is not None:
             oprot.writeFieldBegin('ownerType', TType.I32, 7)
@@ -2300,12 +2299,12 @@ class SerDeInfo(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.serializationLib = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.serializationLib = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -2313,8 +2312,8 @@ class SerDeInfo(object):
                     self.parameters = {}
                     (_ktype93, _vtype94, _size92) = iprot.readMapBegin()
                     for _i96 in range(_size92):
-                        _key97 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val98 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key97 = iprot.readString()
+                        _val98 = iprot.readString()
                         self.parameters[_key97] = _val98
                     iprot.readMapEnd()
                 else:
@@ -2331,18 +2330,18 @@ class SerDeInfo(object):
         oprot.writeStructBegin('SerDeInfo')
         if self.name is not None:
             oprot.writeFieldBegin('name', TType.STRING, 1)
-            oprot.writeString(self.name.encode('utf-8') if sys.version_info[0] == 2 else self.name)
+            oprot.writeString(self.name)
             oprot.writeFieldEnd()
         if self.serializationLib is not None:
             oprot.writeFieldBegin('serializationLib', TType.STRING, 2)
-            oprot.writeString(self.serializationLib.encode('utf-8') if sys.version_info[0] == 2 else self.serializationLib)
+            oprot.writeString(self.serializationLib)
             oprot.writeFieldEnd()
         if self.parameters is not None:
             oprot.writeFieldBegin('parameters', TType.MAP, 3)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.parameters))
             for kiter99, viter100 in self.parameters.items():
-                oprot.writeString(kiter99.encode('utf-8') if sys.version_info[0] == 2 else kiter99)
-                oprot.writeString(viter100.encode('utf-8') if sys.version_info[0] == 2 else viter100)
+                oprot.writeString(kiter99)
+                oprot.writeString(viter100)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -2386,7 +2385,7 @@ class Order(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.col = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.col = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
@@ -2406,7 +2405,7 @@ class Order(object):
         oprot.writeStructBegin('Order')
         if self.col is not None:
             oprot.writeFieldBegin('col', TType.STRING, 1)
-            oprot.writeString(self.col.encode('utf-8') if sys.version_info[0] == 2 else self.col)
+            oprot.writeString(self.col)
             oprot.writeFieldEnd()
         if self.order is not None:
             oprot.writeFieldBegin('order', TType.I32, 2)
@@ -2458,7 +2457,7 @@ class SkewedInfo(object):
                     self.skewedColNames = []
                     (_etype104, _size101) = iprot.readListBegin()
                     for _i105 in range(_size101):
-                        _elem106 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem106 = iprot.readString()
                         self.skewedColNames.append(_elem106)
                     iprot.readListEnd()
                 else:
@@ -2471,7 +2470,7 @@ class SkewedInfo(object):
                         _elem112 = []
                         (_etype116, _size113) = iprot.readListBegin()
                         for _i117 in range(_size113):
-                            _elem118 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                            _elem118 = iprot.readString()
                             _elem112.append(_elem118)
                         iprot.readListEnd()
                         self.skewedColValues.append(_elem112)
@@ -2486,10 +2485,10 @@ class SkewedInfo(object):
                         _key124 = []
                         (_etype129, _size126) = iprot.readListBegin()
                         for _i130 in range(_size126):
-                            _elem131 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                            _elem131 = iprot.readString()
                             _key124.append(_elem131)
                         iprot.readListEnd()
-                        _val125 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _val125 = iprot.readString()
                         self.skewedColValueLocationMaps[_key124] = _val125
                     iprot.readMapEnd()
                 else:
@@ -2508,7 +2507,7 @@ class SkewedInfo(object):
             oprot.writeFieldBegin('skewedColNames', TType.LIST, 1)
             oprot.writeListBegin(TType.STRING, len(self.skewedColNames))
             for iter132 in self.skewedColNames:
-                oprot.writeString(iter132.encode('utf-8') if sys.version_info[0] == 2 else iter132)
+                oprot.writeString(iter132)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.skewedColValues is not None:
@@ -2517,7 +2516,7 @@ class SkewedInfo(object):
             for iter133 in self.skewedColValues:
                 oprot.writeListBegin(TType.STRING, len(iter133))
                 for iter134 in iter133:
-                    oprot.writeString(iter134.encode('utf-8') if sys.version_info[0] == 2 else iter134)
+                    oprot.writeString(iter134)
                 oprot.writeListEnd()
             oprot.writeListEnd()
             oprot.writeFieldEnd()
@@ -2527,9 +2526,9 @@ class SkewedInfo(object):
             for kiter135, viter136 in self.skewedColValueLocationMaps.items():
                 oprot.writeListBegin(TType.STRING, len(kiter135))
                 for iter137 in kiter135:
-                    oprot.writeString(iter137.encode('utf-8') if sys.version_info[0] == 2 else iter137)
+                    oprot.writeString(iter137)
                 oprot.writeListEnd()
-                oprot.writeString(viter136.encode('utf-8') if sys.version_info[0] == 2 else viter136)
+                oprot.writeString(viter136)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -2604,17 +2603,17 @@ class StorageDescriptor(object):
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.location = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.location = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.inputFormat = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.inputFormat = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.outputFormat = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.outputFormat = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 5:
@@ -2638,7 +2637,7 @@ class StorageDescriptor(object):
                     self.bucketCols = []
                     (_etype147, _size144) = iprot.readListBegin()
                     for _i148 in range(_size144):
-                        _elem149 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem149 = iprot.readString()
                         self.bucketCols.append(_elem149)
                     iprot.readListEnd()
                 else:
@@ -2659,8 +2658,8 @@ class StorageDescriptor(object):
                     self.parameters = {}
                     (_ktype157, _vtype158, _size156) = iprot.readMapBegin()
                     for _i160 in range(_size156):
-                        _key161 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val162 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key161 = iprot.readString()
+                        _val162 = iprot.readString()
                         self.parameters[_key161] = _val162
                     iprot.readMapEnd()
                 else:
@@ -2695,15 +2694,15 @@ class StorageDescriptor(object):
             oprot.writeFieldEnd()
         if self.location is not None:
             oprot.writeFieldBegin('location', TType.STRING, 2)
-            oprot.writeString(self.location.encode('utf-8') if sys.version_info[0] == 2 else self.location)
+            oprot.writeString(self.location)
             oprot.writeFieldEnd()
         if self.inputFormat is not None:
             oprot.writeFieldBegin('inputFormat', TType.STRING, 3)
-            oprot.writeString(self.inputFormat.encode('utf-8') if sys.version_info[0] == 2 else self.inputFormat)
+            oprot.writeString(self.inputFormat)
             oprot.writeFieldEnd()
         if self.outputFormat is not None:
             oprot.writeFieldBegin('outputFormat', TType.STRING, 4)
-            oprot.writeString(self.outputFormat.encode('utf-8') if sys.version_info[0] == 2 else self.outputFormat)
+            oprot.writeString(self.outputFormat)
             oprot.writeFieldEnd()
         if self.compressed is not None:
             oprot.writeFieldBegin('compressed', TType.BOOL, 5)
@@ -2721,7 +2720,7 @@ class StorageDescriptor(object):
             oprot.writeFieldBegin('bucketCols', TType.LIST, 8)
             oprot.writeListBegin(TType.STRING, len(self.bucketCols))
             for iter164 in self.bucketCols:
-                oprot.writeString(iter164.encode('utf-8') if sys.version_info[0] == 2 else iter164)
+                oprot.writeString(iter164)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.sortCols is not None:
@@ -2735,8 +2734,8 @@ class StorageDescriptor(object):
             oprot.writeFieldBegin('parameters', TType.MAP, 10)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.parameters))
             for kiter166, viter167 in self.parameters.items():
-                oprot.writeString(kiter166.encode('utf-8') if sys.version_info[0] == 2 else kiter166)
-                oprot.writeString(viter167.encode('utf-8') if sys.version_info[0] == 2 else viter167)
+                oprot.writeString(kiter166)
+                oprot.writeString(viter167)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.skewedInfo is not None:
@@ -2814,17 +2813,17 @@ class Table(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.tableName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tableName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.dbName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.owner = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.owner = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
@@ -2864,25 +2863,25 @@ class Table(object):
                     self.parameters = {}
                     (_ktype175, _vtype176, _size174) = iprot.readMapBegin()
                     for _i178 in range(_size174):
-                        _key179 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val180 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key179 = iprot.readString()
+                        _val180 = iprot.readString()
                         self.parameters[_key179] = _val180
                     iprot.readMapEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 10:
                 if ftype == TType.STRING:
-                    self.viewOriginalText = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.viewOriginalText = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 11:
                 if ftype == TType.STRING:
-                    self.viewExpandedText = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.viewExpandedText = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 12:
                 if ftype == TType.STRING:
-                    self.tableType = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tableType = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 13:
@@ -2913,15 +2912,15 @@ class Table(object):
         oprot.writeStructBegin('Table')
         if self.tableName is not None:
             oprot.writeFieldBegin('tableName', TType.STRING, 1)
-            oprot.writeString(self.tableName.encode('utf-8') if sys.version_info[0] == 2 else self.tableName)
+            oprot.writeString(self.tableName)
             oprot.writeFieldEnd()
         if self.dbName is not None:
             oprot.writeFieldBegin('dbName', TType.STRING, 2)
-            oprot.writeString(self.dbName.encode('utf-8') if sys.version_info[0] == 2 else self.dbName)
+            oprot.writeString(self.dbName)
             oprot.writeFieldEnd()
         if self.owner is not None:
             oprot.writeFieldBegin('owner', TType.STRING, 3)
-            oprot.writeString(self.owner.encode('utf-8') if sys.version_info[0] == 2 else self.owner)
+            oprot.writeString(self.owner)
             oprot.writeFieldEnd()
         if self.createTime is not None:
             oprot.writeFieldBegin('createTime', TType.I32, 4)
@@ -2950,21 +2949,21 @@ class Table(object):
             oprot.writeFieldBegin('parameters', TType.MAP, 9)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.parameters))
             for kiter182, viter183 in self.parameters.items():
-                oprot.writeString(kiter182.encode('utf-8') if sys.version_info[0] == 2 else kiter182)
-                oprot.writeString(viter183.encode('utf-8') if sys.version_info[0] == 2 else viter183)
+                oprot.writeString(kiter182)
+                oprot.writeString(viter183)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.viewOriginalText is not None:
             oprot.writeFieldBegin('viewOriginalText', TType.STRING, 10)
-            oprot.writeString(self.viewOriginalText.encode('utf-8') if sys.version_info[0] == 2 else self.viewOriginalText)
+            oprot.writeString(self.viewOriginalText)
             oprot.writeFieldEnd()
         if self.viewExpandedText is not None:
             oprot.writeFieldBegin('viewExpandedText', TType.STRING, 11)
-            oprot.writeString(self.viewExpandedText.encode('utf-8') if sys.version_info[0] == 2 else self.viewExpandedText)
+            oprot.writeString(self.viewExpandedText)
             oprot.writeFieldEnd()
         if self.tableType is not None:
             oprot.writeFieldBegin('tableType', TType.STRING, 12)
-            oprot.writeString(self.tableType.encode('utf-8') if sys.version_info[0] == 2 else self.tableType)
+            oprot.writeString(self.tableType)
             oprot.writeFieldEnd()
         if self.privileges is not None:
             oprot.writeFieldBegin('privileges', TType.STRUCT, 13)
@@ -3034,19 +3033,19 @@ class Partition(object):
                     self.values = []
                     (_etype187, _size184) = iprot.readListBegin()
                     for _i188 in range(_size184):
-                        _elem189 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem189 = iprot.readString()
                         self.values.append(_elem189)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.dbName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.tableName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tableName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
@@ -3070,8 +3069,8 @@ class Partition(object):
                     self.parameters = {}
                     (_ktype191, _vtype192, _size190) = iprot.readMapBegin()
                     for _i194 in range(_size190):
-                        _key195 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val196 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key195 = iprot.readString()
+                        _val196 = iprot.readString()
                         self.parameters[_key195] = _val196
                     iprot.readMapEnd()
                 else:
@@ -3096,16 +3095,16 @@ class Partition(object):
             oprot.writeFieldBegin('values', TType.LIST, 1)
             oprot.writeListBegin(TType.STRING, len(self.values))
             for iter197 in self.values:
-                oprot.writeString(iter197.encode('utf-8') if sys.version_info[0] == 2 else iter197)
+                oprot.writeString(iter197)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.dbName is not None:
             oprot.writeFieldBegin('dbName', TType.STRING, 2)
-            oprot.writeString(self.dbName.encode('utf-8') if sys.version_info[0] == 2 else self.dbName)
+            oprot.writeString(self.dbName)
             oprot.writeFieldEnd()
         if self.tableName is not None:
             oprot.writeFieldBegin('tableName', TType.STRING, 3)
-            oprot.writeString(self.tableName.encode('utf-8') if sys.version_info[0] == 2 else self.tableName)
+            oprot.writeString(self.tableName)
             oprot.writeFieldEnd()
         if self.createTime is not None:
             oprot.writeFieldBegin('createTime', TType.I32, 4)
@@ -3123,8 +3122,8 @@ class Partition(object):
             oprot.writeFieldBegin('parameters', TType.MAP, 7)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.parameters))
             for kiter198, viter199 in self.parameters.items():
-                oprot.writeString(kiter198.encode('utf-8') if sys.version_info[0] == 2 else kiter198)
-                oprot.writeString(viter199.encode('utf-8') if sys.version_info[0] == 2 else viter199)
+                oprot.writeString(kiter198)
+                oprot.writeString(viter199)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.privileges is not None:
@@ -3183,7 +3182,7 @@ class PartitionWithoutSD(object):
                     self.values = []
                     (_etype203, _size200) = iprot.readListBegin()
                     for _i204 in range(_size200):
-                        _elem205 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem205 = iprot.readString()
                         self.values.append(_elem205)
                     iprot.readListEnd()
                 else:
@@ -3200,7 +3199,7 @@ class PartitionWithoutSD(object):
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.relativePath = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.relativePath = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 5:
@@ -3208,8 +3207,8 @@ class PartitionWithoutSD(object):
                     self.parameters = {}
                     (_ktype207, _vtype208, _size206) = iprot.readMapBegin()
                     for _i210 in range(_size206):
-                        _key211 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val212 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key211 = iprot.readString()
+                        _val212 = iprot.readString()
                         self.parameters[_key211] = _val212
                     iprot.readMapEnd()
                 else:
@@ -3234,7 +3233,7 @@ class PartitionWithoutSD(object):
             oprot.writeFieldBegin('values', TType.LIST, 1)
             oprot.writeListBegin(TType.STRING, len(self.values))
             for iter213 in self.values:
-                oprot.writeString(iter213.encode('utf-8') if sys.version_info[0] == 2 else iter213)
+                oprot.writeString(iter213)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.createTime is not None:
@@ -3247,14 +3246,14 @@ class PartitionWithoutSD(object):
             oprot.writeFieldEnd()
         if self.relativePath is not None:
             oprot.writeFieldBegin('relativePath', TType.STRING, 4)
-            oprot.writeString(self.relativePath.encode('utf-8') if sys.version_info[0] == 2 else self.relativePath)
+            oprot.writeString(self.relativePath)
             oprot.writeFieldEnd()
         if self.parameters is not None:
             oprot.writeFieldBegin('parameters', TType.MAP, 5)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.parameters))
             for kiter214, viter215 in self.parameters.items():
-                oprot.writeString(kiter214.encode('utf-8') if sys.version_info[0] == 2 else kiter214)
-                oprot.writeString(viter215.encode('utf-8') if sys.version_info[0] == 2 else viter215)
+                oprot.writeString(kiter214)
+                oprot.writeString(viter215)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.privileges is not None:
@@ -3450,17 +3449,17 @@ class PartitionSpec(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.dbName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tableName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tableName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.rootPath = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.rootPath = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
@@ -3487,15 +3486,15 @@ class PartitionSpec(object):
         oprot.writeStructBegin('PartitionSpec')
         if self.dbName is not None:
             oprot.writeFieldBegin('dbName', TType.STRING, 1)
-            oprot.writeString(self.dbName.encode('utf-8') if sys.version_info[0] == 2 else self.dbName)
+            oprot.writeString(self.dbName)
             oprot.writeFieldEnd()
         if self.tableName is not None:
             oprot.writeFieldBegin('tableName', TType.STRING, 2)
-            oprot.writeString(self.tableName.encode('utf-8') if sys.version_info[0] == 2 else self.tableName)
+            oprot.writeString(self.tableName)
             oprot.writeFieldEnd()
         if self.rootPath is not None:
             oprot.writeFieldBegin('rootPath', TType.STRING, 3)
-            oprot.writeString(self.rootPath.encode('utf-8') if sys.version_info[0] == 2 else self.rootPath)
+            oprot.writeString(self.rootPath)
             oprot.writeFieldEnd()
         if self.sharedSDPartitionSpec is not None:
             oprot.writeFieldBegin('sharedSDPartitionSpec', TType.STRUCT, 4)
@@ -3562,22 +3561,22 @@ class Index(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.indexName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.indexName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.indexHandlerClass = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.indexHandlerClass = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.dbName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.origTableName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.origTableName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 5:
@@ -3592,7 +3591,7 @@ class Index(object):
                     iprot.skip(ftype)
             elif fid == 7:
                 if ftype == TType.STRING:
-                    self.indexTableName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.indexTableName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 8:
@@ -3606,8 +3605,8 @@ class Index(object):
                     self.parameters = {}
                     (_ktype231, _vtype232, _size230) = iprot.readMapBegin()
                     for _i234 in range(_size230):
-                        _key235 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val236 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key235 = iprot.readString()
+                        _val236 = iprot.readString()
                         self.parameters[_key235] = _val236
                     iprot.readMapEnd()
                 else:
@@ -3629,19 +3628,19 @@ class Index(object):
         oprot.writeStructBegin('Index')
         if self.indexName is not None:
             oprot.writeFieldBegin('indexName', TType.STRING, 1)
-            oprot.writeString(self.indexName.encode('utf-8') if sys.version_info[0] == 2 else self.indexName)
+            oprot.writeString(self.indexName)
             oprot.writeFieldEnd()
         if self.indexHandlerClass is not None:
             oprot.writeFieldBegin('indexHandlerClass', TType.STRING, 2)
-            oprot.writeString(self.indexHandlerClass.encode('utf-8') if sys.version_info[0] == 2 else self.indexHandlerClass)
+            oprot.writeString(self.indexHandlerClass)
             oprot.writeFieldEnd()
         if self.dbName is not None:
             oprot.writeFieldBegin('dbName', TType.STRING, 3)
-            oprot.writeString(self.dbName.encode('utf-8') if sys.version_info[0] == 2 else self.dbName)
+            oprot.writeString(self.dbName)
             oprot.writeFieldEnd()
         if self.origTableName is not None:
             oprot.writeFieldBegin('origTableName', TType.STRING, 4)
-            oprot.writeString(self.origTableName.encode('utf-8') if sys.version_info[0] == 2 else self.origTableName)
+            oprot.writeString(self.origTableName)
             oprot.writeFieldEnd()
         if self.createTime is not None:
             oprot.writeFieldBegin('createTime', TType.I32, 5)
@@ -3653,7 +3652,7 @@ class Index(object):
             oprot.writeFieldEnd()
         if self.indexTableName is not None:
             oprot.writeFieldBegin('indexTableName', TType.STRING, 7)
-            oprot.writeString(self.indexTableName.encode('utf-8') if sys.version_info[0] == 2 else self.indexTableName)
+            oprot.writeString(self.indexTableName)
             oprot.writeFieldEnd()
         if self.sd is not None:
             oprot.writeFieldBegin('sd', TType.STRUCT, 8)
@@ -3663,8 +3662,8 @@ class Index(object):
             oprot.writeFieldBegin('parameters', TType.MAP, 9)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.parameters))
             for kiter237, viter238 in self.parameters.items():
-                oprot.writeString(kiter237.encode('utf-8') if sys.version_info[0] == 2 else kiter237)
-                oprot.writeString(viter238.encode('utf-8') if sys.version_info[0] == 2 else viter238)
+                oprot.writeString(kiter237)
+                oprot.writeString(viter238)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         if self.deferredRebuild is not None:
@@ -3731,7 +3730,7 @@ class BooleanColumnStatsData(object):
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.bitVectors = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.bitVectors = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -3758,7 +3757,7 @@ class BooleanColumnStatsData(object):
             oprot.writeFieldEnd()
         if self.bitVectors is not None:
             oprot.writeFieldBegin('bitVectors', TType.STRING, 4)
-            oprot.writeString(self.bitVectors.encode('utf-8') if sys.version_info[0] == 2 else self.bitVectors)
+            oprot.writeString(self.bitVectors)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -3833,7 +3832,7 @@ class DoubleColumnStatsData(object):
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.STRING:
-                    self.bitVectors = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.bitVectors = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -3864,7 +3863,7 @@ class DoubleColumnStatsData(object):
             oprot.writeFieldEnd()
         if self.bitVectors is not None:
             oprot.writeFieldBegin('bitVectors', TType.STRING, 5)
-            oprot.writeString(self.bitVectors.encode('utf-8') if sys.version_info[0] == 2 else self.bitVectors)
+            oprot.writeString(self.bitVectors)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -3937,7 +3936,7 @@ class LongColumnStatsData(object):
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.STRING:
-                    self.bitVectors = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.bitVectors = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -3968,7 +3967,7 @@ class LongColumnStatsData(object):
             oprot.writeFieldEnd()
         if self.bitVectors is not None:
             oprot.writeFieldBegin('bitVectors', TType.STRING, 5)
-            oprot.writeString(self.bitVectors.encode('utf-8') if sys.version_info[0] == 2 else self.bitVectors)
+            oprot.writeString(self.bitVectors)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -4041,7 +4040,7 @@ class StringColumnStatsData(object):
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.STRING:
-                    self.bitVectors = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.bitVectors = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -4072,7 +4071,7 @@ class StringColumnStatsData(object):
             oprot.writeFieldEnd()
         if self.bitVectors is not None:
             oprot.writeFieldBegin('bitVectors', TType.STRING, 5)
-            oprot.writeString(self.bitVectors.encode('utf-8') if sys.version_info[0] == 2 else self.bitVectors)
+            oprot.writeString(self.bitVectors)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -4142,7 +4141,7 @@ class BinaryColumnStatsData(object):
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.bitVectors = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.bitVectors = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -4169,7 +4168,7 @@ class BinaryColumnStatsData(object):
             oprot.writeFieldEnd()
         if self.bitVectors is not None:
             oprot.writeFieldBegin('bitVectors', TType.STRING, 4)
-            oprot.writeString(self.bitVectors.encode('utf-8') if sys.version_info[0] == 2 else self.bitVectors)
+            oprot.writeString(self.bitVectors)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -4317,7 +4316,7 @@ class DecimalColumnStatsData(object):
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.STRING:
-                    self.bitVectors = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.bitVectors = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -4348,7 +4347,7 @@ class DecimalColumnStatsData(object):
             oprot.writeFieldEnd()
         if self.bitVectors is not None:
             oprot.writeFieldBegin('bitVectors', TType.STRING, 5)
-            oprot.writeString(self.bitVectors.encode('utf-8') if sys.version_info[0] == 2 else self.bitVectors)
+            oprot.writeString(self.bitVectors)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -4481,7 +4480,7 @@ class DateColumnStatsData(object):
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.STRING:
-                    self.bitVectors = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.bitVectors = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -4512,7 +4511,7 @@ class DateColumnStatsData(object):
             oprot.writeFieldEnd()
         if self.bitVectors is not None:
             oprot.writeFieldBegin('bitVectors', TType.STRING, 5)
-            oprot.writeString(self.bitVectors.encode('utf-8') if sys.version_info[0] == 2 else self.bitVectors)
+            oprot.writeString(self.bitVectors)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -4690,12 +4689,12 @@ class ColumnStatisticsObj(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.colName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.colName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.colType = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.colType = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -4716,11 +4715,11 @@ class ColumnStatisticsObj(object):
         oprot.writeStructBegin('ColumnStatisticsObj')
         if self.colName is not None:
             oprot.writeFieldBegin('colName', TType.STRING, 1)
-            oprot.writeString(self.colName.encode('utf-8') if sys.version_info[0] == 2 else self.colName)
+            oprot.writeString(self.colName)
             oprot.writeFieldEnd()
         if self.colType is not None:
             oprot.writeFieldBegin('colType', TType.STRING, 2)
-            oprot.writeString(self.colType.encode('utf-8') if sys.version_info[0] == 2 else self.colType)
+            oprot.writeString(self.colType)
             oprot.writeFieldEnd()
         if self.statsData is not None:
             oprot.writeFieldBegin('statsData', TType.STRUCT, 3)
@@ -4784,17 +4783,17 @@ class ColumnStatisticsDesc(object):
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.dbName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.tableName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tableName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.partName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.partName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 5:
@@ -4818,15 +4817,15 @@ class ColumnStatisticsDesc(object):
             oprot.writeFieldEnd()
         if self.dbName is not None:
             oprot.writeFieldBegin('dbName', TType.STRING, 2)
-            oprot.writeString(self.dbName.encode('utf-8') if sys.version_info[0] == 2 else self.dbName)
+            oprot.writeString(self.dbName)
             oprot.writeFieldEnd()
         if self.tableName is not None:
             oprot.writeFieldBegin('tableName', TType.STRING, 3)
-            oprot.writeString(self.tableName.encode('utf-8') if sys.version_info[0] == 2 else self.tableName)
+            oprot.writeString(self.tableName)
             oprot.writeFieldEnd()
         if self.partName is not None:
             oprot.writeFieldBegin('partName', TType.STRING, 4)
-            oprot.writeString(self.partName.encode('utf-8') if sys.version_info[0] == 2 else self.partName)
+            oprot.writeString(self.partName)
             oprot.writeFieldEnd()
         if self.lastAnalyzed is not None:
             oprot.writeFieldBegin('lastAnalyzed', TType.I64, 5)
@@ -5132,8 +5131,8 @@ class Schema(object):
                     self.properties = {}
                     (_ktype267, _vtype268, _size266) = iprot.readMapBegin()
                     for _i270 in range(_size266):
-                        _key271 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val272 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key271 = iprot.readString()
+                        _val272 = iprot.readString()
                         self.properties[_key271] = _val272
                     iprot.readMapEnd()
                 else:
@@ -5159,8 +5158,8 @@ class Schema(object):
             oprot.writeFieldBegin('properties', TType.MAP, 2)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.properties))
             for kiter274, viter275 in self.properties.items():
-                oprot.writeString(kiter274.encode('utf-8') if sys.version_info[0] == 2 else kiter274)
-                oprot.writeString(viter275.encode('utf-8') if sys.version_info[0] == 2 else viter275)
+                oprot.writeString(kiter274)
+                oprot.writeString(viter275)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -5205,8 +5204,8 @@ class EnvironmentContext(object):
                     self.properties = {}
                     (_ktype277, _vtype278, _size276) = iprot.readMapBegin()
                     for _i280 in range(_size276):
-                        _key281 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val282 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key281 = iprot.readString()
+                        _val282 = iprot.readString()
                         self.properties[_key281] = _val282
                     iprot.readMapEnd()
                 else:
@@ -5225,8 +5224,8 @@ class EnvironmentContext(object):
             oprot.writeFieldBegin('properties', TType.MAP, 1)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.properties))
             for kiter283, viter284 in self.properties.items():
-                oprot.writeString(kiter283.encode('utf-8') if sys.version_info[0] == 2 else kiter283)
-                oprot.writeString(viter284.encode('utf-8') if sys.version_info[0] == 2 else viter284)
+                oprot.writeString(kiter283)
+                oprot.writeString(viter284)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -5270,12 +5269,12 @@ class PrimaryKeysRequest(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -5290,11 +5289,11 @@ class PrimaryKeysRequest(object):
         oprot.writeStructBegin('PrimaryKeysRequest')
         if self.db_name is not None:
             oprot.writeFieldBegin('db_name', TType.STRING, 1)
-            oprot.writeString(self.db_name.encode('utf-8') if sys.version_info[0] == 2 else self.db_name)
+            oprot.writeString(self.db_name)
             oprot.writeFieldEnd()
         if self.tbl_name is not None:
             oprot.writeFieldBegin('tbl_name', TType.STRING, 2)
-            oprot.writeString(self.tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.tbl_name)
+            oprot.writeString(self.tbl_name)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -5412,22 +5411,22 @@ class ForeignKeysRequest(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.parent_db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.parent_db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.parent_tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.parent_tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.foreign_db_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.foreign_db_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.foreign_tbl_name = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.foreign_tbl_name = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -5442,19 +5441,19 @@ class ForeignKeysRequest(object):
         oprot.writeStructBegin('ForeignKeysRequest')
         if self.parent_db_name is not None:
             oprot.writeFieldBegin('parent_db_name', TType.STRING, 1)
-            oprot.writeString(self.parent_db_name.encode('utf-8') if sys.version_info[0] == 2 else self.parent_db_name)
+            oprot.writeString(self.parent_db_name)
             oprot.writeFieldEnd()
         if self.parent_tbl_name is not None:
             oprot.writeFieldBegin('parent_tbl_name', TType.STRING, 2)
-            oprot.writeString(self.parent_tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.parent_tbl_name)
+            oprot.writeString(self.parent_tbl_name)
             oprot.writeFieldEnd()
         if self.foreign_db_name is not None:
             oprot.writeFieldBegin('foreign_db_name', TType.STRING, 3)
-            oprot.writeString(self.foreign_db_name.encode('utf-8') if sys.version_info[0] == 2 else self.foreign_db_name)
+            oprot.writeString(self.foreign_db_name)
             oprot.writeFieldEnd()
         if self.foreign_tbl_name is not None:
             oprot.writeFieldBegin('foreign_tbl_name', TType.STRING, 4)
-            oprot.writeString(self.foreign_tbl_name.encode('utf-8') if sys.version_info[0] == 2 else self.foreign_tbl_name)
+            oprot.writeString(self.foreign_tbl_name)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -5566,17 +5565,17 @@ class DropConstraintRequest(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.dbname = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbname = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tablename = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tablename = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.constraintname = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.constraintname = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -5591,15 +5590,15 @@ class DropConstraintRequest(object):
         oprot.writeStructBegin('DropConstraintRequest')
         if self.dbname is not None:
             oprot.writeFieldBegin('dbname', TType.STRING, 1)
-            oprot.writeString(self.dbname.encode('utf-8') if sys.version_info[0] == 2 else self.dbname)
+            oprot.writeString(self.dbname)
             oprot.writeFieldEnd()
         if self.tablename is not None:
             oprot.writeFieldBegin('tablename', TType.STRING, 2)
-            oprot.writeString(self.tablename.encode('utf-8') if sys.version_info[0] == 2 else self.tablename)
+            oprot.writeString(self.tablename)
             oprot.writeFieldEnd()
         if self.constraintname is not None:
             oprot.writeFieldBegin('constraintname', TType.STRING, 3)
-            oprot.writeString(self.constraintname.encode('utf-8') if sys.version_info[0] == 2 else self.constraintname)
+            oprot.writeString(self.constraintname)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -5868,12 +5867,12 @@ class PartitionsByExprRequest(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.dbName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tblName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tblName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -5883,7 +5882,7 @@ class PartitionsByExprRequest(object):
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.defaultPartitionName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.defaultPartitionName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 5:
@@ -5903,11 +5902,11 @@ class PartitionsByExprRequest(object):
         oprot.writeStructBegin('PartitionsByExprRequest')
         if self.dbName is not None:
             oprot.writeFieldBegin('dbName', TType.STRING, 1)
-            oprot.writeString(self.dbName.encode('utf-8') if sys.version_info[0] == 2 else self.dbName)
+            oprot.writeString(self.dbName)
             oprot.writeFieldEnd()
         if self.tblName is not None:
             oprot.writeFieldBegin('tblName', TType.STRING, 2)
-            oprot.writeString(self.tblName.encode('utf-8') if sys.version_info[0] == 2 else self.tblName)
+            oprot.writeString(self.tblName)
             oprot.writeFieldEnd()
         if self.expr is not None:
             oprot.writeFieldBegin('expr', TType.STRING, 3)
@@ -5915,7 +5914,7 @@ class PartitionsByExprRequest(object):
             oprot.writeFieldEnd()
         if self.defaultPartitionName is not None:
             oprot.writeFieldBegin('defaultPartitionName', TType.STRING, 4)
-            oprot.writeString(self.defaultPartitionName.encode('utf-8') if sys.version_info[0] == 2 else self.defaultPartitionName)
+            oprot.writeString(self.defaultPartitionName)
             oprot.writeFieldEnd()
         if self.maxParts is not None:
             oprot.writeFieldBegin('maxParts', TType.I16, 5)
@@ -6036,7 +6035,7 @@ class PartitionsStatsResult(object):
                     self.partStats = {}
                     (_ktype328, _vtype329, _size327) = iprot.readMapBegin()
                     for _i331 in range(_size327):
-                        _key332 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key332 = iprot.readString()
                         _val333 = []
                         (_etype337, _size334) = iprot.readListBegin()
                         for _i338 in range(_size334):
@@ -6062,7 +6061,7 @@ class PartitionsStatsResult(object):
             oprot.writeFieldBegin('partStats', TType.MAP, 1)
             oprot.writeMapBegin(TType.STRING, TType.LIST, len(self.partStats))
             for kiter340, viter341 in self.partStats.items():
-                oprot.writeString(kiter340.encode('utf-8') if sys.version_info[0] == 2 else kiter340)
+                oprot.writeString(kiter340)
                 oprot.writeListBegin(TType.STRUCT, len(viter341))
                 for iter342 in viter341:
                     iter342.write(oprot)
@@ -6114,12 +6113,12 @@ class TableStatsRequest(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.dbName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tblName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tblName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -6127,7 +6126,7 @@ class TableStatsRequest(object):
                     self.colNames = []
                     (_etype346, _size343) = iprot.readListBegin()
                     for _i347 in range(_size343):
-                        _elem348 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem348 = iprot.readString()
                         self.colNames.append(_elem348)
                     iprot.readListEnd()
                 else:
@@ -6144,17 +6143,17 @@ class TableStatsRequest(object):
         oprot.writeStructBegin('TableStatsRequest')
         if self.dbName is not None:
             oprot.writeFieldBegin('dbName', TType.STRING, 1)
-            oprot.writeString(self.dbName.encode('utf-8') if sys.version_info[0] == 2 else self.dbName)
+            oprot.writeString(self.dbName)
             oprot.writeFieldEnd()
         if self.tblName is not None:
             oprot.writeFieldBegin('tblName', TType.STRING, 2)
-            oprot.writeString(self.tblName.encode('utf-8') if sys.version_info[0] == 2 else self.tblName)
+            oprot.writeString(self.tblName)
             oprot.writeFieldEnd()
         if self.colNames is not None:
             oprot.writeFieldBegin('colNames', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.colNames))
             for iter349 in self.colNames:
-                oprot.writeString(iter349.encode('utf-8') if sys.version_info[0] == 2 else iter349)
+                oprot.writeString(iter349)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -6208,12 +6207,12 @@ class PartitionsStatsRequest(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.dbName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tblName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tblName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -6221,7 +6220,7 @@ class PartitionsStatsRequest(object):
                     self.colNames = []
                     (_etype353, _size350) = iprot.readListBegin()
                     for _i354 in range(_size350):
-                        _elem355 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem355 = iprot.readString()
                         self.colNames.append(_elem355)
                     iprot.readListEnd()
                 else:
@@ -6231,7 +6230,7 @@ class PartitionsStatsRequest(object):
                     self.partNames = []
                     (_etype359, _size356) = iprot.readListBegin()
                     for _i360 in range(_size356):
-                        _elem361 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem361 = iprot.readString()
                         self.partNames.append(_elem361)
                     iprot.readListEnd()
                 else:
@@ -6248,24 +6247,24 @@ class PartitionsStatsRequest(object):
         oprot.writeStructBegin('PartitionsStatsRequest')
         if self.dbName is not None:
             oprot.writeFieldBegin('dbName', TType.STRING, 1)
-            oprot.writeString(self.dbName.encode('utf-8') if sys.version_info[0] == 2 else self.dbName)
+            oprot.writeString(self.dbName)
             oprot.writeFieldEnd()
         if self.tblName is not None:
             oprot.writeFieldBegin('tblName', TType.STRING, 2)
-            oprot.writeString(self.tblName.encode('utf-8') if sys.version_info[0] == 2 else self.tblName)
+            oprot.writeString(self.tblName)
             oprot.writeFieldEnd()
         if self.colNames is not None:
             oprot.writeFieldBegin('colNames', TType.LIST, 3)
             oprot.writeListBegin(TType.STRING, len(self.colNames))
             for iter362 in self.colNames:
-                oprot.writeString(iter362.encode('utf-8') if sys.version_info[0] == 2 else iter362)
+                oprot.writeString(iter362)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.partNames is not None:
             oprot.writeFieldBegin('partNames', TType.LIST, 4)
             oprot.writeListBegin(TType.STRING, len(self.partNames))
             for iter363 in self.partNames:
-                oprot.writeString(iter363.encode('utf-8') if sys.version_info[0] == 2 else iter363)
+                oprot.writeString(iter363)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -6388,12 +6387,12 @@ class AddPartitionsRequest(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.dbName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tblName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tblName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -6429,11 +6428,11 @@ class AddPartitionsRequest(object):
         oprot.writeStructBegin('AddPartitionsRequest')
         if self.dbName is not None:
             oprot.writeFieldBegin('dbName', TType.STRING, 1)
-            oprot.writeString(self.dbName.encode('utf-8') if sys.version_info[0] == 2 else self.dbName)
+            oprot.writeString(self.dbName)
             oprot.writeFieldEnd()
         if self.tblName is not None:
             oprot.writeFieldBegin('tblName', TType.STRING, 2)
-            oprot.writeString(self.tblName.encode('utf-8') if sys.version_info[0] == 2 else self.tblName)
+            oprot.writeString(self.tblName)
             oprot.writeFieldEnd()
         if self.parts is not None:
             oprot.writeFieldBegin('parts', TType.LIST, 3)
@@ -6636,7 +6635,7 @@ class RequestPartsSpec(object):
                     self.names = []
                     (_etype388, _size385) = iprot.readListBegin()
                     for _i389 in range(_size385):
-                        _elem390 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem390 = iprot.readString()
                         self.names.append(_elem390)
                     iprot.readListEnd()
                 else:
@@ -6666,7 +6665,7 @@ class RequestPartsSpec(object):
             oprot.writeFieldBegin('names', TType.LIST, 1)
             oprot.writeListBegin(TType.STRING, len(self.names))
             for iter397 in self.names:
-                oprot.writeString(iter397.encode('utf-8') if sys.version_info[0] == 2 else iter397)
+                oprot.writeString(iter397)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.exprs is not None:
@@ -6729,12 +6728,12 @@ class DropPartitionsRequest(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.dbName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tblName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tblName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
@@ -6781,11 +6780,11 @@ class DropPartitionsRequest(object):
         oprot.writeStructBegin('DropPartitionsRequest')
         if self.dbName is not None:
             oprot.writeFieldBegin('dbName', TType.STRING, 1)
-            oprot.writeString(self.dbName.encode('utf-8') if sys.version_info[0] == 2 else self.dbName)
+            oprot.writeString(self.dbName)
             oprot.writeFieldEnd()
         if self.tblName is not None:
             oprot.writeFieldBegin('tblName', TType.STRING, 2)
-            oprot.writeString(self.tblName.encode('utf-8') if sys.version_info[0] == 2 else self.tblName)
+            oprot.writeString(self.tblName)
             oprot.writeFieldEnd()
         if self.parts is not None:
             oprot.writeFieldBegin('parts', TType.STRUCT, 3)
@@ -6863,7 +6862,7 @@ class ResourceUri(object):
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.uri = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.uri = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -6882,7 +6881,7 @@ class ResourceUri(object):
             oprot.writeFieldEnd()
         if self.uri is not None:
             oprot.writeFieldBegin('uri', TType.STRING, 2)
-            oprot.writeString(self.uri.encode('utf-8') if sys.version_info[0] == 2 else self.uri)
+            oprot.writeString(self.uri)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -6937,22 +6936,22 @@ class Function(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.functionName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.functionName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.dbName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.className = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.className = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.ownerName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.ownerName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 5:
@@ -6993,19 +6992,19 @@ class Function(object):
         oprot.writeStructBegin('Function')
         if self.functionName is not None:
             oprot.writeFieldBegin('functionName', TType.STRING, 1)
-            oprot.writeString(self.functionName.encode('utf-8') if sys.version_info[0] == 2 else self.functionName)
+            oprot.writeString(self.functionName)
             oprot.writeFieldEnd()
         if self.dbName is not None:
             oprot.writeFieldBegin('dbName', TType.STRING, 2)
-            oprot.writeString(self.dbName.encode('utf-8') if sys.version_info[0] == 2 else self.dbName)
+            oprot.writeString(self.dbName)
             oprot.writeFieldEnd()
         if self.className is not None:
             oprot.writeFieldBegin('className', TType.STRING, 3)
-            oprot.writeString(self.className.encode('utf-8') if sys.version_info[0] == 2 else self.className)
+            oprot.writeString(self.className)
             oprot.writeFieldEnd()
         if self.ownerName is not None:
             oprot.writeFieldBegin('ownerName', TType.STRING, 4)
-            oprot.writeString(self.ownerName.encode('utf-8') if sys.version_info[0] == 2 else self.ownerName)
+            oprot.writeString(self.ownerName)
             oprot.writeFieldEnd()
         if self.ownerType is not None:
             oprot.writeFieldBegin('ownerType', TType.I32, 5)
@@ -7087,17 +7086,17 @@ class TxnInfo(object):
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.user = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.user = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.hostname = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.hostname = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.STRING:
-                    self.agentInfo = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.agentInfo = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 6:
@@ -7107,7 +7106,7 @@ class TxnInfo(object):
                     iprot.skip(ftype)
             elif fid == 7:
                 if ftype == TType.STRING:
-                    self.metaInfo = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.metaInfo = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -7130,15 +7129,15 @@ class TxnInfo(object):
             oprot.writeFieldEnd()
         if self.user is not None:
             oprot.writeFieldBegin('user', TType.STRING, 3)
-            oprot.writeString(self.user.encode('utf-8') if sys.version_info[0] == 2 else self.user)
+            oprot.writeString(self.user)
             oprot.writeFieldEnd()
         if self.hostname is not None:
             oprot.writeFieldBegin('hostname', TType.STRING, 4)
-            oprot.writeString(self.hostname.encode('utf-8') if sys.version_info[0] == 2 else self.hostname)
+            oprot.writeString(self.hostname)
             oprot.writeFieldEnd()
         if self.agentInfo is not None:
             oprot.writeFieldBegin('agentInfo', TType.STRING, 5)
-            oprot.writeString(self.agentInfo.encode('utf-8') if sys.version_info[0] == 2 else self.agentInfo)
+            oprot.writeString(self.agentInfo)
             oprot.writeFieldEnd()
         if self.heartbeatCount is not None:
             oprot.writeFieldBegin('heartbeatCount', TType.I32, 6)
@@ -7146,7 +7145,7 @@ class TxnInfo(object):
             oprot.writeFieldEnd()
         if self.metaInfo is not None:
             oprot.writeFieldBegin('metaInfo', TType.STRING, 7)
-            oprot.writeString(self.metaInfo.encode('utf-8') if sys.version_info[0] == 2 else self.metaInfo)
+            oprot.writeString(self.metaInfo)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -7376,17 +7375,17 @@ class OpenTxnRequest(object):
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.user = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.user = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.hostname = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.hostname = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.agentInfo = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.agentInfo = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -7405,15 +7404,15 @@ class OpenTxnRequest(object):
             oprot.writeFieldEnd()
         if self.user is not None:
             oprot.writeFieldBegin('user', TType.STRING, 2)
-            oprot.writeString(self.user.encode('utf-8') if sys.version_info[0] == 2 else self.user)
+            oprot.writeString(self.user)
             oprot.writeFieldEnd()
         if self.hostname is not None:
             oprot.writeFieldBegin('hostname', TType.STRING, 3)
-            oprot.writeString(self.hostname.encode('utf-8') if sys.version_info[0] == 2 else self.hostname)
+            oprot.writeString(self.hostname)
             oprot.writeFieldEnd()
         if self.agentInfo is not None:
             oprot.writeFieldBegin('agentInfo', TType.STRING, 4)
-            oprot.writeString(self.agentInfo.encode('utf-8') if sys.version_info[0] == 2 else self.agentInfo)
+            oprot.writeString(self.agentInfo)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -7730,17 +7729,17 @@ class LockComponent(object):
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.dbname = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbname = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.tablename = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tablename = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.STRING:
-                    self.partitionname = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.partitionname = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 6:
@@ -7773,15 +7772,15 @@ class LockComponent(object):
             oprot.writeFieldEnd()
         if self.dbname is not None:
             oprot.writeFieldBegin('dbname', TType.STRING, 3)
-            oprot.writeString(self.dbname.encode('utf-8') if sys.version_info[0] == 2 else self.dbname)
+            oprot.writeString(self.dbname)
             oprot.writeFieldEnd()
         if self.tablename is not None:
             oprot.writeFieldBegin('tablename', TType.STRING, 4)
-            oprot.writeString(self.tablename.encode('utf-8') if sys.version_info[0] == 2 else self.tablename)
+            oprot.writeString(self.tablename)
             oprot.writeFieldEnd()
         if self.partitionname is not None:
             oprot.writeFieldBegin('partitionname', TType.STRING, 5)
-            oprot.writeString(self.partitionname.encode('utf-8') if sys.version_info[0] == 2 else self.partitionname)
+            oprot.writeString(self.partitionname)
             oprot.writeFieldEnd()
         if self.operationType is not None:
             oprot.writeFieldBegin('operationType', TType.I32, 6)
@@ -7860,17 +7859,17 @@ class LockRequest(object):
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.user = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.user = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.hostname = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.hostname = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.STRING:
-                    self.agentInfo = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.agentInfo = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -7896,15 +7895,15 @@ class LockRequest(object):
             oprot.writeFieldEnd()
         if self.user is not None:
             oprot.writeFieldBegin('user', TType.STRING, 3)
-            oprot.writeString(self.user.encode('utf-8') if sys.version_info[0] == 2 else self.user)
+            oprot.writeString(self.user)
             oprot.writeFieldEnd()
         if self.hostname is not None:
             oprot.writeFieldBegin('hostname', TType.STRING, 4)
-            oprot.writeString(self.hostname.encode('utf-8') if sys.version_info[0] == 2 else self.hostname)
+            oprot.writeString(self.hostname)
             oprot.writeFieldEnd()
         if self.agentInfo is not None:
             oprot.writeFieldBegin('agentInfo', TType.STRING, 5)
-            oprot.writeString(self.agentInfo.encode('utf-8') if sys.version_info[0] == 2 else self.agentInfo)
+            oprot.writeString(self.agentInfo)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -8166,17 +8165,17 @@ class ShowLocksRequest(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.dbname = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbname = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tablename = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tablename = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.partname = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.partname = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
@@ -8196,15 +8195,15 @@ class ShowLocksRequest(object):
         oprot.writeStructBegin('ShowLocksRequest')
         if self.dbname is not None:
             oprot.writeFieldBegin('dbname', TType.STRING, 1)
-            oprot.writeString(self.dbname.encode('utf-8') if sys.version_info[0] == 2 else self.dbname)
+            oprot.writeString(self.dbname)
             oprot.writeFieldEnd()
         if self.tablename is not None:
             oprot.writeFieldBegin('tablename', TType.STRING, 2)
-            oprot.writeString(self.tablename.encode('utf-8') if sys.version_info[0] == 2 else self.tablename)
+            oprot.writeString(self.tablename)
             oprot.writeFieldEnd()
         if self.partname is not None:
             oprot.writeFieldBegin('partname', TType.STRING, 3)
-            oprot.writeString(self.partname.encode('utf-8') if sys.version_info[0] == 2 else self.partname)
+            oprot.writeString(self.partname)
             oprot.writeFieldEnd()
         if self.isExtended is not None:
             oprot.writeFieldBegin('isExtended', TType.BOOL, 4)
@@ -8284,17 +8283,17 @@ class ShowLocksResponseElement(object):
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.dbname = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbname = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.tablename = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tablename = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.partname = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.partname = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 5:
@@ -8324,12 +8323,12 @@ class ShowLocksResponseElement(object):
                     iprot.skip(ftype)
             elif fid == 10:
                 if ftype == TType.STRING:
-                    self.user = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.user = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 11:
                 if ftype == TType.STRING:
-                    self.hostname = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.hostname = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 12:
@@ -8339,7 +8338,7 @@ class ShowLocksResponseElement(object):
                     iprot.skip(ftype)
             elif fid == 13:
                 if ftype == TType.STRING:
-                    self.agentInfo = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.agentInfo = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 14:
@@ -8373,15 +8372,15 @@ class ShowLocksResponseElement(object):
             oprot.writeFieldEnd()
         if self.dbname is not None:
             oprot.writeFieldBegin('dbname', TType.STRING, 2)
-            oprot.writeString(self.dbname.encode('utf-8') if sys.version_info[0] == 2 else self.dbname)
+            oprot.writeString(self.dbname)
             oprot.writeFieldEnd()
         if self.tablename is not None:
             oprot.writeFieldBegin('tablename', TType.STRING, 3)
-            oprot.writeString(self.tablename.encode('utf-8') if sys.version_info[0] == 2 else self.tablename)
+            oprot.writeString(self.tablename)
             oprot.writeFieldEnd()
         if self.partname is not None:
             oprot.writeFieldBegin('partname', TType.STRING, 4)
-            oprot.writeString(self.partname.encode('utf-8') if sys.version_info[0] == 2 else self.partname)
+            oprot.writeString(self.partname)
             oprot.writeFieldEnd()
         if self.state is not None:
             oprot.writeFieldBegin('state', TType.I32, 5)
@@ -8405,11 +8404,11 @@ class ShowLocksResponseElement(object):
             oprot.writeFieldEnd()
         if self.user is not None:
             oprot.writeFieldBegin('user', TType.STRING, 10)
-            oprot.writeString(self.user.encode('utf-8') if sys.version_info[0] == 2 else self.user)
+            oprot.writeString(self.user)
             oprot.writeFieldEnd()
         if self.hostname is not None:
             oprot.writeFieldBegin('hostname', TType.STRING, 11)
-            oprot.writeString(self.hostname.encode('utf-8') if sys.version_info[0] == 2 else self.hostname)
+            oprot.writeString(self.hostname)
             oprot.writeFieldEnd()
         if self.heartbeatCount is not None:
             oprot.writeFieldBegin('heartbeatCount', TType.I32, 12)
@@ -8417,7 +8416,7 @@ class ShowLocksResponseElement(object):
             oprot.writeFieldEnd()
         if self.agentInfo is not None:
             oprot.writeFieldBegin('agentInfo', TType.STRING, 13)
-            oprot.writeString(self.agentInfo.encode('utf-8') if sys.version_info[0] == 2 else self.agentInfo)
+            oprot.writeString(self.agentInfo)
             oprot.writeFieldEnd()
         if self.blockedByExtId is not None:
             oprot.writeFieldBegin('blockedByExtId', TType.I64, 14)
@@ -8784,17 +8783,17 @@ class CompactionRequest(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.dbname = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbname = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tablename = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tablename = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.partitionname = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.partitionname = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
@@ -8804,7 +8803,7 @@ class CompactionRequest(object):
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.STRING:
-                    self.runas = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.runas = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 6:
@@ -8812,8 +8811,8 @@ class CompactionRequest(object):
                     self.properties = {}
                     (_ktype463, _vtype464, _size462) = iprot.readMapBegin()
                     for _i466 in range(_size462):
-                        _key467 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
-                        _val468 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _key467 = iprot.readString()
+                        _val468 = iprot.readString()
                         self.properties[_key467] = _val468
                     iprot.readMapEnd()
                 else:
@@ -8830,15 +8829,15 @@ class CompactionRequest(object):
         oprot.writeStructBegin('CompactionRequest')
         if self.dbname is not None:
             oprot.writeFieldBegin('dbname', TType.STRING, 1)
-            oprot.writeString(self.dbname.encode('utf-8') if sys.version_info[0] == 2 else self.dbname)
+            oprot.writeString(self.dbname)
             oprot.writeFieldEnd()
         if self.tablename is not None:
             oprot.writeFieldBegin('tablename', TType.STRING, 2)
-            oprot.writeString(self.tablename.encode('utf-8') if sys.version_info[0] == 2 else self.tablename)
+            oprot.writeString(self.tablename)
             oprot.writeFieldEnd()
         if self.partitionname is not None:
             oprot.writeFieldBegin('partitionname', TType.STRING, 3)
-            oprot.writeString(self.partitionname.encode('utf-8') if sys.version_info[0] == 2 else self.partitionname)
+            oprot.writeString(self.partitionname)
             oprot.writeFieldEnd()
         if self.type is not None:
             oprot.writeFieldBegin('type', TType.I32, 4)
@@ -8846,14 +8845,14 @@ class CompactionRequest(object):
             oprot.writeFieldEnd()
         if self.runas is not None:
             oprot.writeFieldBegin('runas', TType.STRING, 5)
-            oprot.writeString(self.runas.encode('utf-8') if sys.version_info[0] == 2 else self.runas)
+            oprot.writeString(self.runas)
             oprot.writeFieldEnd()
         if self.properties is not None:
             oprot.writeFieldBegin('properties', TType.MAP, 6)
             oprot.writeMapBegin(TType.STRING, TType.STRING, len(self.properties))
             for kiter469, viter470 in self.properties.items():
-                oprot.writeString(kiter469.encode('utf-8') if sys.version_info[0] == 2 else kiter469)
-                oprot.writeString(viter470.encode('utf-8') if sys.version_info[0] == 2 else viter470)
+                oprot.writeString(kiter469)
+                oprot.writeString(viter470)
             oprot.writeMapEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -8963,17 +8962,17 @@ class ShowCompactResponseElement(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.dbname = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbname = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tablename = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tablename = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.partitionname = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.partitionname = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
@@ -8983,12 +8982,12 @@ class ShowCompactResponseElement(object):
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.STRING:
-                    self.state = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.state = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 6:
                 if ftype == TType.STRING:
-                    self.workerid = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.workerid = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 7:
@@ -8998,7 +8997,7 @@ class ShowCompactResponseElement(object):
                     iprot.skip(ftype)
             elif fid == 8:
                 if ftype == TType.STRING:
-                    self.runAs = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.runAs = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 9:
@@ -9008,7 +9007,7 @@ class ShowCompactResponseElement(object):
                     iprot.skip(ftype)
             elif fid == 10:
                 if ftype == TType.STRING:
-                    self.metaInfo = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.metaInfo = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 11:
@@ -9018,7 +9017,7 @@ class ShowCompactResponseElement(object):
                     iprot.skip(ftype)
             elif fid == 12:
                 if ftype == TType.STRING:
-                    self.hadoopJobId = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.hadoopJobId = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -9033,15 +9032,15 @@ class ShowCompactResponseElement(object):
         oprot.writeStructBegin('ShowCompactResponseElement')
         if self.dbname is not None:
             oprot.writeFieldBegin('dbname', TType.STRING, 1)
-            oprot.writeString(self.dbname.encode('utf-8') if sys.version_info[0] == 2 else self.dbname)
+            oprot.writeString(self.dbname)
             oprot.writeFieldEnd()
         if self.tablename is not None:
             oprot.writeFieldBegin('tablename', TType.STRING, 2)
-            oprot.writeString(self.tablename.encode('utf-8') if sys.version_info[0] == 2 else self.tablename)
+            oprot.writeString(self.tablename)
             oprot.writeFieldEnd()
         if self.partitionname is not None:
             oprot.writeFieldBegin('partitionname', TType.STRING, 3)
-            oprot.writeString(self.partitionname.encode('utf-8') if sys.version_info[0] == 2 else self.partitionname)
+            oprot.writeString(self.partitionname)
             oprot.writeFieldEnd()
         if self.type is not None:
             oprot.writeFieldBegin('type', TType.I32, 4)
@@ -9049,11 +9048,11 @@ class ShowCompactResponseElement(object):
             oprot.writeFieldEnd()
         if self.state is not None:
             oprot.writeFieldBegin('state', TType.STRING, 5)
-            oprot.writeString(self.state.encode('utf-8') if sys.version_info[0] == 2 else self.state)
+            oprot.writeString(self.state)
             oprot.writeFieldEnd()
         if self.workerid is not None:
             oprot.writeFieldBegin('workerid', TType.STRING, 6)
-            oprot.writeString(self.workerid.encode('utf-8') if sys.version_info[0] == 2 else self.workerid)
+            oprot.writeString(self.workerid)
             oprot.writeFieldEnd()
         if self.start is not None:
             oprot.writeFieldBegin('start', TType.I64, 7)
@@ -9061,7 +9060,7 @@ class ShowCompactResponseElement(object):
             oprot.writeFieldEnd()
         if self.runAs is not None:
             oprot.writeFieldBegin('runAs', TType.STRING, 8)
-            oprot.writeString(self.runAs.encode('utf-8') if sys.version_info[0] == 2 else self.runAs)
+            oprot.writeString(self.runAs)
             oprot.writeFieldEnd()
         if self.hightestTxnId is not None:
             oprot.writeFieldBegin('hightestTxnId', TType.I64, 9)
@@ -9069,7 +9068,7 @@ class ShowCompactResponseElement(object):
             oprot.writeFieldEnd()
         if self.metaInfo is not None:
             oprot.writeFieldBegin('metaInfo', TType.STRING, 10)
-            oprot.writeString(self.metaInfo.encode('utf-8') if sys.version_info[0] == 2 else self.metaInfo)
+            oprot.writeString(self.metaInfo)
             oprot.writeFieldEnd()
         if self.endTime is not None:
             oprot.writeFieldBegin('endTime', TType.I64, 11)
@@ -9077,7 +9076,7 @@ class ShowCompactResponseElement(object):
             oprot.writeFieldEnd()
         if self.hadoopJobId is not None:
             oprot.writeFieldBegin('hadoopJobId', TType.STRING, 12)
-            oprot.writeString(self.hadoopJobId.encode('utf-8') if sys.version_info[0] == 2 else self.hadoopJobId)
+            oprot.writeString(self.hadoopJobId)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -9206,12 +9205,12 @@ class AddDynamicPartitions(object):
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.dbname = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbname = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.tablename = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tablename = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
@@ -9219,7 +9218,7 @@ class AddDynamicPartitions(object):
                     self.partitionnames = []
                     (_etype481, _size478) = iprot.readListBegin()
                     for _i482 in range(_size478):
-                        _elem483 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem483 = iprot.readString()
                         self.partitionnames.append(_elem483)
                     iprot.readListEnd()
                 else:
@@ -9245,17 +9244,17 @@ class AddDynamicPartitions(object):
             oprot.writeFieldEnd()
         if self.dbname is not None:
             oprot.writeFieldBegin('dbname', TType.STRING, 2)
-            oprot.writeString(self.dbname.encode('utf-8') if sys.version_info[0] == 2 else self.dbname)
+            oprot.writeString(self.dbname)
             oprot.writeFieldEnd()
         if self.tablename is not None:
             oprot.writeFieldBegin('tablename', TType.STRING, 3)
-            oprot.writeString(self.tablename.encode('utf-8') if sys.version_info[0] == 2 else self.tablename)
+            oprot.writeString(self.tablename)
             oprot.writeFieldEnd()
         if self.partitionnames is not None:
             oprot.writeFieldBegin('partitionnames', TType.LIST, 4)
             oprot.writeListBegin(TType.STRING, len(self.partitionnames))
             for iter484 in self.partitionnames:
-                oprot.writeString(iter484.encode('utf-8') if sys.version_info[0] == 2 else iter484)
+                oprot.writeString(iter484)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.operationType is not None:
@@ -9398,22 +9397,22 @@ class NotificationEvent(object):
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.eventType = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.eventType = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.dbName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.STRING:
-                    self.tableName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tableName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 6:
                 if ftype == TType.STRING:
-                    self.message = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.message = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -9436,19 +9435,19 @@ class NotificationEvent(object):
             oprot.writeFieldEnd()
         if self.eventType is not None:
             oprot.writeFieldBegin('eventType', TType.STRING, 3)
-            oprot.writeString(self.eventType.encode('utf-8') if sys.version_info[0] == 2 else self.eventType)
+            oprot.writeString(self.eventType)
             oprot.writeFieldEnd()
         if self.dbName is not None:
             oprot.writeFieldBegin('dbName', TType.STRING, 4)
-            oprot.writeString(self.dbName.encode('utf-8') if sys.version_info[0] == 2 else self.dbName)
+            oprot.writeString(self.dbName)
             oprot.writeFieldEnd()
         if self.tableName is not None:
             oprot.writeFieldBegin('tableName', TType.STRING, 5)
-            oprot.writeString(self.tableName.encode('utf-8') if sys.version_info[0] == 2 else self.tableName)
+            oprot.writeString(self.tableName)
             oprot.writeFieldEnd()
         if self.message is not None:
             oprot.writeFieldBegin('message', TType.STRING, 6)
-            oprot.writeString(self.message.encode('utf-8') if sys.version_info[0] == 2 else self.message)
+            oprot.writeString(self.message)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -9627,7 +9626,7 @@ class InsertEventRequestData(object):
                     self.filesAdded = []
                     (_etype495, _size492) = iprot.readListBegin()
                     for _i496 in range(_size492):
-                        _elem497 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem497 = iprot.readString()
                         self.filesAdded.append(_elem497)
                     iprot.readListEnd()
                 else:
@@ -9651,7 +9650,7 @@ class InsertEventRequestData(object):
             oprot.writeFieldBegin('filesAdded', TType.LIST, 1)
             oprot.writeListBegin(TType.STRING, len(self.filesAdded))
             for iter498 in self.filesAdded:
-                oprot.writeString(iter498.encode('utf-8') if sys.version_info[0] == 2 else iter498)
+                oprot.writeString(iter498)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.replace is not None:
@@ -9775,12 +9774,12 @@ class FireEventRequest(object):
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.dbName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.tableName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tableName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 5:
@@ -9788,7 +9787,7 @@ class FireEventRequest(object):
                     self.partitionVals = []
                     (_etype502, _size499) = iprot.readListBegin()
                     for _i503 in range(_size499):
-                        _elem504 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem504 = iprot.readString()
                         self.partitionVals.append(_elem504)
                     iprot.readListEnd()
                 else:
@@ -9813,17 +9812,17 @@ class FireEventRequest(object):
             oprot.writeFieldEnd()
         if self.dbName is not None:
             oprot.writeFieldBegin('dbName', TType.STRING, 3)
-            oprot.writeString(self.dbName.encode('utf-8') if sys.version_info[0] == 2 else self.dbName)
+            oprot.writeString(self.dbName)
             oprot.writeFieldEnd()
         if self.tableName is not None:
             oprot.writeFieldBegin('tableName', TType.STRING, 4)
-            oprot.writeString(self.tableName.encode('utf-8') if sys.version_info[0] == 2 else self.tableName)
+            oprot.writeString(self.tableName)
             oprot.writeFieldEnd()
         if self.partitionVals is not None:
             oprot.writeFieldBegin('partitionVals', TType.LIST, 5)
             oprot.writeListBegin(TType.STRING, len(self.partitionVals))
             for iter505 in self.partitionVals:
-                oprot.writeString(iter505.encode('utf-8') if sys.version_info[0] == 2 else iter505)
+                oprot.writeString(iter505)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -10614,17 +10613,17 @@ class CacheFileMetadataRequest(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.dbName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tblName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tblName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.partName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.partName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
@@ -10644,15 +10643,15 @@ class CacheFileMetadataRequest(object):
         oprot.writeStructBegin('CacheFileMetadataRequest')
         if self.dbName is not None:
             oprot.writeFieldBegin('dbName', TType.STRING, 1)
-            oprot.writeString(self.dbName.encode('utf-8') if sys.version_info[0] == 2 else self.dbName)
+            oprot.writeString(self.dbName)
             oprot.writeFieldEnd()
         if self.tblName is not None:
             oprot.writeFieldBegin('tblName', TType.STRING, 2)
-            oprot.writeString(self.tblName.encode('utf-8') if sys.version_info[0] == 2 else self.tblName)
+            oprot.writeString(self.tblName)
             oprot.writeFieldEnd()
         if self.partName is not None:
             oprot.writeFieldBegin('partName', TType.STRING, 3)
-            oprot.writeString(self.partName.encode('utf-8') if sys.version_info[0] == 2 else self.partName)
+            oprot.writeString(self.partName)
             oprot.writeFieldEnd()
         if self.isAllParts is not None:
             oprot.writeFieldBegin('isAllParts', TType.BOOL, 4)
@@ -10772,22 +10771,22 @@ class TableMeta(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.dbName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.tableName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tableName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.tableType = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tableType = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
                 if ftype == TType.STRING:
-                    self.comments = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.comments = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -10802,19 +10801,19 @@ class TableMeta(object):
         oprot.writeStructBegin('TableMeta')
         if self.dbName is not None:
             oprot.writeFieldBegin('dbName', TType.STRING, 1)
-            oprot.writeString(self.dbName.encode('utf-8') if sys.version_info[0] == 2 else self.dbName)
+            oprot.writeString(self.dbName)
             oprot.writeFieldEnd()
         if self.tableName is not None:
             oprot.writeFieldBegin('tableName', TType.STRING, 2)
-            oprot.writeString(self.tableName.encode('utf-8') if sys.version_info[0] == 2 else self.tableName)
+            oprot.writeString(self.tableName)
             oprot.writeFieldEnd()
         if self.tableType is not None:
             oprot.writeFieldBegin('tableType', TType.STRING, 3)
-            oprot.writeString(self.tableType.encode('utf-8') if sys.version_info[0] == 2 else self.tableType)
+            oprot.writeString(self.tableType)
             oprot.writeFieldEnd()
         if self.comments is not None:
             oprot.writeFieldBegin('comments', TType.STRING, 4)
-            oprot.writeString(self.comments.encode('utf-8') if sys.version_info[0] == 2 else self.comments)
+            oprot.writeString(self.comments)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -10861,7 +10860,7 @@ class MetaException(TException):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.message = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.message = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -10876,7 +10875,7 @@ class MetaException(TException):
         oprot.writeStructBegin('MetaException')
         if self.message is not None:
             oprot.writeFieldBegin('message', TType.STRING, 1)
-            oprot.writeString(self.message.encode('utf-8') if sys.version_info[0] == 2 else self.message)
+            oprot.writeString(self.message)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -10920,7 +10919,7 @@ class UnknownTableException(TException):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.message = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.message = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -10935,7 +10934,7 @@ class UnknownTableException(TException):
         oprot.writeStructBegin('UnknownTableException')
         if self.message is not None:
             oprot.writeFieldBegin('message', TType.STRING, 1)
-            oprot.writeString(self.message.encode('utf-8') if sys.version_info[0] == 2 else self.message)
+            oprot.writeString(self.message)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -10979,7 +10978,7 @@ class UnknownDBException(TException):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.message = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.message = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -10994,7 +10993,7 @@ class UnknownDBException(TException):
         oprot.writeStructBegin('UnknownDBException')
         if self.message is not None:
             oprot.writeFieldBegin('message', TType.STRING, 1)
-            oprot.writeString(self.message.encode('utf-8') if sys.version_info[0] == 2 else self.message)
+            oprot.writeString(self.message)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -11038,7 +11037,7 @@ class AlreadyExistsException(TException):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.message = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.message = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -11053,7 +11052,7 @@ class AlreadyExistsException(TException):
         oprot.writeStructBegin('AlreadyExistsException')
         if self.message is not None:
             oprot.writeFieldBegin('message', TType.STRING, 1)
-            oprot.writeString(self.message.encode('utf-8') if sys.version_info[0] == 2 else self.message)
+            oprot.writeString(self.message)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -11097,7 +11096,7 @@ class InvalidPartitionException(TException):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.message = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.message = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -11112,7 +11111,7 @@ class InvalidPartitionException(TException):
         oprot.writeStructBegin('InvalidPartitionException')
         if self.message is not None:
             oprot.writeFieldBegin('message', TType.STRING, 1)
-            oprot.writeString(self.message.encode('utf-8') if sys.version_info[0] == 2 else self.message)
+            oprot.writeString(self.message)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -11156,7 +11155,7 @@ class UnknownPartitionException(TException):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.message = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.message = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -11171,7 +11170,7 @@ class UnknownPartitionException(TException):
         oprot.writeStructBegin('UnknownPartitionException')
         if self.message is not None:
             oprot.writeFieldBegin('message', TType.STRING, 1)
-            oprot.writeString(self.message.encode('utf-8') if sys.version_info[0] == 2 else self.message)
+            oprot.writeString(self.message)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -11215,7 +11214,7 @@ class InvalidObjectException(TException):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.message = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.message = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -11230,7 +11229,7 @@ class InvalidObjectException(TException):
         oprot.writeStructBegin('InvalidObjectException')
         if self.message is not None:
             oprot.writeFieldBegin('message', TType.STRING, 1)
-            oprot.writeString(self.message.encode('utf-8') if sys.version_info[0] == 2 else self.message)
+            oprot.writeString(self.message)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -11274,7 +11273,7 @@ class NoSuchObjectException(TException):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.message = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.message = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -11289,7 +11288,7 @@ class NoSuchObjectException(TException):
         oprot.writeStructBegin('NoSuchObjectException')
         if self.message is not None:
             oprot.writeFieldBegin('message', TType.STRING, 1)
-            oprot.writeString(self.message.encode('utf-8') if sys.version_info[0] == 2 else self.message)
+            oprot.writeString(self.message)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -11333,7 +11332,7 @@ class IndexAlreadyExistsException(TException):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.message = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.message = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -11348,7 +11347,7 @@ class IndexAlreadyExistsException(TException):
         oprot.writeStructBegin('IndexAlreadyExistsException')
         if self.message is not None:
             oprot.writeFieldBegin('message', TType.STRING, 1)
-            oprot.writeString(self.message.encode('utf-8') if sys.version_info[0] == 2 else self.message)
+            oprot.writeString(self.message)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -11392,7 +11391,7 @@ class InvalidOperationException(TException):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.message = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.message = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -11407,7 +11406,7 @@ class InvalidOperationException(TException):
         oprot.writeStructBegin('InvalidOperationException')
         if self.message is not None:
             oprot.writeFieldBegin('message', TType.STRING, 1)
-            oprot.writeString(self.message.encode('utf-8') if sys.version_info[0] == 2 else self.message)
+            oprot.writeString(self.message)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -11451,7 +11450,7 @@ class ConfigValSecurityException(TException):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.message = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.message = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -11466,7 +11465,7 @@ class ConfigValSecurityException(TException):
         oprot.writeStructBegin('ConfigValSecurityException')
         if self.message is not None:
             oprot.writeFieldBegin('message', TType.STRING, 1)
-            oprot.writeString(self.message.encode('utf-8') if sys.version_info[0] == 2 else self.message)
+            oprot.writeString(self.message)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -11510,7 +11509,7 @@ class InvalidInputException(TException):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.message = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.message = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -11525,7 +11524,7 @@ class InvalidInputException(TException):
         oprot.writeStructBegin('InvalidInputException')
         if self.message is not None:
             oprot.writeFieldBegin('message', TType.STRING, 1)
-            oprot.writeString(self.message.encode('utf-8') if sys.version_info[0] == 2 else self.message)
+            oprot.writeString(self.message)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -11569,7 +11568,7 @@ class NoSuchTxnException(TException):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.message = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.message = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -11584,7 +11583,7 @@ class NoSuchTxnException(TException):
         oprot.writeStructBegin('NoSuchTxnException')
         if self.message is not None:
             oprot.writeFieldBegin('message', TType.STRING, 1)
-            oprot.writeString(self.message.encode('utf-8') if sys.version_info[0] == 2 else self.message)
+            oprot.writeString(self.message)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -11628,7 +11627,7 @@ class TxnAbortedException(TException):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.message = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.message = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -11643,7 +11642,7 @@ class TxnAbortedException(TException):
         oprot.writeStructBegin('TxnAbortedException')
         if self.message is not None:
             oprot.writeFieldBegin('message', TType.STRING, 1)
-            oprot.writeString(self.message.encode('utf-8') if sys.version_info[0] == 2 else self.message)
+            oprot.writeString(self.message)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -11687,7 +11686,7 @@ class TxnOpenException(TException):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.message = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.message = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -11702,7 +11701,7 @@ class TxnOpenException(TException):
         oprot.writeStructBegin('TxnOpenException')
         if self.message is not None:
             oprot.writeFieldBegin('message', TType.STRING, 1)
-            oprot.writeString(self.message.encode('utf-8') if sys.version_info[0] == 2 else self.message)
+            oprot.writeString(self.message)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -11746,7 +11745,7 @@ class NoSuchLockException(TException):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.message = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.message = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -11761,7 +11760,7 @@ class NoSuchLockException(TException):
         oprot.writeStructBegin('NoSuchLockException')
         if self.message is not None:
             oprot.writeFieldBegin('message', TType.STRING, 1)
-            oprot.writeString(self.message.encode('utf-8') if sys.version_info[0] == 2 else self.message)
+            oprot.writeString(self.message)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -11812,19 +11811,19 @@ class GetPartitionsProjectionSpec(object):
                     self.fieldList = []
                     (_etype569, _size566) = iprot.readListBegin()
                     for _i570 in range(_size566):
-                        _elem571 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem571 = iprot.readString()
                         self.fieldList.append(_elem571)
                     iprot.readListEnd()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.includeParamKeyPattern = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.includeParamKeyPattern = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.excludeParamKeyPattern = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.excludeParamKeyPattern = iprot.readString()
                 else:
                     iprot.skip(ftype)
             else:
@@ -11841,16 +11840,16 @@ class GetPartitionsProjectionSpec(object):
             oprot.writeFieldBegin('fieldList', TType.LIST, 1)
             oprot.writeListBegin(TType.STRING, len(self.fieldList))
             for iter572 in self.fieldList:
-                oprot.writeString(iter572.encode('utf-8') if sys.version_info[0] == 2 else iter572)
+                oprot.writeString(iter572)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.includeParamKeyPattern is not None:
             oprot.writeFieldBegin('includeParamKeyPattern', TType.STRING, 2)
-            oprot.writeString(self.includeParamKeyPattern.encode('utf-8') if sys.version_info[0] == 2 else self.includeParamKeyPattern)
+            oprot.writeString(self.includeParamKeyPattern)
             oprot.writeFieldEnd()
         if self.excludeParamKeyPattern is not None:
             oprot.writeFieldBegin('excludeParamKeyPattern', TType.STRING, 3)
-            oprot.writeString(self.excludeParamKeyPattern.encode('utf-8') if sys.version_info[0] == 2 else self.excludeParamKeyPattern)
+            oprot.writeString(self.excludeParamKeyPattern)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -11901,7 +11900,7 @@ class GetPartitionsFilterSpec(object):
                     self.filters = []
                     (_etype576, _size573) = iprot.readListBegin()
                     for _i577 in range(_size573):
-                        _elem578 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem578 = iprot.readString()
                         self.filters.append(_elem578)
                     iprot.readListEnd()
                 else:
@@ -11924,7 +11923,7 @@ class GetPartitionsFilterSpec(object):
             oprot.writeFieldBegin('filters', TType.LIST, 8)
             oprot.writeListBegin(TType.STRING, len(self.filters))
             for iter579 in self.filters:
-                oprot.writeString(iter579.encode('utf-8') if sys.version_info[0] == 2 else iter579)
+                oprot.writeString(iter579)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
@@ -12045,17 +12044,17 @@ class GetPartitionsRequest(object):
                 break
             if fid == 1:
                 if ftype == TType.STRING:
-                    self.catName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.catName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 2:
                 if ftype == TType.STRING:
-                    self.dbName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.dbName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 3:
                 if ftype == TType.STRING:
-                    self.tblName = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.tblName = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 4:
@@ -12065,7 +12064,7 @@ class GetPartitionsRequest(object):
                     iprot.skip(ftype)
             elif fid == 5:
                 if ftype == TType.STRING:
-                    self.user = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                    self.user = iprot.readString()
                 else:
                     iprot.skip(ftype)
             elif fid == 6:
@@ -12073,7 +12072,7 @@ class GetPartitionsRequest(object):
                     self.groupNames = []
                     (_etype590, _size587) = iprot.readListBegin()
                     for _i591 in range(_size587):
-                        _elem592 = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
+                        _elem592 = iprot.readString()
                         self.groupNames.append(_elem592)
                     iprot.readListEnd()
                 else:
@@ -12102,15 +12101,15 @@ class GetPartitionsRequest(object):
         oprot.writeStructBegin('GetPartitionsRequest')
         if self.catName is not None:
             oprot.writeFieldBegin('catName', TType.STRING, 1)
-            oprot.writeString(self.catName.encode('utf-8') if sys.version_info[0] == 2 else self.catName)
+            oprot.writeString(self.catName)
             oprot.writeFieldEnd()
         if self.dbName is not None:
             oprot.writeFieldBegin('dbName', TType.STRING, 2)
-            oprot.writeString(self.dbName.encode('utf-8') if sys.version_info[0] == 2 else self.dbName)
+            oprot.writeString(self.dbName)
             oprot.writeFieldEnd()
         if self.tblName is not None:
             oprot.writeFieldBegin('tblName', TType.STRING, 3)
-            oprot.writeString(self.tblName.encode('utf-8') if sys.version_info[0] == 2 else self.tblName)
+            oprot.writeString(self.tblName)
             oprot.writeFieldEnd()
         if self.withAuth is not None:
             oprot.writeFieldBegin('withAuth', TType.BOOL, 4)
@@ -12118,13 +12117,13 @@ class GetPartitionsRequest(object):
             oprot.writeFieldEnd()
         if self.user is not None:
             oprot.writeFieldBegin('user', TType.STRING, 5)
-            oprot.writeString(self.user.encode('utf-8') if sys.version_info[0] == 2 else self.user)
+            oprot.writeString(self.user)
             oprot.writeFieldEnd()
         if self.groupNames is not None:
             oprot.writeFieldBegin('groupNames', TType.LIST, 6)
             oprot.writeListBegin(TType.STRING, len(self.groupNames))
             for iter593 in self.groupNames:
-                oprot.writeString(iter593.encode('utf-8') if sys.version_info[0] == 2 else iter593)
+                oprot.writeString(iter593)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.projectionSpec is not None:
@@ -12154,24 +12153,24 @@ class GetPartitionsRequest(object):
 all_structs.append(Version)
 Version.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'version', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'comments', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'version', None, None, ),  # 1
+    (2, TType.STRING, 'comments', None, None, ),  # 2
 )
 all_structs.append(FieldSchema)
 FieldSchema.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'type', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'comment', 'UTF8', None, ),  # 3
+    (1, TType.STRING, 'name', None, None, ),  # 1
+    (2, TType.STRING, 'type', None, None, ),  # 2
+    (3, TType.STRING, 'comment', None, None, ),  # 3
 )
 all_structs.append(SQLPrimaryKey)
 SQLPrimaryKey.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'table_db', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'table_name', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'column_name', 'UTF8', None, ),  # 3
+    (1, TType.STRING, 'table_db', None, None, ),  # 1
+    (2, TType.STRING, 'table_name', None, None, ),  # 2
+    (3, TType.STRING, 'column_name', None, None, ),  # 3
     (4, TType.I32, 'key_seq', None, None, ),  # 4
-    (5, TType.STRING, 'pk_name', 'UTF8', None, ),  # 5
+    (5, TType.STRING, 'pk_name', None, None, ),  # 5
     (6, TType.BOOL, 'enable_cstr', None, None, ),  # 6
     (7, TType.BOOL, 'validate_cstr', None, None, ),  # 7
     (8, TType.BOOL, 'rely_cstr', None, None, ),  # 8
@@ -12179,17 +12178,17 @@ SQLPrimaryKey.thrift_spec = (
 all_structs.append(SQLForeignKey)
 SQLForeignKey.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'pktable_db', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'pktable_name', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'pkcolumn_name', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'fktable_db', 'UTF8', None, ),  # 4
-    (5, TType.STRING, 'fktable_name', 'UTF8', None, ),  # 5
-    (6, TType.STRING, 'fkcolumn_name', 'UTF8', None, ),  # 6
+    (1, TType.STRING, 'pktable_db', None, None, ),  # 1
+    (2, TType.STRING, 'pktable_name', None, None, ),  # 2
+    (3, TType.STRING, 'pkcolumn_name', None, None, ),  # 3
+    (4, TType.STRING, 'fktable_db', None, None, ),  # 4
+    (5, TType.STRING, 'fktable_name', None, None, ),  # 5
+    (6, TType.STRING, 'fkcolumn_name', None, None, ),  # 6
     (7, TType.I32, 'key_seq', None, None, ),  # 7
     (8, TType.I32, 'update_rule', None, None, ),  # 8
     (9, TType.I32, 'delete_rule', None, None, ),  # 9
-    (10, TType.STRING, 'fk_name', 'UTF8', None, ),  # 10
-    (11, TType.STRING, 'pk_name', 'UTF8', None, ),  # 11
+    (10, TType.STRING, 'fk_name', None, None, ),  # 10
+    (11, TType.STRING, 'pk_name', None, None, ),  # 11
     (12, TType.BOOL, 'enable_cstr', None, None, ),  # 12
     (13, TType.BOOL, 'validate_cstr', None, None, ),  # 13
     (14, TType.BOOL, 'rely_cstr', None, None, ),  # 14
@@ -12197,26 +12196,26 @@ SQLForeignKey.thrift_spec = (
 all_structs.append(Type)
 Type.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'type1', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'type2', 'UTF8', None, ),  # 3
+    (1, TType.STRING, 'name', None, None, ),  # 1
+    (2, TType.STRING, 'type1', None, None, ),  # 2
+    (3, TType.STRING, 'type2', None, None, ),  # 3
     (4, TType.LIST, 'fields', (TType.STRUCT, [FieldSchema, None], False), None, ),  # 4
 )
 all_structs.append(HiveObjectRef)
 HiveObjectRef.thrift_spec = (
     None,  # 0
     (1, TType.I32, 'objectType', None, None, ),  # 1
-    (2, TType.STRING, 'dbName', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'objectName', 'UTF8', None, ),  # 3
-    (4, TType.LIST, 'partValues', (TType.STRING, 'UTF8', False), None, ),  # 4
-    (5, TType.STRING, 'columnName', 'UTF8', None, ),  # 5
+    (2, TType.STRING, 'dbName', None, None, ),  # 2
+    (3, TType.STRING, 'objectName', None, None, ),  # 3
+    (4, TType.LIST, 'partValues', (TType.STRING, None, False), None, ),  # 4
+    (5, TType.STRING, 'columnName', None, None, ),  # 5
 )
 all_structs.append(PrivilegeGrantInfo)
 PrivilegeGrantInfo.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'privilege', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'privilege', None, None, ),  # 1
     (2, TType.I32, 'createTime', None, None, ),  # 2
-    (3, TType.STRING, 'grantor', 'UTF8', None, ),  # 3
+    (3, TType.STRING, 'grantor', None, None, ),  # 3
     (4, TType.I32, 'grantorType', None, None, ),  # 4
     (5, TType.BOOL, 'grantOption', None, None, ),  # 5
 )
@@ -12224,7 +12223,7 @@ all_structs.append(HiveObjectPrivilege)
 HiveObjectPrivilege.thrift_spec = (
     None,  # 0
     (1, TType.STRUCT, 'hiveObject', [HiveObjectRef, None], None, ),  # 1
-    (2, TType.STRING, 'principalName', 'UTF8', None, ),  # 2
+    (2, TType.STRING, 'principalName', None, None, ),  # 2
     (3, TType.I32, 'principalType', None, None, ),  # 3
     (4, TType.STRUCT, 'grantInfo', [PrivilegeGrantInfo, None], None, ),  # 4
 )
@@ -12236,9 +12235,9 @@ PrivilegeBag.thrift_spec = (
 all_structs.append(PrincipalPrivilegeSet)
 PrincipalPrivilegeSet.thrift_spec = (
     None,  # 0
-    (1, TType.MAP, 'userPrivileges', (TType.STRING, 'UTF8', TType.LIST, (TType.STRUCT, [PrivilegeGrantInfo, None], False), False), None, ),  # 1
-    (2, TType.MAP, 'groupPrivileges', (TType.STRING, 'UTF8', TType.LIST, (TType.STRUCT, [PrivilegeGrantInfo, None], False), False), None, ),  # 2
-    (3, TType.MAP, 'rolePrivileges', (TType.STRING, 'UTF8', TType.LIST, (TType.STRUCT, [PrivilegeGrantInfo, None], False), False), None, ),  # 3
+    (1, TType.MAP, 'userPrivileges', (TType.STRING, None, TType.LIST, (TType.STRUCT, [PrivilegeGrantInfo, None], False), False), None, ),  # 1
+    (2, TType.MAP, 'groupPrivileges', (TType.STRING, None, TType.LIST, (TType.STRUCT, [PrivilegeGrantInfo, None], False), False), None, ),  # 2
+    (3, TType.MAP, 'rolePrivileges', (TType.STRING, None, TType.LIST, (TType.STRUCT, [PrivilegeGrantInfo, None], False), False), None, ),  # 3
 )
 all_structs.append(GrantRevokePrivilegeRequest)
 GrantRevokePrivilegeRequest.thrift_spec = (
@@ -12255,25 +12254,25 @@ GrantRevokePrivilegeResponse.thrift_spec = (
 all_structs.append(Role)
 Role.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'roleName', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'roleName', None, None, ),  # 1
     (2, TType.I32, 'createTime', None, None, ),  # 2
-    (3, TType.STRING, 'ownerName', 'UTF8', None, ),  # 3
+    (3, TType.STRING, 'ownerName', None, None, ),  # 3
 )
 all_structs.append(RolePrincipalGrant)
 RolePrincipalGrant.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'roleName', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'principalName', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'roleName', None, None, ),  # 1
+    (2, TType.STRING, 'principalName', None, None, ),  # 2
     (3, TType.I32, 'principalType', None, None, ),  # 3
     (4, TType.BOOL, 'grantOption', None, None, ),  # 4
     (5, TType.I32, 'grantTime', None, None, ),  # 5
-    (6, TType.STRING, 'grantorName', 'UTF8', None, ),  # 6
+    (6, TType.STRING, 'grantorName', None, None, ),  # 6
     (7, TType.I32, 'grantorPrincipalType', None, None, ),  # 7
 )
 all_structs.append(GetRoleGrantsForPrincipalRequest)
 GetRoleGrantsForPrincipalRequest.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'principal_name', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'principal_name', None, None, ),  # 1
     (2, TType.I32, 'principal_type', None, None, ),  # 2
 )
 all_structs.append(GetRoleGrantsForPrincipalResponse)
@@ -12284,7 +12283,7 @@ GetRoleGrantsForPrincipalResponse.thrift_spec = (
 all_structs.append(GetPrincipalsInRoleRequest)
 GetPrincipalsInRoleRequest.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'roleName', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'roleName', None, None, ),  # 1
 )
 all_structs.append(GetPrincipalsInRoleResponse)
 GetPrincipalsInRoleResponse.thrift_spec = (
@@ -12295,10 +12294,10 @@ all_structs.append(GrantRevokeRoleRequest)
 GrantRevokeRoleRequest.thrift_spec = (
     None,  # 0
     (1, TType.I32, 'requestType', None, None, ),  # 1
-    (2, TType.STRING, 'roleName', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'principalName', 'UTF8', None, ),  # 3
+    (2, TType.STRING, 'roleName', None, None, ),  # 2
+    (3, TType.STRING, 'principalName', None, None, ),  # 3
     (4, TType.I32, 'principalType', None, None, ),  # 4
-    (5, TType.STRING, 'grantor', 'UTF8', None, ),  # 5
+    (5, TType.STRING, 'grantor', None, None, ),  # 5
     (6, TType.I32, 'grantorType', None, None, ),  # 6
     (7, TType.BOOL, 'grantOption', None, None, ),  # 7
 )
@@ -12310,12 +12309,12 @@ GrantRevokeRoleResponse.thrift_spec = (
 all_structs.append(Database)
 Database.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'description', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'locationUri', 'UTF8', None, ),  # 3
-    (4, TType.MAP, 'parameters', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 4
+    (1, TType.STRING, 'name', None, None, ),  # 1
+    (2, TType.STRING, 'description', None, None, ),  # 2
+    (3, TType.STRING, 'locationUri', None, None, ),  # 3
+    (4, TType.MAP, 'parameters', (TType.STRING, None, TType.STRING, None, False), None, ),  # 4
     (5, TType.STRUCT, 'privileges', [PrincipalPrivilegeSet, None], None, ),  # 5
-    (6, TType.STRING, 'ownerName', 'UTF8', None, ),  # 6
+    (6, TType.STRING, 'ownerName', None, None, ),  # 6
     (7, TType.I32, 'ownerType', None, None, ),  # 7
     None,  # 8
     (9, TType.I32, 'createTime', None, None, ),  # 9
@@ -12323,54 +12322,54 @@ Database.thrift_spec = (
 all_structs.append(SerDeInfo)
 SerDeInfo.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'serializationLib', 'UTF8', None, ),  # 2
-    (3, TType.MAP, 'parameters', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 3
+    (1, TType.STRING, 'name', None, None, ),  # 1
+    (2, TType.STRING, 'serializationLib', None, None, ),  # 2
+    (3, TType.MAP, 'parameters', (TType.STRING, None, TType.STRING, None, False), None, ),  # 3
 )
 all_structs.append(Order)
 Order.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'col', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'col', None, None, ),  # 1
     (2, TType.I32, 'order', None, None, ),  # 2
 )
 all_structs.append(SkewedInfo)
 SkewedInfo.thrift_spec = (
     None,  # 0
-    (1, TType.LIST, 'skewedColNames', (TType.STRING, 'UTF8', False), None, ),  # 1
-    (2, TType.LIST, 'skewedColValues', (TType.LIST, (TType.STRING, 'UTF8', False), False), None, ),  # 2
-    (3, TType.MAP, 'skewedColValueLocationMaps', (TType.LIST, (TType.STRING, 'UTF8', False), TType.STRING, 'UTF8', False), None, ),  # 3
+    (1, TType.LIST, 'skewedColNames', (TType.STRING, None, False), None, ),  # 1
+    (2, TType.LIST, 'skewedColValues', (TType.LIST, (TType.STRING, None, False), False), None, ),  # 2
+    (3, TType.MAP, 'skewedColValueLocationMaps', (TType.LIST, (TType.STRING, None, False), TType.STRING, None, False), None, ),  # 3
 )
 all_structs.append(StorageDescriptor)
 StorageDescriptor.thrift_spec = (
     None,  # 0
     (1, TType.LIST, 'cols', (TType.STRUCT, [FieldSchema, None], False), None, ),  # 1
-    (2, TType.STRING, 'location', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'inputFormat', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'outputFormat', 'UTF8', None, ),  # 4
+    (2, TType.STRING, 'location', None, None, ),  # 2
+    (3, TType.STRING, 'inputFormat', None, None, ),  # 3
+    (4, TType.STRING, 'outputFormat', None, None, ),  # 4
     (5, TType.BOOL, 'compressed', None, None, ),  # 5
     (6, TType.I32, 'numBuckets', None, None, ),  # 6
     (7, TType.STRUCT, 'serdeInfo', [SerDeInfo, None], None, ),  # 7
-    (8, TType.LIST, 'bucketCols', (TType.STRING, 'UTF8', False), None, ),  # 8
+    (8, TType.LIST, 'bucketCols', (TType.STRING, None, False), None, ),  # 8
     (9, TType.LIST, 'sortCols', (TType.STRUCT, [Order, None], False), None, ),  # 9
-    (10, TType.MAP, 'parameters', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 10
+    (10, TType.MAP, 'parameters', (TType.STRING, None, TType.STRING, None, False), None, ),  # 10
     (11, TType.STRUCT, 'skewedInfo', [SkewedInfo, None], None, ),  # 11
     (12, TType.BOOL, 'storedAsSubDirectories', None, None, ),  # 12
 )
 all_structs.append(Table)
 Table.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'tableName', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'dbName', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'owner', 'UTF8', None, ),  # 3
+    (1, TType.STRING, 'tableName', None, None, ),  # 1
+    (2, TType.STRING, 'dbName', None, None, ),  # 2
+    (3, TType.STRING, 'owner', None, None, ),  # 3
     (4, TType.I32, 'createTime', None, None, ),  # 4
     (5, TType.I32, 'lastAccessTime', None, None, ),  # 5
     (6, TType.I32, 'retention', None, None, ),  # 6
     (7, TType.STRUCT, 'sd', [StorageDescriptor, None], None, ),  # 7
     (8, TType.LIST, 'partitionKeys', (TType.STRUCT, [FieldSchema, None], False), None, ),  # 8
-    (9, TType.MAP, 'parameters', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 9
-    (10, TType.STRING, 'viewOriginalText', 'UTF8', None, ),  # 10
-    (11, TType.STRING, 'viewExpandedText', 'UTF8', None, ),  # 11
-    (12, TType.STRING, 'tableType', 'UTF8', None, ),  # 12
+    (9, TType.MAP, 'parameters', (TType.STRING, None, TType.STRING, None, False), None, ),  # 9
+    (10, TType.STRING, 'viewOriginalText', None, None, ),  # 10
+    (11, TType.STRING, 'viewExpandedText', None, None, ),  # 11
+    (12, TType.STRING, 'tableType', None, None, ),  # 12
     (13, TType.STRUCT, 'privileges', [PrincipalPrivilegeSet, None], None, ),  # 13
     (14, TType.BOOL, 'temporary', None, False, ),  # 14
     (15, TType.I32, 'ownerType', None, 1, ),  # 15
@@ -12378,23 +12377,23 @@ Table.thrift_spec = (
 all_structs.append(Partition)
 Partition.thrift_spec = (
     None,  # 0
-    (1, TType.LIST, 'values', (TType.STRING, 'UTF8', False), None, ),  # 1
-    (2, TType.STRING, 'dbName', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'tableName', 'UTF8', None, ),  # 3
+    (1, TType.LIST, 'values', (TType.STRING, None, False), None, ),  # 1
+    (2, TType.STRING, 'dbName', None, None, ),  # 2
+    (3, TType.STRING, 'tableName', None, None, ),  # 3
     (4, TType.I32, 'createTime', None, None, ),  # 4
     (5, TType.I32, 'lastAccessTime', None, None, ),  # 5
     (6, TType.STRUCT, 'sd', [StorageDescriptor, None], None, ),  # 6
-    (7, TType.MAP, 'parameters', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 7
+    (7, TType.MAP, 'parameters', (TType.STRING, None, TType.STRING, None, False), None, ),  # 7
     (8, TType.STRUCT, 'privileges', [PrincipalPrivilegeSet, None], None, ),  # 8
 )
 all_structs.append(PartitionWithoutSD)
 PartitionWithoutSD.thrift_spec = (
     None,  # 0
-    (1, TType.LIST, 'values', (TType.STRING, 'UTF8', False), None, ),  # 1
+    (1, TType.LIST, 'values', (TType.STRING, None, False), None, ),  # 1
     (2, TType.I32, 'createTime', None, None, ),  # 2
     (3, TType.I32, 'lastAccessTime', None, None, ),  # 3
-    (4, TType.STRING, 'relativePath', 'UTF8', None, ),  # 4
-    (5, TType.MAP, 'parameters', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 5
+    (4, TType.STRING, 'relativePath', None, None, ),  # 4
+    (5, TType.MAP, 'parameters', (TType.STRING, None, TType.STRING, None, False), None, ),  # 5
     (6, TType.STRUCT, 'privileges', [PrincipalPrivilegeSet, None], None, ),  # 6
 )
 all_structs.append(PartitionSpecWithSharedSD)
@@ -12411,24 +12410,24 @@ PartitionListComposingSpec.thrift_spec = (
 all_structs.append(PartitionSpec)
 PartitionSpec.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'dbName', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tableName', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'rootPath', 'UTF8', None, ),  # 3
+    (1, TType.STRING, 'dbName', None, None, ),  # 1
+    (2, TType.STRING, 'tableName', None, None, ),  # 2
+    (3, TType.STRING, 'rootPath', None, None, ),  # 3
     (4, TType.STRUCT, 'sharedSDPartitionSpec', [PartitionSpecWithSharedSD, None], None, ),  # 4
     (5, TType.STRUCT, 'partitionList', [PartitionListComposingSpec, None], None, ),  # 5
 )
 all_structs.append(Index)
 Index.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'indexName', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'indexHandlerClass', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'dbName', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'origTableName', 'UTF8', None, ),  # 4
+    (1, TType.STRING, 'indexName', None, None, ),  # 1
+    (2, TType.STRING, 'indexHandlerClass', None, None, ),  # 2
+    (3, TType.STRING, 'dbName', None, None, ),  # 3
+    (4, TType.STRING, 'origTableName', None, None, ),  # 4
     (5, TType.I32, 'createTime', None, None, ),  # 5
     (6, TType.I32, 'lastAccessTime', None, None, ),  # 6
-    (7, TType.STRING, 'indexTableName', 'UTF8', None, ),  # 7
+    (7, TType.STRING, 'indexTableName', None, None, ),  # 7
     (8, TType.STRUCT, 'sd', [StorageDescriptor, None], None, ),  # 8
-    (9, TType.MAP, 'parameters', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 9
+    (9, TType.MAP, 'parameters', (TType.STRING, None, TType.STRING, None, False), None, ),  # 9
     (10, TType.BOOL, 'deferredRebuild', None, None, ),  # 10
 )
 all_structs.append(BooleanColumnStatsData)
@@ -12437,7 +12436,7 @@ BooleanColumnStatsData.thrift_spec = (
     (1, TType.I64, 'numTrues', None, None, ),  # 1
     (2, TType.I64, 'numFalses', None, None, ),  # 2
     (3, TType.I64, 'numNulls', None, None, ),  # 3
-    (4, TType.STRING, 'bitVectors', 'UTF8', None, ),  # 4
+    (4, TType.STRING, 'bitVectors', None, None, ),  # 4
 )
 all_structs.append(DoubleColumnStatsData)
 DoubleColumnStatsData.thrift_spec = (
@@ -12446,7 +12445,7 @@ DoubleColumnStatsData.thrift_spec = (
     (2, TType.DOUBLE, 'highValue', None, None, ),  # 2
     (3, TType.I64, 'numNulls', None, None, ),  # 3
     (4, TType.I64, 'numDVs', None, None, ),  # 4
-    (5, TType.STRING, 'bitVectors', 'UTF8', None, ),  # 5
+    (5, TType.STRING, 'bitVectors', None, None, ),  # 5
 )
 all_structs.append(LongColumnStatsData)
 LongColumnStatsData.thrift_spec = (
@@ -12455,7 +12454,7 @@ LongColumnStatsData.thrift_spec = (
     (2, TType.I64, 'highValue', None, None, ),  # 2
     (3, TType.I64, 'numNulls', None, None, ),  # 3
     (4, TType.I64, 'numDVs', None, None, ),  # 4
-    (5, TType.STRING, 'bitVectors', 'UTF8', None, ),  # 5
+    (5, TType.STRING, 'bitVectors', None, None, ),  # 5
 )
 all_structs.append(StringColumnStatsData)
 StringColumnStatsData.thrift_spec = (
@@ -12464,7 +12463,7 @@ StringColumnStatsData.thrift_spec = (
     (2, TType.DOUBLE, 'avgColLen', None, None, ),  # 2
     (3, TType.I64, 'numNulls', None, None, ),  # 3
     (4, TType.I64, 'numDVs', None, None, ),  # 4
-    (5, TType.STRING, 'bitVectors', 'UTF8', None, ),  # 5
+    (5, TType.STRING, 'bitVectors', None, None, ),  # 5
 )
 all_structs.append(BinaryColumnStatsData)
 BinaryColumnStatsData.thrift_spec = (
@@ -12472,7 +12471,7 @@ BinaryColumnStatsData.thrift_spec = (
     (1, TType.I64, 'maxColLen', None, None, ),  # 1
     (2, TType.DOUBLE, 'avgColLen', None, None, ),  # 2
     (3, TType.I64, 'numNulls', None, None, ),  # 3
-    (4, TType.STRING, 'bitVectors', 'UTF8', None, ),  # 4
+    (4, TType.STRING, 'bitVectors', None, None, ),  # 4
 )
 all_structs.append(Decimal)
 Decimal.thrift_spec = (
@@ -12488,7 +12487,7 @@ DecimalColumnStatsData.thrift_spec = (
     (2, TType.STRUCT, 'highValue', [Decimal, None], None, ),  # 2
     (3, TType.I64, 'numNulls', None, None, ),  # 3
     (4, TType.I64, 'numDVs', None, None, ),  # 4
-    (5, TType.STRING, 'bitVectors', 'UTF8', None, ),  # 5
+    (5, TType.STRING, 'bitVectors', None, None, ),  # 5
 )
 all_structs.append(Date)
 Date.thrift_spec = (
@@ -12502,7 +12501,7 @@ DateColumnStatsData.thrift_spec = (
     (2, TType.STRUCT, 'highValue', [Date, None], None, ),  # 2
     (3, TType.I64, 'numNulls', None, None, ),  # 3
     (4, TType.I64, 'numDVs', None, None, ),  # 4
-    (5, TType.STRING, 'bitVectors', 'UTF8', None, ),  # 5
+    (5, TType.STRING, 'bitVectors', None, None, ),  # 5
 )
 all_structs.append(ColumnStatisticsData)
 ColumnStatisticsData.thrift_spec = (
@@ -12518,17 +12517,17 @@ ColumnStatisticsData.thrift_spec = (
 all_structs.append(ColumnStatisticsObj)
 ColumnStatisticsObj.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'colName', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'colType', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'colName', None, None, ),  # 1
+    (2, TType.STRING, 'colType', None, None, ),  # 2
     (3, TType.STRUCT, 'statsData', [ColumnStatisticsData, None], None, ),  # 3
 )
 all_structs.append(ColumnStatisticsDesc)
 ColumnStatisticsDesc.thrift_spec = (
     None,  # 0
     (1, TType.BOOL, 'isTblLevel', None, None, ),  # 1
-    (2, TType.STRING, 'dbName', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'tableName', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'partName', 'UTF8', None, ),  # 4
+    (2, TType.STRING, 'dbName', None, None, ),  # 2
+    (3, TType.STRING, 'tableName', None, None, ),  # 3
+    (4, TType.STRING, 'partName', None, None, ),  # 4
     (5, TType.I64, 'lastAnalyzed', None, None, ),  # 5
 )
 all_structs.append(ColumnStatistics)
@@ -12553,18 +12552,18 @@ all_structs.append(Schema)
 Schema.thrift_spec = (
     None,  # 0
     (1, TType.LIST, 'fieldSchemas', (TType.STRUCT, [FieldSchema, None], False), None, ),  # 1
-    (2, TType.MAP, 'properties', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 2
+    (2, TType.MAP, 'properties', (TType.STRING, None, TType.STRING, None, False), None, ),  # 2
 )
 all_structs.append(EnvironmentContext)
 EnvironmentContext.thrift_spec = (
     None,  # 0
-    (1, TType.MAP, 'properties', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 1
+    (1, TType.MAP, 'properties', (TType.STRING, None, TType.STRING, None, False), None, ),  # 1
 )
 all_structs.append(PrimaryKeysRequest)
 PrimaryKeysRequest.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tbl_name', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'db_name', None, None, ),  # 1
+    (2, TType.STRING, 'tbl_name', None, None, ),  # 2
 )
 all_structs.append(PrimaryKeysResponse)
 PrimaryKeysResponse.thrift_spec = (
@@ -12574,10 +12573,10 @@ PrimaryKeysResponse.thrift_spec = (
 all_structs.append(ForeignKeysRequest)
 ForeignKeysRequest.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'parent_db_name', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'parent_tbl_name', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'foreign_db_name', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'foreign_tbl_name', 'UTF8', None, ),  # 4
+    (1, TType.STRING, 'parent_db_name', None, None, ),  # 1
+    (2, TType.STRING, 'parent_tbl_name', None, None, ),  # 2
+    (3, TType.STRING, 'foreign_db_name', None, None, ),  # 3
+    (4, TType.STRING, 'foreign_tbl_name', None, None, ),  # 4
 )
 all_structs.append(ForeignKeysResponse)
 ForeignKeysResponse.thrift_spec = (
@@ -12587,9 +12586,9 @@ ForeignKeysResponse.thrift_spec = (
 all_structs.append(DropConstraintRequest)
 DropConstraintRequest.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'dbname', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tablename', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'constraintname', 'UTF8', None, ),  # 3
+    (1, TType.STRING, 'dbname', None, None, ),  # 1
+    (2, TType.STRING, 'tablename', None, None, ),  # 2
+    (3, TType.STRING, 'constraintname', None, None, ),  # 3
 )
 all_structs.append(AddPrimaryKeyRequest)
 AddPrimaryKeyRequest.thrift_spec = (
@@ -12610,10 +12609,10 @@ PartitionsByExprResult.thrift_spec = (
 all_structs.append(PartitionsByExprRequest)
 PartitionsByExprRequest.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'dbName', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tblName', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'dbName', None, None, ),  # 1
+    (2, TType.STRING, 'tblName', None, None, ),  # 2
     (3, TType.STRING, 'expr', 'BINARY', None, ),  # 3
-    (4, TType.STRING, 'defaultPartitionName', 'UTF8', None, ),  # 4
+    (4, TType.STRING, 'defaultPartitionName', None, None, ),  # 4
     (5, TType.I16, 'maxParts', None, -1, ),  # 5
 )
 all_structs.append(TableStatsResult)
@@ -12624,22 +12623,22 @@ TableStatsResult.thrift_spec = (
 all_structs.append(PartitionsStatsResult)
 PartitionsStatsResult.thrift_spec = (
     None,  # 0
-    (1, TType.MAP, 'partStats', (TType.STRING, 'UTF8', TType.LIST, (TType.STRUCT, [ColumnStatisticsObj, None], False), False), None, ),  # 1
+    (1, TType.MAP, 'partStats', (TType.STRING, None, TType.LIST, (TType.STRUCT, [ColumnStatisticsObj, None], False), False), None, ),  # 1
 )
 all_structs.append(TableStatsRequest)
 TableStatsRequest.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'dbName', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tblName', 'UTF8', None, ),  # 2
-    (3, TType.LIST, 'colNames', (TType.STRING, 'UTF8', False), None, ),  # 3
+    (1, TType.STRING, 'dbName', None, None, ),  # 1
+    (2, TType.STRING, 'tblName', None, None, ),  # 2
+    (3, TType.LIST, 'colNames', (TType.STRING, None, False), None, ),  # 3
 )
 all_structs.append(PartitionsStatsRequest)
 PartitionsStatsRequest.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'dbName', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tblName', 'UTF8', None, ),  # 2
-    (3, TType.LIST, 'colNames', (TType.STRING, 'UTF8', False), None, ),  # 3
-    (4, TType.LIST, 'partNames', (TType.STRING, 'UTF8', False), None, ),  # 4
+    (1, TType.STRING, 'dbName', None, None, ),  # 1
+    (2, TType.STRING, 'tblName', None, None, ),  # 2
+    (3, TType.LIST, 'colNames', (TType.STRING, None, False), None, ),  # 3
+    (4, TType.LIST, 'partNames', (TType.STRING, None, False), None, ),  # 4
 )
 all_structs.append(AddPartitionsResult)
 AddPartitionsResult.thrift_spec = (
@@ -12649,8 +12648,8 @@ AddPartitionsResult.thrift_spec = (
 all_structs.append(AddPartitionsRequest)
 AddPartitionsRequest.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'dbName', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tblName', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'dbName', None, None, ),  # 1
+    (2, TType.STRING, 'tblName', None, None, ),  # 2
     (3, TType.LIST, 'parts', (TType.STRUCT, [Partition, None], False), None, ),  # 3
     (4, TType.BOOL, 'ifNotExists', None, None, ),  # 4
     (5, TType.BOOL, 'needResult', None, True, ),  # 5
@@ -12669,14 +12668,14 @@ DropPartitionsExpr.thrift_spec = (
 all_structs.append(RequestPartsSpec)
 RequestPartsSpec.thrift_spec = (
     None,  # 0
-    (1, TType.LIST, 'names', (TType.STRING, 'UTF8', False), None, ),  # 1
+    (1, TType.LIST, 'names', (TType.STRING, None, False), None, ),  # 1
     (2, TType.LIST, 'exprs', (TType.STRUCT, [DropPartitionsExpr, None], False), None, ),  # 2
 )
 all_structs.append(DropPartitionsRequest)
 DropPartitionsRequest.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'dbName', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tblName', 'UTF8', None, ),  # 2
+    (1, TType.STRING, 'dbName', None, None, ),  # 1
+    (2, TType.STRING, 'tblName', None, None, ),  # 2
     (3, TType.STRUCT, 'parts', [RequestPartsSpec, None], None, ),  # 3
     (4, TType.BOOL, 'deleteData', None, None, ),  # 4
     (5, TType.BOOL, 'ifExists', None, True, ),  # 5
@@ -12688,15 +12687,15 @@ all_structs.append(ResourceUri)
 ResourceUri.thrift_spec = (
     None,  # 0
     (1, TType.I32, 'resourceType', None, None, ),  # 1
-    (2, TType.STRING, 'uri', 'UTF8', None, ),  # 2
+    (2, TType.STRING, 'uri', None, None, ),  # 2
 )
 all_structs.append(Function)
 Function.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'functionName', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'dbName', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'className', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'ownerName', 'UTF8', None, ),  # 4
+    (1, TType.STRING, 'functionName', None, None, ),  # 1
+    (2, TType.STRING, 'dbName', None, None, ),  # 2
+    (3, TType.STRING, 'className', None, None, ),  # 3
+    (4, TType.STRING, 'ownerName', None, None, ),  # 4
     (5, TType.I32, 'ownerType', None, None, ),  # 5
     (6, TType.I32, 'createTime', None, None, ),  # 6
     (7, TType.I32, 'functionType', None, None, ),  # 7
@@ -12707,11 +12706,11 @@ TxnInfo.thrift_spec = (
     None,  # 0
     (1, TType.I64, 'id', None, None, ),  # 1
     (2, TType.I32, 'state', None, None, ),  # 2
-    (3, TType.STRING, 'user', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'hostname', 'UTF8', None, ),  # 4
-    (5, TType.STRING, 'agentInfo', 'UTF8', "Unknown", ),  # 5
+    (3, TType.STRING, 'user', None, None, ),  # 3
+    (4, TType.STRING, 'hostname', None, None, ),  # 4
+    (5, TType.STRING, 'agentInfo', None, "Unknown", ),  # 5
     (6, TType.I32, 'heartbeatCount', None, 0, ),  # 6
-    (7, TType.STRING, 'metaInfo', 'UTF8', None, ),  # 7
+    (7, TType.STRING, 'metaInfo', None, None, ),  # 7
 )
 all_structs.append(GetOpenTxnsInfoResponse)
 GetOpenTxnsInfoResponse.thrift_spec = (
@@ -12730,9 +12729,9 @@ all_structs.append(OpenTxnRequest)
 OpenTxnRequest.thrift_spec = (
     None,  # 0
     (1, TType.I32, 'num_txns', None, None, ),  # 1
-    (2, TType.STRING, 'user', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'hostname', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'agentInfo', 'UTF8', "Unknown", ),  # 4
+    (2, TType.STRING, 'user', None, None, ),  # 2
+    (3, TType.STRING, 'hostname', None, None, ),  # 3
+    (4, TType.STRING, 'agentInfo', None, "Unknown", ),  # 4
 )
 all_structs.append(OpenTxnsResponse)
 OpenTxnsResponse.thrift_spec = (
@@ -12759,9 +12758,9 @@ LockComponent.thrift_spec = (
     None,  # 0
     (1, TType.I32, 'type', None, None, ),  # 1
     (2, TType.I32, 'level', None, None, ),  # 2
-    (3, TType.STRING, 'dbname', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'tablename', 'UTF8', None, ),  # 4
-    (5, TType.STRING, 'partitionname', 'UTF8', None, ),  # 5
+    (3, TType.STRING, 'dbname', None, None, ),  # 3
+    (4, TType.STRING, 'tablename', None, None, ),  # 4
+    (5, TType.STRING, 'partitionname', None, None, ),  # 5
     (6, TType.I32, 'operationType', None, 5, ),  # 6
     (7, TType.BOOL, 'isAcid', None, False, ),  # 7
 )
@@ -12770,9 +12769,9 @@ LockRequest.thrift_spec = (
     None,  # 0
     (1, TType.LIST, 'component', (TType.STRUCT, [LockComponent, None], False), None, ),  # 1
     (2, TType.I64, 'txnid', None, None, ),  # 2
-    (3, TType.STRING, 'user', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'hostname', 'UTF8', None, ),  # 4
-    (5, TType.STRING, 'agentInfo', 'UTF8', "Unknown", ),  # 5
+    (3, TType.STRING, 'user', None, None, ),  # 3
+    (4, TType.STRING, 'hostname', None, None, ),  # 4
+    (5, TType.STRING, 'agentInfo', None, "Unknown", ),  # 5
 )
 all_structs.append(LockResponse)
 LockResponse.thrift_spec = (
@@ -12795,27 +12794,27 @@ UnlockRequest.thrift_spec = (
 all_structs.append(ShowLocksRequest)
 ShowLocksRequest.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'dbname', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tablename', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'partname', 'UTF8', None, ),  # 3
+    (1, TType.STRING, 'dbname', None, None, ),  # 1
+    (2, TType.STRING, 'tablename', None, None, ),  # 2
+    (3, TType.STRING, 'partname', None, None, ),  # 3
     (4, TType.BOOL, 'isExtended', None, False, ),  # 4
 )
 all_structs.append(ShowLocksResponseElement)
 ShowLocksResponseElement.thrift_spec = (
     None,  # 0
     (1, TType.I64, 'lockid', None, None, ),  # 1
-    (2, TType.STRING, 'dbname', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'tablename', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'partname', 'UTF8', None, ),  # 4
+    (2, TType.STRING, 'dbname', None, None, ),  # 2
+    (3, TType.STRING, 'tablename', None, None, ),  # 3
+    (4, TType.STRING, 'partname', None, None, ),  # 4
     (5, TType.I32, 'state', None, None, ),  # 5
     (6, TType.I32, 'type', None, None, ),  # 6
     (7, TType.I64, 'txnid', None, None, ),  # 7
     (8, TType.I64, 'lastheartbeat', None, None, ),  # 8
     (9, TType.I64, 'acquiredat', None, None, ),  # 9
-    (10, TType.STRING, 'user', 'UTF8', None, ),  # 10
-    (11, TType.STRING, 'hostname', 'UTF8', None, ),  # 11
+    (10, TType.STRING, 'user', None, None, ),  # 10
+    (11, TType.STRING, 'hostname', None, None, ),  # 11
     (12, TType.I32, 'heartbeatCount', None, 0, ),  # 12
-    (13, TType.STRING, 'agentInfo', 'UTF8', None, ),  # 13
+    (13, TType.STRING, 'agentInfo', None, None, ),  # 13
     (14, TType.I64, 'blockedByExtId', None, None, ),  # 14
     (15, TType.I64, 'blockedByIntId', None, None, ),  # 15
     (16, TType.I64, 'lockIdInternal', None, None, ),  # 16
@@ -12846,12 +12845,12 @@ HeartbeatTxnRangeResponse.thrift_spec = (
 all_structs.append(CompactionRequest)
 CompactionRequest.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'dbname', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tablename', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'partitionname', 'UTF8', None, ),  # 3
+    (1, TType.STRING, 'dbname', None, None, ),  # 1
+    (2, TType.STRING, 'tablename', None, None, ),  # 2
+    (3, TType.STRING, 'partitionname', None, None, ),  # 3
     (4, TType.I32, 'type', None, None, ),  # 4
-    (5, TType.STRING, 'runas', 'UTF8', None, ),  # 5
-    (6, TType.MAP, 'properties', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 6
+    (5, TType.STRING, 'runas', None, None, ),  # 5
+    (6, TType.MAP, 'properties', (TType.STRING, None, TType.STRING, None, False), None, ),  # 6
 )
 all_structs.append(ShowCompactRequest)
 ShowCompactRequest.thrift_spec = (
@@ -12859,18 +12858,18 @@ ShowCompactRequest.thrift_spec = (
 all_structs.append(ShowCompactResponseElement)
 ShowCompactResponseElement.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'dbname', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tablename', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'partitionname', 'UTF8', None, ),  # 3
+    (1, TType.STRING, 'dbname', None, None, ),  # 1
+    (2, TType.STRING, 'tablename', None, None, ),  # 2
+    (3, TType.STRING, 'partitionname', None, None, ),  # 3
     (4, TType.I32, 'type', None, None, ),  # 4
-    (5, TType.STRING, 'state', 'UTF8', None, ),  # 5
-    (6, TType.STRING, 'workerid', 'UTF8', None, ),  # 6
+    (5, TType.STRING, 'state', None, None, ),  # 5
+    (6, TType.STRING, 'workerid', None, None, ),  # 6
     (7, TType.I64, 'start', None, None, ),  # 7
-    (8, TType.STRING, 'runAs', 'UTF8', None, ),  # 8
+    (8, TType.STRING, 'runAs', None, None, ),  # 8
     (9, TType.I64, 'hightestTxnId', None, None, ),  # 9
-    (10, TType.STRING, 'metaInfo', 'UTF8', None, ),  # 10
+    (10, TType.STRING, 'metaInfo', None, None, ),  # 10
     (11, TType.I64, 'endTime', None, None, ),  # 11
-    (12, TType.STRING, 'hadoopJobId', 'UTF8', "None", ),  # 12
+    (12, TType.STRING, 'hadoopJobId', None, "None", ),  # 12
 )
 all_structs.append(ShowCompactResponse)
 ShowCompactResponse.thrift_spec = (
@@ -12881,9 +12880,9 @@ all_structs.append(AddDynamicPartitions)
 AddDynamicPartitions.thrift_spec = (
     None,  # 0
     (1, TType.I64, 'txnid', None, None, ),  # 1
-    (2, TType.STRING, 'dbname', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'tablename', 'UTF8', None, ),  # 3
-    (4, TType.LIST, 'partitionnames', (TType.STRING, 'UTF8', False), None, ),  # 4
+    (2, TType.STRING, 'dbname', None, None, ),  # 2
+    (3, TType.STRING, 'tablename', None, None, ),  # 3
+    (4, TType.LIST, 'partitionnames', (TType.STRING, None, False), None, ),  # 4
     (5, TType.I32, 'operationType', None, 5, ),  # 5
 )
 all_structs.append(NotificationEventRequest)
@@ -12897,10 +12896,10 @@ NotificationEvent.thrift_spec = (
     None,  # 0
     (1, TType.I64, 'eventId', None, None, ),  # 1
     (2, TType.I32, 'eventTime', None, None, ),  # 2
-    (3, TType.STRING, 'eventType', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'dbName', 'UTF8', None, ),  # 4
-    (5, TType.STRING, 'tableName', 'UTF8', None, ),  # 5
-    (6, TType.STRING, 'message', 'UTF8', None, ),  # 6
+    (3, TType.STRING, 'eventType', None, None, ),  # 3
+    (4, TType.STRING, 'dbName', None, None, ),  # 4
+    (5, TType.STRING, 'tableName', None, None, ),  # 5
+    (6, TType.STRING, 'message', None, None, ),  # 6
 )
 all_structs.append(NotificationEventResponse)
 NotificationEventResponse.thrift_spec = (
@@ -12915,7 +12914,7 @@ CurrentNotificationEventId.thrift_spec = (
 all_structs.append(InsertEventRequestData)
 InsertEventRequestData.thrift_spec = (
     None,  # 0
-    (1, TType.LIST, 'filesAdded', (TType.STRING, 'UTF8', False), None, ),  # 1
+    (1, TType.LIST, 'filesAdded', (TType.STRING, None, False), None, ),  # 1
     (2, TType.BOOL, 'replace', None, None, ),  # 2
 )
 all_structs.append(FireEventRequestData)
@@ -12928,9 +12927,9 @@ FireEventRequest.thrift_spec = (
     None,  # 0
     (1, TType.BOOL, 'successful', None, None, ),  # 1
     (2, TType.STRUCT, 'data', [FireEventRequestData, None], None, ),  # 2
-    (3, TType.STRING, 'dbName', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'tableName', 'UTF8', None, ),  # 4
-    (5, TType.LIST, 'partitionVals', (TType.STRING, 'UTF8', False), None, ),  # 5
+    (3, TType.STRING, 'dbName', None, None, ),  # 3
+    (4, TType.STRING, 'tableName', None, None, ),  # 4
+    (5, TType.LIST, 'partitionVals', (TType.STRING, None, False), None, ),  # 5
 )
 all_structs.append(FireEventResponse)
 FireEventResponse.thrift_spec = (
@@ -12992,9 +12991,9 @@ CacheFileMetadataResult.thrift_spec = (
 all_structs.append(CacheFileMetadataRequest)
 CacheFileMetadataRequest.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'dbName', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tblName', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'partName', 'UTF8', None, ),  # 3
+    (1, TType.STRING, 'dbName', None, None, ),  # 1
+    (2, TType.STRING, 'tblName', None, None, ),  # 2
+    (3, TType.STRING, 'partName', None, None, ),  # 3
     (4, TType.BOOL, 'isAllParts', None, None, ),  # 4
 )
 all_structs.append(GetAllFunctionsResponse)
@@ -13005,97 +13004,97 @@ GetAllFunctionsResponse.thrift_spec = (
 all_structs.append(TableMeta)
 TableMeta.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'dbName', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'tableName', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'tableType', 'UTF8', None, ),  # 3
-    (4, TType.STRING, 'comments', 'UTF8', None, ),  # 4
+    (1, TType.STRING, 'dbName', None, None, ),  # 1
+    (2, TType.STRING, 'tableName', None, None, ),  # 2
+    (3, TType.STRING, 'tableType', None, None, ),  # 3
+    (4, TType.STRING, 'comments', None, None, ),  # 4
 )
 all_structs.append(MetaException)
 MetaException.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'message', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'message', None, None, ),  # 1
 )
 all_structs.append(UnknownTableException)
 UnknownTableException.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'message', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'message', None, None, ),  # 1
 )
 all_structs.append(UnknownDBException)
 UnknownDBException.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'message', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'message', None, None, ),  # 1
 )
 all_structs.append(AlreadyExistsException)
 AlreadyExistsException.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'message', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'message', None, None, ),  # 1
 )
 all_structs.append(InvalidPartitionException)
 InvalidPartitionException.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'message', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'message', None, None, ),  # 1
 )
 all_structs.append(UnknownPartitionException)
 UnknownPartitionException.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'message', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'message', None, None, ),  # 1
 )
 all_structs.append(InvalidObjectException)
 InvalidObjectException.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'message', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'message', None, None, ),  # 1
 )
 all_structs.append(NoSuchObjectException)
 NoSuchObjectException.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'message', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'message', None, None, ),  # 1
 )
 all_structs.append(IndexAlreadyExistsException)
 IndexAlreadyExistsException.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'message', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'message', None, None, ),  # 1
 )
 all_structs.append(InvalidOperationException)
 InvalidOperationException.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'message', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'message', None, None, ),  # 1
 )
 all_structs.append(ConfigValSecurityException)
 ConfigValSecurityException.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'message', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'message', None, None, ),  # 1
 )
 all_structs.append(InvalidInputException)
 InvalidInputException.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'message', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'message', None, None, ),  # 1
 )
 all_structs.append(NoSuchTxnException)
 NoSuchTxnException.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'message', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'message', None, None, ),  # 1
 )
 all_structs.append(TxnAbortedException)
 TxnAbortedException.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'message', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'message', None, None, ),  # 1
 )
 all_structs.append(TxnOpenException)
 TxnOpenException.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'message', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'message', None, None, ),  # 1
 )
 all_structs.append(NoSuchLockException)
 NoSuchLockException.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'message', 'UTF8', None, ),  # 1
+    (1, TType.STRING, 'message', None, None, ),  # 1
 )
 all_structs.append(GetPartitionsProjectionSpec)
 GetPartitionsProjectionSpec.thrift_spec = (
     None,  # 0
-    (1, TType.LIST, 'fieldList', (TType.STRING, 'UTF8', False), None, ),  # 1
-    (2, TType.STRING, 'includeParamKeyPattern', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'excludeParamKeyPattern', 'UTF8', None, ),  # 3
+    (1, TType.LIST, 'fieldList', (TType.STRING, None, False), None, ),  # 1
+    (2, TType.STRING, 'includeParamKeyPattern', None, None, ),  # 2
+    (3, TType.STRING, 'excludeParamKeyPattern', None, None, ),  # 3
 )
 all_structs.append(GetPartitionsFilterSpec)
 GetPartitionsFilterSpec.thrift_spec = (
@@ -13107,7 +13106,7 @@ GetPartitionsFilterSpec.thrift_spec = (
     None,  # 5
     None,  # 6
     (7, TType.I32, 'filterMode', None, None, ),  # 7
-    (8, TType.LIST, 'filters', (TType.STRING, 'UTF8', False), None, ),  # 8
+    (8, TType.LIST, 'filters', (TType.STRING, None, False), None, ),  # 8
 )
 all_structs.append(GetPartitionsResponse)
 GetPartitionsResponse.thrift_spec = (
@@ -13117,12 +13116,12 @@ GetPartitionsResponse.thrift_spec = (
 all_structs.append(GetPartitionsRequest)
 GetPartitionsRequest.thrift_spec = (
     None,  # 0
-    (1, TType.STRING, 'catName', 'UTF8', None, ),  # 1
-    (2, TType.STRING, 'dbName', 'UTF8', None, ),  # 2
-    (3, TType.STRING, 'tblName', 'UTF8', None, ),  # 3
+    (1, TType.STRING, 'catName', None, None, ),  # 1
+    (2, TType.STRING, 'dbName', None, None, ),  # 2
+    (3, TType.STRING, 'tblName', None, None, ),  # 3
     (4, TType.BOOL, 'withAuth', None, None, ),  # 4
-    (5, TType.STRING, 'user', 'UTF8', None, ),  # 5
-    (6, TType.LIST, 'groupNames', (TType.STRING, 'UTF8', False), None, ),  # 6
+    (5, TType.STRING, 'user', None, None, ),  # 5
+    (6, TType.LIST, 'groupNames', (TType.STRING, None, False), None, ),  # 6
     (7, TType.STRUCT, 'projectionSpec', [GetPartitionsProjectionSpec, None], None, ),  # 7
     (8, TType.STRUCT, 'filterSpec', [GetPartitionsFilterSpec, None], None, ),  # 8
 )

--- a/impala/tests/test_data_types.py
+++ b/impala/tests/test_data_types.py
@@ -68,3 +68,11 @@ def test_date_basic(cur, date_table):
     cur.execute('select d from {0} order by d'.format(date_table))
     results = cur.fetchall()
     assert results == [(datetime.date(1, 1, 1),), (datetime.date(1999, 9, 9),)]
+
+@pytest.mark.connect
+def test_utf8_strings(cur):
+    """Use a string with multi byte unicode code points in a query."""
+    cur.execute('select "\xE4\xBD\xA0\xE5\xA5\xBD"')
+    results = cur.fetchall()
+    assert results == [("\xE4\xBD\xA0\xE5\xA5\xBD",)]
+

--- a/impala/thrift/process_thrift.sh
+++ b/impala/thrift/process_thrift.sh
@@ -28,57 +28,61 @@ set +u
 source $IMPALA_REPO/bin/impala-config.sh
 set -u
 
-echo "Copying thrift files from the main Impala repo at $IMPALA_REPO"
-cp $IMPALA_REPO/common/thrift/hive-3-api/TCLIService.thrift $IMPYLA_REPO/impala/thrift
-cp $IMPALA_REPO/common/thrift/ImpalaService.thrift $IMPYLA_REPO/impala/thrift
-cp $IMPALA_REPO/common/thrift/ErrorCodes.thrift $IMPYLA_REPO/impala/thrift
-cp $IMPALA_REPO/common/thrift/ExecStats.thrift $IMPYLA_REPO/impala/thrift
-cp $IMPALA_REPO/common/thrift/Metrics.thrift $IMPYLA_REPO/impala/thrift
-cp $IMPALA_REPO/common/thrift/RuntimeProfile.thrift $IMPYLA_REPO/impala/thrift
-cp $IMPALA_REPO/common/thrift/Status.thrift $IMPYLA_REPO/impala/thrift
-cp $IMPALA_REPO/common/thrift/Types.thrift $IMPYLA_REPO/impala/thrift
+SYNC_IMPYLA_THRIFT_FILES="${SYNC_IMPYLA_THRIFT_FILES:-false}"
+if [ "$SYNC_IMPYLA_THRIFT_FILES" = true ] ; then
+  echo "Copying thrift files from the main Impala repo at $IMPALA_REPO"
+  cp $IMPALA_REPO/common/thrift/hive-3-api/TCLIService.thrift $IMPYLA_REPO/impala/thrift
+  cp $IMPALA_REPO/common/thrift/ImpalaService.thrift $IMPYLA_REPO/impala/thrift
+  cp $IMPALA_REPO/common/thrift/ErrorCodes.thrift $IMPYLA_REPO/impala/thrift
+  cp $IMPALA_REPO/common/thrift/ExecStats.thrift $IMPYLA_REPO/impala/thrift
+  cp $IMPALA_REPO/common/thrift/Metrics.thrift $IMPYLA_REPO/impala/thrift
+  cp $IMPALA_REPO/common/thrift/RuntimeProfile.thrift $IMPYLA_REPO/impala/thrift
+  cp $IMPALA_REPO/common/thrift/Status.thrift $IMPYLA_REPO/impala/thrift
+  cp $IMPALA_REPO/common/thrift/Types.thrift $IMPYLA_REPO/impala/thrift
+  cp $IMPALA_TOOLCHAIN_PACKAGES_HOME/thrift-$IMPALA_THRIFT_VERSION/share/fb303/if/fb303.thrift \
+      $IMPYLA_REPO/impala/thrift
 
-echo "Copying thrift from $IMPALA_THRIFT_VERSION"
-cp $IMPALA_TOOLCHAIN_PACKAGES_HOME/thrift-$IMPALA_THRIFT_VERSION/share/fb303/if/fb303.thrift \
-    $IMPYLA_REPO/impala/thrift
 
-# beeswax.thrift already includes a namespace py declaration, which breaks my
-# directory structure, so here I delete it (in preparation for adding the proper
-# namespace declaration below)
-grep -v 'namespace py beeswaxd' $IMPALA_REPO/common/thrift/beeswax.thrift \
-        > $IMPYLA_REPO/impala/thrift/beeswax.thrift
+  # beeswax.thrift already includes a namespace py declaration, which breaks my
+  # directory structure, so here I delete it (in preparation for adding the proper
+  # namespace declaration below)
+  grep -v 'namespace py beeswaxd' $IMPALA_REPO/common/thrift/beeswax.thrift \
+          > $IMPYLA_REPO/impala/thrift/beeswax.thrift
 
-# hive_metastore.thrift assumes a directory structure for fb303.thrift, so we
-# change the include statement here
-cat $HIVE_SRC_DIR/standalone-metastore/src/main/thrift/hive_metastore.thrift \
-        | sed 's/share\/fb303\/if\///g' \
-        > $IMPYLA_REPO/impala/thrift/hive_metastore.thrift
+  # hive_metastore.thrift assumes a directory structure for fb303.thrift, so we
+  # change the include statement here
 
-# We add "namespace py" statements to all the thrift files so we can get the
-# appropriate directory structure
-echo "Adding namespace py lines to thrift files"
-for THRIFT_FILE in $IMPYLA_REPO/impala/thrift/*.thrift; do
-    FILE_NAME=$(basename $THRIFT_FILE)
-    BASE_NAME=${FILE_NAME%.*}
-    ADD_NAMESPACE_PY="
-        BEGIN {
-            n = 0
-        }
-        {
-            if (\$0 ~ /^namespace/ && n == 0) {
-                print \"namespace py impala._thrift_gen.$BASE_NAME\";
-                n += 1;
-            }
-            print \$0;
-        }"
-    echo "    $BASE_NAME"
-    cat $THRIFT_FILE | awk "$ADD_NAMESPACE_PY" > $IMPYLA_REPO/impala/thrift/temp.thrift
-    mv $IMPYLA_REPO/impala/thrift/temp.thrift $THRIFT_FILE
-done
+  cat $HIVE_SRC_DIR/standalone-metastore/src/main/thrift/hive_metastore.thrift \
+          | sed 's/share\/fb303\/if\///g' \
+          > $IMPYLA_REPO/impala/thrift/hive_metastore.thrift
+
+
+  # We add "namespace py" statements to all the thrift files so we can get the
+  # appropriate directory structure
+  echo "Adding namespace py lines to thrift files"
+  for THRIFT_FILE in $IMPYLA_REPO/impala/thrift/*.thrift; do
+      FILE_NAME=$(basename $THRIFT_FILE)
+      BASE_NAME=${FILE_NAME%.*}
+      ADD_NAMESPACE_PY="
+          BEGIN {
+              n = 0
+          }
+          {
+              if (\$0 ~ /^namespace/ && n == 0) {
+                  print \"namespace py impala._thrift_gen.$BASE_NAME\";
+                  n += 1;
+              }
+              print \$0;
+          }"
+      echo "    $BASE_NAME"
+      cat $THRIFT_FILE | awk "$ADD_NAMESPACE_PY" > $IMPYLA_REPO/impala/thrift/temp.thrift
+      mv $IMPYLA_REPO/impala/thrift/temp.thrift $THRIFT_FILE
+  done
+fi
 
 echo "Generating thrift python modules"
 THRIFT_BIN="$IMPALA_TOOLCHAIN_PACKAGES_HOME/thrift-$IMPALA_THRIFT_VERSION/bin/thrift"
-$THRIFT_BIN -r --gen py:new_style -out $IMPYLA_REPO $IMPYLA_REPO/impala/thrift/ImpalaService.thrift
+$THRIFT_BIN -r --gen py:new_style,no_utf8strings -out $IMPYLA_REPO $IMPYLA_REPO/impala/thrift/ImpalaService.thrift
 
 echo "Removing extraneous $IMPYLA_REPO/__init__.py"
 rm -f $IMPYLA_REPO/__init__.py


### PR DESCRIPTION
Switching to thrift 0.11.0 caused calling .decode('utf-8','replace')
in Python 2.* on every deserialized string value, which meant that
Impyla returned 'unicode' instead of 'string' type for strings in
result sets. Thrift does this to keep Python 2 and 3 behavior as
similar as possible, but in our case this is a potential breaking
change.

The fix is to set no_utf8strings option in the thrift compiler.
An alternative would have been to re encode 'unicode' results to
'string' before returning the results, but that could lead to
regression in performance and break usages of strings that are
not valid utf8.

Other changes:
- a unicode test is added to test_data_types.py which would fail
  in Python 2.* without this fix
- process_thrift.sh is changed to not sync thrift files from Impala
  by default, so now it is a simple tool to recompile thrift files