### PR TITLE
Add support for retaining cookies among http requests for LDAP and GSSAPI/PLAIN SASL #464

### DIFF
--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -827,7 +827,7 @@ def threaded(func):
 def connect(host, port, timeout=None, use_ssl=False, ca_cert=None,
             user=None, password=None, kerberos_service_name='impala',
             auth_mechanism=None, krb_host=None, use_http_transport=False,
-            http_path='', auth_cookie_names=None, retries=3, jwt=None):
+            http_path='', http_cookie_names=None, retries=3, jwt=None):
     log.debug('Connecting to HiveServer2 %s:%s with %s authentication '
               'mechanism', host, port, auth_mechanism)
 
@@ -848,7 +848,7 @@ def connect(host, port, timeout=None, use_ssl=False, ca_cert=None,
                                        user=user, password=password,
                                        kerberos_host=kerberos_host,
                                        kerberos_service_name=kerberos_service_name,
-                                       auth_cookie_names=auth_cookie_names,
+                                       http_cookie_names=http_cookie_names,
                                        jwt=jwt)
     else:
         sock = get_socket(host, port, use_ssl, ca_cert)

--- a/impala/tests/test_util.py
+++ b/impala/tests/test_util.py
@@ -23,7 +23,7 @@ else:
     import unittest
 
 import pytest
-from impala.util import cookie_matches_path, get_cookie_expiry, get_first_matching_cookie
+from impala.util import cookie_matches_path, get_cookie_expiry, get_all_matching_cookies
 
 
 class ImpalaUtilTests(unittest.TestCase):
@@ -78,49 +78,59 @@ class ImpalaUtilTests(unittest.TestCase):
         assert now + days2k <= get_cookie_expiry({'max-age': '172800000'}) <= now + days2k + sec
 
 
-    def test_get_first_matching_cookie(self):
-        assert get_first_matching_cookie(['a', 'b'], '/path', {}) is None
+    def test_get_all_matching_cookies(self):
+        cookies = get_all_matching_cookies(['a', 'b'], '/path', {})
+        assert not cookies
 
         headers = {'Set-Cookie': '''c_cookie=c_value
         b_cookie=b_value
         a_cookie=a_value'''}
-        c = get_first_matching_cookie(['a_cookie', 'b_cookie'], '/path', headers)
-        assert c.key == 'a_cookie' and c.value == 'a_value'
-        c = get_first_matching_cookie(['b_cookie', 'a_cookie'], '/path', headers)
-        assert c.key == 'b_cookie' and c.value == 'b_value'
+        cookies = get_all_matching_cookies(['a_cookie', 'b_cookie'], '/path', headers)
+        assert len(cookies) == 2
+        assert cookies[0].key == 'a_cookie' and cookies[0].value == 'a_value'
+        assert cookies[1].key == 'b_cookie' and cookies[1].value == 'b_value'
+        cookies = get_all_matching_cookies(['b_cookie', 'a_cookie'], '/path', headers)
+        assert len(cookies) == 2
+        assert cookies[0].key == 'b_cookie' and cookies[0].value == 'b_value'
+        assert cookies[1].key == 'a_cookie' and cookies[1].value == 'a_value'
 
         headers = {'Set-Cookie': '''c_cookie=c_value;Path=/
         b_cookie=b_value;Path=/path
         a_cookie=a_value;Path=/'''}
-        c = get_first_matching_cookie(['a_cookie', 'b_cookie'], '/path', headers)
-        assert c.key == 'a_cookie' and c.value == 'a_value'
-        c = get_first_matching_cookie(['b_cookie', 'a_cookie'], '/path', headers)
-        assert c.key == 'b_cookie' and c.value == 'b_value'
+        cookies = get_all_matching_cookies(['a_cookie', 'b_cookie'], '/path', headers)
+        assert len(cookies) == 2
+        assert cookies[0].key == 'a_cookie' and cookies[0].value == 'a_value'
+        assert cookies[1].key == 'b_cookie' and cookies[1].value == 'b_value'
 
         headers = {'Set-Cookie': '''c_cookie=c_value;Path=/
         b_cookie=b_value;Path=/path
         a_cookie=a_value;Path=/path/path2'''}
