### PR TITLE
Fix TIMESTAMP handling regression in #445

### DIFF
--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -994,7 +994,7 @@ class CBatch(Batch):
         return values
 
     def _convert_strings_to_unicode(self, type_, is_null, values):
-        if type_ in ["STRING", "LIST", "MAP", "STRUCT", "UNIONTYPE", "DECIMAL", "DATE", "NULL"]:
+        if type_ in ["STRING", "LIST", "MAP", "STRUCT", "UNIONTYPE", "DECIMAL", "DATE", "TIMESTAMP", "NULL"]:
             for i in range(len(values)):
                 if is_null[i]:
                     values[i] = None


### PR DESCRIPTION
TIMESTAMP was omitted from `_convert_strings_to_unicode`, causing `_parse_timestamp` to receive a bytes-like object for any returned column with a timestamp type.

Before:
```
2021-05-17 02:00:06,858 DEBUG sqlalchemy.pool.impl.QueuePool Created new connection <impala.hiveserver2.HiveServer2Connection object at 0x7f912df6ea50>
2021-05-17 02:00:06,859 DEBUG sqlalchemy.pool.impl.QueuePool Connection <impala.hiveserver2.HiveServer2Connection object at 0x7f912df6ea50> checked out from pool
2021-05-17 02:00:07,174 INFO sqlalchemy.engine.base.Engine SELECT type, fired_at FROM MyCompany.Zendesk.Zendesk_Webhook LIMIT 2
2021-05-17 02:00:07,175 INFO sqlalchemy.engine.base.Engine {}
2021-05-17 02:00:11,630 INFO sqlalchemy.engine.base.Engine ROLLBACK
Traceback (most recent call last):
  File "superset/test1.py", line 8, in <module>
    print(engine.execute("SELECT * FROM MyCompany.Zendesk.Zendesk_Webhook LIMIT 2").fetchall())
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/result.py", line 1289, in fetchall
    e, None, None, self.cursor, self.context
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/base.py", line 1514, in _handle_dbapi_exception
    util.raise_(exc_info[1], with_traceback=exc_info[2])
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/util/compat.py", line 182, in raise_
    raise exception
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/result.py", line 1284, in fetchall
    l = self.process_rows(self._fetchall_impl())
  File "/usr/local/lib/python3.7/site-packages/sqlalchemy/engine/result.py", line 1230, in _fetchall_impl
    return self.cursor.fetchall()
  File "/usr/local/lib/python3.7/site-packages/impala/hiveserver2.py", line 553, in fetchall
    elements = self._pop_from_buffer(self.buffersize)
  File "/usr/local/lib/python3.7/site-packages/impala/hiveserver2.py", line 619, in _pop_from_buffer
    self._ensure_buffer_is_filled()
  File "/usr/local/lib/python3.7/site-packages/impala/hiveserver2.py", line 607, in _ensure_buffer_is_filled
    convert_types=self.convert_types)
  File "/usr/local/lib/python3.7/site-packages/impala/hiveserver2.py", line 1405, in fetch
    convert_types=convert_types)
  File "/usr/local/lib/python3.7/site-packages/impala/hiveserver2.py", line 1410, in _wrap_results
    return CBatch(results, expect_more_rows, schema, convert_types=convert_types)
  File "/usr/local/lib/python3.7/site-packages/impala/hiveserver2.py", line 988, in __init__
    values = self._convert_values(type_, is_null, values)
  File "/usr/local/lib/python3.7/site-packages/impala/hiveserver2.py", line 997, in _convert_values
    _parse_timestamp(values[i]))
  File "/usr/local/lib/python3.7/site-packages/impala/hiveserver2.py", line 798, in _parse_timestamp
    match = _TIMESTAMP_PATTERN.match(value)
TypeError: cannot use a string pattern on a bytes-like object
```

After:
```
2021-05-17 02:12:31,765 DEBUG sqlalchemy.pool.impl.QueuePool Created new connection <impala.hiveserver2.HiveServer2Connection object at 0x7f1becc3aa50>
2021-05-17 02:12:31,766 DEBUG sqlalchemy.pool.impl.QueuePool Connection <impala.hiveserver2.HiveServer2Connection object at 0x7f1becc3aa50> checked out from pool
2021-05-17 02:12:32,084 INFO sqlalchemy.engine.base.Engine SELECT type, fired_at FROM MyCompany.Zendesk.Zendesk_Webhook LIMIT 2
2021-05-17 02:12:32,084 INFO sqlalchemy.engine.base.Engine {}
[('create', datetime.datetime(2021, 1, 11, 17, 52, 46, 612000)), ('create', datetime.datetime(2021, 1, 11, 17, 53, 16, 942000))]
2021-05-17 02:12:35,268 DEBUG sqlalchemy.pool.impl.QueuePool Connection <impala.hiveserver2.HiveServer2Connection object at 0x7f1becc3aa50> being returned to pool
2021-05-17 02:12:35,269 DEBUG sqlalchemy.pool.impl.QueuePool Connection <impala.hiveserver2.HiveServer2Connection object at 0x7f1becc3aa50> rollback-on-return
```