### PR TITLE
Extensions to SQLAlchemy ImpalaDLLCompiler to support Alembic schema migrations

### DIFF
--- a/impala/sqlalchemy.py
+++ b/impala/sqlalchemy.py
@@ -102,8 +102,11 @@ class ImpalaTypeCompiler(GenericTypeCompiler):
     def visit_DATETIME(self, type_):
         return 'TIMESTAMP'
 
-    visit_DATE = visit_DATETIME
     visit_TIME = visit_DATETIME
+
+    # Impala > 3.4.0 support the DATE type - https://issues.apache.org/jira/browse/IMPALA-6169
+    def visit_DATE(self, type_):
+        return 'DATE'
 
     def visit_TINYINT(self, type_):
         return 'TINYINT'

--- a/impala/sqlalchemy.py
+++ b/impala/sqlalchemy.py
@@ -89,14 +89,11 @@ class ImpalaTypeCompiler(GenericTypeCompiler):
     # pylint: disable=unused-argument
 
     # https://docs.cloudera.com/documentation/enterprise/6/6.3/topics/impala_porting.html
-    # Impala only supports the STRING type
-    def visit_VARCHAR(self, type_):
+    def visit_TEXT(self, type_):
         return 'STRING'
 
-    visit_NCHAR = visit_VARCHAR
-    visit_VARCHAR = visit_VARCHAR
-    visit_NVARCHAR = visit_VARCHAR
-    visit_TEXT = visit_VARCHAR
+    visit_NCHAR = visit_TEXT
+    visit_NVARCHAR = visit_TEXT
 
     # Impala only supports the TIMESTAMP type
     def visit_DATETIME(self, type_):

--- a/impala/sqlalchemy.py
+++ b/impala/sqlalchemy.py
@@ -48,11 +48,11 @@ class STRING(String):
 
 
 class ImpalaDDLCompiler(DDLCompiler):
-    # Impala has no support for foreign keys.
+    # Omit support for foreign keys due to Impala's limited support - https://issues.apache.org/jira/browse/IMPALA-2112
     def visit_foreign_key_constraint(self, constraint):
         return None
 
-    # Impala has no support for primary keys.
+    # Omit support for primary keys due to Impala's limited support - https://issues.apache.org/jira/browse/IMPALA-2112
     def visit_primary_key_constraint(self, constraint):
         return None
 

--- a/impala/sqlalchemy.py
+++ b/impala/sqlalchemy.py
@@ -95,15 +95,14 @@ class ImpalaTypeCompiler(GenericTypeCompiler):
     visit_NCHAR = visit_TEXT
     visit_NVARCHAR = visit_TEXT
 
-    # Impala only supports the TIMESTAMP type
     def visit_DATETIME(self, type_):
         return 'TIMESTAMP'
 
+    # Most Impala versions only support the TIMESTAMP type
+    # TODO Impala > 3.4.0 supports the DATE type - https://issues.apache.org/jira/browse/IMPALA-6169
+    #      A future improvement would be to introduce an additional impala4 dialect that supports DATE
     visit_TIME = visit_DATETIME
-
-    # Impala > 3.4.0 support the DATE type - https://issues.apache.org/jira/browse/IMPALA-6169
-    def visit_DATE(self, type_):
-        return 'DATE'
+    visit_DATE = visit_DATETIME
 
     def visit_TINYINT(self, type_):
         return 'TINYINT'

--- a/impala/sqlalchemy.py
+++ b/impala/sqlalchemy.py
@@ -68,6 +68,9 @@ class ImpalaDDLCompiler(DDLCompiler):
 
         table_opts = []
 
+        if 'impala_partitioned_by' in table.kwargs:
+            table_opts.append('PARTITIONED BY %s' % table.kwargs.get('impala_partitioned_by'))
+
         if 'impala_partition_by' in table.kwargs:
             table_opts.append('PARTITION BY %s' % table.kwargs.get('impala_partition_by'))
 


### PR DESCRIPTION
Specifically, 

1. Extend ImpalaDLLCompiler to prevent CONSTRAINT and NOT NULL clauses being added to CreateTable DDL and 
2. Translate all "string" types to STRING and "datetime" types to TIMESTAMP.

This prevents the `alembic_version` table DDL from containing a primary key constraint and a NOT NULL VARCHAR column that aren't supported in an Impala TEXT table.