### PR TITLE
ISSUE #477: Retain cookies among http requests for NOSASL and JWT

### DIFF
--- a/impala/_thrift_api.py
+++ b/impala/_thrift_api.py
@@ -433,10 +433,30 @@ def get_http_transport(host, port, http_path, timeout=None, use_ssl=False,
             return custom_headers
 
         transport.setGetCustomHeadersFunc(get_custom_headers)
+
     elif auth_mechanism == 'JWT':
-      # For JWT authentication, the JWT is sent on the Authorization Bearer
-      # HTTP header.
-      transport.setCustomHeaders({'Authorization': 'Bearer {0}'.format(jwt)})
+        # For JWT authentication, the JWT is sent on the Authorization Bearer
+        # HTTP header.
+        def get_custom_headers(cookie_header, has_auth_cookie):
+            custom_headers = {}
+            if cookie_header:
+                log.debug('add cookies to HTTP header')
+                custom_headers['Cookie'] = cookie_header
+
+            custom_headers['Authorization'] = "Bearer " + jwt
+            return custom_headers
+
+        transport.setGetCustomHeadersFunc(get_custom_headers)
+
+    elif auth_mechanism == 'NOSASL':
+        def get_custom_headers(cookie_header, has_auth_cookie):
+            custom_headers = {}
+            if cookie_header:
+                log.debug('add cookies to HTTP header')
+                custom_headers['Cookie'] = cookie_header
+            return custom_headers
+
+        transport.setGetCustomHeadersFunc(get_custom_headers)
 
     # Without buffering Thrift would call socket.recv() each time it deserializes
     # something (e.g. a member in a struct).

--- a/impala/dbapi.py
+++ b/impala/dbapi.py
@@ -98,7 +98,7 @@ def connect(host='localhost', port=21050, database=None, timeout=None,
         ".auth" string, for example, "impala.auth" for Impala authentication cookies.
         If 'http_cookie_names' is explicitly set to a not None empty value ([], or ''),
         Impyla won't attempt to do cookie based authentication or session management.
-        Currently cookie retention is supported for GSSAPI/LDAP/SASL over http.
+        Currently cookie retention is supported for GSSAPI/LDAP/SASL/NOSASL/JWT over http.
     jwt: string containing a JSON Web Token
         This is used for auth_mechanism=JWT when using the HTTP transport.
     use_ldap : bool, optional


### PR DESCRIPTION
Issue cloudera#464 add support to retain cookies, but it does
not support NOSASL and JWT authentication.
   
This patch extends support of retaining cookie for NOSASL and JWT
authentications.
   
Testing:
 - Manually tested Impyla in connection with Impala in NOSASL mode,
   injected cookies from Impala THttpServer with some hacking,
   verified that Impyla sent cookies back to server.
 - Manually ran ImpalaConnectionTests::test_jwt_auth for Impyla.