### PR TITLE
Speed up fetchmany() and fetchall()

### DIFF
--- a/impala/compat.py
+++ b/impala/compat.py
@@ -30,3 +30,8 @@ elif six.PY2:
         from cdecimal import Decimal
     except ImportError:
         from decimal import Decimal  # noqa
+
+try:
+  _xrange = xrange
+except NameError:
+  _xrange = range  # python3 compatibilty

--- a/impala/tests/test_hs2_fault_injection.py
+++ b/impala/tests/test_hs2_fault_injection.py
@@ -268,7 +268,7 @@ class TestHS2FaultInjection(object):
         con = self.connect()
         cur = con.cursor(configuration=self.configuration)
         caplog.set_level(logging.DEBUG)
-        cur.execute('select 1', {})
+        cur.execute_async('select 1', {})
         self.transport.enable_fault(502, "Injected Fault", 0.1)
         cur.fetchall()
         cur.close()

--- a/impala/tests/test_impala.py
+++ b/impala/tests/test_impala.py
@@ -14,13 +14,10 @@
 import sys
 
 import pytest
+from impala.compat import _xrange as xrange
 from pytest import yield_fixture
 
 BIGGER_TABLE_NUM_ROWS = 100
-
-if sys.version_info >= (3, 0):
-    def xrange(*args, **kwargs):
-        return iter(range(*args, **kwargs))
 
 @yield_fixture(scope='module')
 def bigger_table(cur):


### PR DESCRIPTION
Optimized the code that transposes columnar batches to rows, now it
takes similar time as the related logic in impala-shell.

Benchmarked with "select * from tpch_parquet.lineitem limit 100000"
(convert_types=False, batches of 1024):
Python 2: 1.38 sec -> 0.89 sec
Python 3: 1.25 sec -> 0.76 sec

Testing:
- Ran the tests with Python 2 and 3, ImpalaDBAPI20Test gives fair
  coverage to the modified functions.
- Also tested row based batches by using HIVE_CLI_SERVICE_PROTOCOL_V5.
  There were no new broken tests besides the ones that already fail.