### PR TITLE
This allows multiple insert

### DIFF
--- a/impala/sqlalchemy.py
+++ b/impala/sqlalchemy.py
@@ -190,6 +190,7 @@ class ImpalaDialect(DefaultDialect):
     max_identifier_length = 128
     supports_sane_rowcount = False
     supports_sane_multi_rowcount = False
+    supports_multivalues_insert = True
     supports_sequences = False
     supports_native_decimal = True
     supports_native_boolean = True


### PR DESCRIPTION
This enabled multiple insert which is supported by Impala and increases insert performance tremendously for huge inserts (42 inserts per second vs 5000 inserts per second).

  allToBeInserted.to_sql('dbtable', engine, if_exists='append', index=False,chunksize=2000,**method='multi')**

Multi insert allows passing of multiple values in a single INSERT clause (like a batch) and increases performance of insert