### PR TITLE
Update setup.py: thrift-sasl is needed for ldap/plain authentication

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,11 +41,9 @@ setup(
     packages=find_packages(),
     install_package_data=True,
     package_data={'impala.thrift': ['*.thrift']},
-    install_requires=['six', 'bitarray', 'thrift==0.11.0'],
+    install_requires=['six', 'bitarray', 'thrift==0.11.0', 'thrift_sasl==0.4.3a2'],
     extras_require={
-        "kerberos": ["thrift_sasl==0.4.3a2",
-                     "kerberos>=1.3.0",
-                    ],
+        "kerberos": ['kerberos>=1.3.0'],
     },
     keywords=('cloudera impala python hadoop sql hdfs mpp spark pydata '
               'pandas distributed db api pep 249 hive hiveserver2 hs2'),


### PR DESCRIPTION
thrift-sasl dependency was installed only with kerberos support.
This is incorrect as thrift-sasl is needed for ldap/plain authentication
as well.