### PR TITLE
Added missing expect_more_rows argument

### DIFF
--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -1342,7 +1342,8 @@ class Operation(ThriftRPC):
                                    fetchType=1)
             resp = self._rpc('FetchResults', req, False)
             schema = [('Log', 'STRING', None, None, None, None, None)]
-            log = self._wrap_results(resp.results, schema, convert_types=True)
+            log = self._wrap_results(resp.results, resp.hasMoreRows, schema,
+                                     convert_types=True)
             log = '\n'.join(l[0] for l in log)
         return log
 


### PR DESCRIPTION
When I implementing get_log in my project found an issue.  
https://github.com/cloudera/impyla/blob/v0.17.0/impala/hiveserver2.py#L1345

_wrap_results takes three positional arguments but passing two arguments.