-        c = get_first_matching_cookie(['a_cookie', 'b_cookie'], '/path', headers)
-        assert c.key == 'b_cookie' and c.value == 'b_value'
-        c = get_first_matching_cookie(['b_cookie', 'a_cookie'], '/path', headers)
-        assert c.key == 'b_cookie' and c.value == 'b_value'
+        cookies = get_all_matching_cookies(['a_cookie', 'b_cookie'], '/path', headers)
+        assert len(cookies) == 1
+        assert cookies[0].key == 'b_cookie' and cookies[0].value == 'b_value'
+        cookies = get_all_matching_cookies(['b_cookie', 'a_cookie'], '/path', headers)
+        assert len(cookies) == 1
+        assert cookies[0].key == 'b_cookie' and cookies[0].value == 'b_value'
 
         headers = {'Set-Cookie': '''c_cookie=c_value;Path=/
         b_cookie=b_value;Path=/path
         a_cookie=a_value;Path=/path'''}
-        c = get_first_matching_cookie(['a_cookie', 'b_cookie'], '/path/path1', headers)
-        assert c.key == 'a_cookie' and c.value == 'a_value'
-        c = get_first_matching_cookie(['b_cookie', 'a_cookie'], '/path/path1', headers)
-        assert c.key == 'b_cookie' and c.value == 'b_value'
+        cookies = get_all_matching_cookies(['a_cookie', 'b_cookie'], '/path/path1',
+            headers)
+        assert len(cookies) == 2
+        assert cookies[0].key == 'a_cookie' and cookies[0].value == 'a_value'
+        assert cookies[1].key == 'b_cookie' and cookies[1].value == 'b_value'
 
         headers = {'Set-Cookie': '''c_cookie=c_value;Path=/
         b_cookie=b_value;Path=/path1
         a_cookie=a_value;Path=/path2'''}
-        c = get_first_matching_cookie(['a_cookie', 'b_cookie'], '/path', headers)
-        assert c is None
+        cookies = get_all_matching_cookies(['a_cookie', 'b_cookie'], '/path', headers)
+        assert not cookies
 
         headers = {'Set-Cookie': '''c_cookie=c_value;Path=/
         b_cookie=b_value;Path=/path1
         a_cookie=a_value;Path=/path2'''}
-        c = get_first_matching_cookie(['a_cookie', 'b_cookie', 'c_cookie'], '/path', headers)
-        assert c.key == 'c_cookie' and c.value == 'c_value'
+        cookies = get_all_matching_cookies(['a_cookie', 'b_cookie', 'c_cookie'], '/path',
+            headers)
+        assert len(cookies) == 1
+        assert cookies[0].key == 'c_cookie' and cookies[0].value == 'c_value'

--- a/impala/util.py
+++ b/impala/util.py
@@ -207,7 +207,7 @@ def get_cookie_expiry(c):
     return None
 
 
-def get_first_matching_cookie(cookie_names, path, resp_headers):
+def get_all_matching_cookies(cookie_names, path, resp_headers):
     if 'Set-Cookie' not in resp_headers:
         return None
 
@@ -217,11 +217,10 @@ def get_first_matching_cookie(cookie_names, path, resp_headers):
     except:
         return None
 
-    if isinstance(cookie_names, six.string_types):
-        cookie_names = [cookie_names]
+    matching_cookies = []
     for cn in cookie_names:
         if cn in cookies:
             c = cookies[cn]
             if c and cookie_matches_path(c, path):
-                return c
-    return None
+                matching_cookies.append(c)
+    return matching_cookies


### PR DESCRIPTION
Issue #415 added cookie support for GSSAPI authentication over HTTP
transport. But it retains only one cookie.

This patch extends support of cookie. It makes impyla retain more than
one cookies, support LDAP and GSSAPI/PLAIN SASL authentication.

Testing:
 - Passed impyla tests/test_util.py.
 - Passed impala custom cluster test LdapImpylaHttpTest with
   verification of cookie auth.
 - Manually tested the multiple cookies in HTTP headers with a
   customized Impala server which could send and receive multiple
   cookies.
 - Manually tested impyla with GSSAPI authentication on a kerberos
   enabled cluster and verified cookie auth working as expected.