### PR TITLE
Add buffering to hs2-http

### DIFF
--- a/impala/_thrift_api.py
+++ b/impala/_thrift_api.py
@@ -428,6 +428,9 @@ def get_http_transport(host, port, http_path, timeout=None, use_ssl=False,
 
         transport.setGetCustomHeadersFunc(get_auth_headers)
 
+    # Without buffering Thrift would call socket.recv() each time it deserializes
+    # something (e.g. a member in a struct).
+    transport = TBufferedTransport(transport)
     return transport
 
 


### PR DESCRIPTION
This can lead to ~6x speed up when fetching a large amount of data.
For details see:
https://github.com/apache/impala/commit/f672c315bc4d08d56cc7399b86767d30c9676287