### PR TITLE
Add support for authentication via JWT token

### DIFF
--- a/impala/_thrift_api.py
+++ b/impala/_thrift_api.py
@@ -304,7 +304,7 @@ def get_socket(host, port, use_ssl, ca_cert):
 def get_http_transport(host, port, http_path, timeout=None, use_ssl=False,
                        ca_cert=None, auth_mechanism='NOSASL', user=None,
                        password=None, kerberos_host=None, kerberos_service_name=None,
-                       auth_cookie_names=None):
+                       auth_cookie_names=None, jwt=None):
     # TODO: support timeout
     if timeout is not None:
         log.error('get_http_transport does not support a timeout')
@@ -363,6 +363,10 @@ def get_http_transport(host, port, http_path, timeout=None, use_ssl=False,
                 return {"Authorization": "Negotiate " + negotiate_details}
 
         transport.setGetCustomHeadersFunc(get_auth_headers)
+    elif auth_mechanism == 'JWT':
+      # For JWT authentication, the JWT is sent on the Authorization Bearer
+      # HTTP header.
+      transport.setCustomHeaders({'Authorization': 'Bearer {0}'.format(jwt)})
 
     # Without buffering Thrift would call socket.recv() each time it deserializes
     # something (e.g. a member in a struct).

--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -827,7 +827,7 @@ def threaded(func):
 def connect(host, port, timeout=None, use_ssl=False, ca_cert=None,
             user=None, password=None, kerberos_service_name='impala',
             auth_mechanism=None, krb_host=None, use_http_transport=False,
-            http_path='', auth_cookie_names=None, retries=3):
+            http_path='', auth_cookie_names=None, retries=3, jwt=None):
     log.debug('Connecting to HiveServer2 %s:%s with %s authentication '
               'mechanism', host, port, auth_mechanism)
 
@@ -848,7 +848,8 @@ def connect(host, port, timeout=None, use_ssl=False, ca_cert=None,
                                        user=user, password=password,
                                        kerberos_host=kerberos_host,
                                        kerberos_service_name=kerberos_service_name,
-                                       auth_cookie_names=auth_cookie_names)
+                                       auth_cookie_names=auth_cookie_names,
+                                       jwt=jwt)
     else:
         sock = get_socket(host, port, use_ssl, ca_cert)
 

--- a/impala/util.py
+++ b/impala/util.py
@@ -167,6 +167,17 @@ def warn_deprecate(functionality='This', alternative=None):
     warnings.warn(msg, Warning)
 
 
+def warn_unused_jwt():
+    msg = ("The JWT argument is ignored as auth_mechanism is not 'JWT'. "
+           "Specify auth_mechanism='JWT' to make use of JWT authentication.")
+    warnings.warn(msg, Warning)
+
+
+def warn_nontls_jwt():
+    msg = ("JWT authentication is running without SSL/TLS. This is not a secure "
+           "configuration unless other layers are providing transport security.")
+    warnings.warn(msg, Warning)
+
 # Cookie-related utils
 
 


### PR DESCRIPTION
Impala recently added support for authentication via a JWT
token in IMPALA-10489. This allows a user to authenticate
with a separate trusted authentication service, obtain
a JWT, and pass that JWT to Impala on the Authencation
Bearer HTTP header.

This implements support for connecting with auth_mechanism=JWT,
which requires a 'jwt' argument specifying the standard string
encoding for the JWT. This is passed on the Authentication Bearer
HTTP header on each message.

Fixes #462

Testing:
 - Added unit tests in test_dbapi_connect.py
 - Tested against a running Impala cluster with JWT authentication