### PR TITLE
Hack to fix non-valid utf-8 stings handling in Python 3

### DIFF
--- a/impala/_thrift_gen/TCLIService/ttypes.py
+++ b/impala/_thrift_gen/TCLIService/ttypes.py
@@ -2348,7 +2348,7 @@ class TStringColumn(object):
                     self.values = []
                     (_etype93, _size90) = iprot.readListBegin()
                     for _i94 in range(_size90):
-                        _elem95 = iprot.readString()
+                        _elem95 = iprot.readBinary()
                         self.values.append(_elem95)
                     iprot.readListEnd()
                 else:
@@ -2372,7 +2372,7 @@ class TStringColumn(object):
             oprot.writeFieldBegin('values', TType.LIST, 1)
             oprot.writeListBegin(TType.STRING, len(self.values))
             for iter96 in self.values:
-                oprot.writeString(iter96)
+                oprot.writeBinary(iter96)
             oprot.writeListEnd()
             oprot.writeFieldEnd()
         if self.nulls is not None:
@@ -6299,7 +6299,7 @@ TDoubleColumn.thrift_spec = (
 all_structs.append(TStringColumn)
 TStringColumn.thrift_spec = (
     None,  # 0
-    (1, TType.LIST, 'values', (TType.STRING, None, False), None, ),  # 1
+    (1, TType.LIST, 'values', (TType.STRING, 'BINARY', False), None, ),  # 1
     (2, TType.STRING, 'nulls', 'BINARY', None, ),  # 2
 )
 all_structs.append(TBinaryColumn)

--- a/impala/tests/test_data_types.py
+++ b/impala/tests/test_data_types.py
@@ -1,3 +1,4 @@
+# -*- coding: UTF-8 -*-
 # Copyright 2015 Cloudera Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +16,6 @@
 import datetime
 import pytest
 from pytest import yield_fixture
-
 
 @yield_fixture(scope='module')
 def decimal_table(cur):
@@ -72,7 +72,19 @@ def test_date_basic(cur, date_table):
 @pytest.mark.connect
 def test_utf8_strings(cur):
     """Use a string with multi byte unicode code points in a query."""
-    cur.execute('select "\xE4\xBD\xA0\xE5\xA5\xBD"')
-    results = cur.fetchall()
-    assert results == [("\xE4\xBD\xA0\xE5\xA5\xBD",)]
+    cur.execute('select "引擎"')
+    result = cur.fetchone()[0]
+    assert result == "引擎"
 
+    # Tests returning strings that are not valid UTF-8.
+    # With Python 3 and Thrift 0.11.0 these tests needed TCLIService.thrift to be
+    # modified. Syncing thrift files from Hive/Impala is likely to break these tests.
+    cur.execute('select substr("引擎", 1, 4)')
+    result = cur.fetchone()[0]
+    assert result == b"\xe5\xbc\x95\xe6"
+    assert result.decode("UTF-8", "replace") == u"引�"
+
+    cur.execute('select unhex("AA")')
+    result = cur.fetchone()[0]
+    assert result == b"\xaa"
+    assert result.decode("UTF-8", "replace") == u"�"

--- a/impala/thrift/TCLIService.thrift
+++ b/impala/thrift/TCLIService.thrift
@@ -363,7 +363,10 @@ struct TDoubleColumn {
 }
 
 struct TStringColumn {
-  1: required list<string> values
+  // This was modified in Impyla (compared to Hive/Impala).
+  // Changed from list<binary> to list<string> to be able to do handle non-valid utf-8
+  // strings in Python 3.
+  1: required list<binary> values
   2: required binary nulls
 }
 


### PR DESCRIPTION
The Thrift lib used with Python 3 was changed from thriftpy2 to
Apache Thrift in https://github.com/cloudera/impyla/pull/439
which broke the handling of STRING columns that contain values that
are not valid utf-8, as the library always throws an exception in
this case.

The hack to fix it is to change TStringColumn's underlying Thrift type
to 'binary' instead of 'string' and do the conversion in Impyla code.

Impala patches Thrift to solve the same issue in impala-shell,
see THRIFT-5303. I prefer a different solution for now for 2 reasons:
- THRIFT-5303 is only released in Thrift in 0.14.0, and bumping
  from 0.11.0 to 0.14.0 needs more consideration.
- The way it solves the issue (replacing invalid chars) is good
  for impala-shell where the final output is always text, but its
  lossiness makes it unsuitable if we actually want to transfer
  binary data in STRING.

Testing:
- added tests with SELECTs that return non-valid uft8 strings
- ran the tests with Python 2/3 + Apache Thrift/thriftpy2
  + BinaryProtocol/BinaryProtocolAccelerated
- saw some performance regression (5-10%) in Python 3, but it seems
  negligible compared to the ~6x gain from switching to Apache Thrift