### PR TITLE
Fix py.test warnings

### DIFF
--- a/impala/tests/conftest.py
+++ b/impala/tests/conftest.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import
 
 import logging
 
-from pytest import fixture, yield_fixture, skip
+from pytest import fixture, skip
 
 from impala.dbapi import connect
 from impala.util import (
@@ -46,7 +46,7 @@ def pytest_configure(config):
         root_logger = logging.getLogger()
         root_logger.setLevel(logging.INFO)
         root_logger.addHandler(logging.StreamHandler())
-
+    config.addinivalue_line("markers", "connect")
 
 def pytest_runtest_setup(item):
     if (getattr(item.obj, 'connect', None) and
@@ -81,7 +81,7 @@ def tmp_db():
     return _random_id('tmp_impyla_')
 
 
-@yield_fixture(scope='session')
+@fixture(scope='session')
 def con(host, port, auth_mech, tmp_db):
     # create the temporary database
     con = connect(host=host, port=port, auth_mechanism=auth_mech)
@@ -107,7 +107,7 @@ def con(host, port, auth_mech, tmp_db):
     con.close()
 
 
-@yield_fixture(scope='session')
+@fixture(scope='session')
 def cur(con):
     cur = con.cursor()
     yield cur

--- a/impala/tests/test_data_types.py
+++ b/impala/tests/test_data_types.py
@@ -15,9 +15,9 @@
 
 import datetime
 import pytest
-from pytest import yield_fixture
+from pytest import fixture
 
-@yield_fixture(scope='module')
+@fixture(scope='module')
 def decimal_table(cur):
     table_name = 'tmp_decimal_table'
     ddl = """CREATE TABLE {0} (
@@ -49,7 +49,7 @@ def test_cursor_description_precision_scale(cur, decimal_table):
     for (exp, obs) in zip(expected, observed):
         assert exp == obs
 
-@yield_fixture(scope='module')
+@fixture(scope='module')
 def date_table(cur):
     table_name = 'tmp_date_table'
     ddl = """CREATE TABLE {0} (d date)""".format(table_name)
@@ -70,7 +70,7 @@ def test_date_basic(cur, date_table):
     assert results == [(datetime.date(1, 1, 1),), (datetime.date(1999, 9, 9),)]
 
 
-@yield_fixture(scope='module')
+@fixture(scope='module')
 def timestamp_table(cur):
     table_name = 'tmp_timestamp_table'
     ddl = """CREATE TABLE {0} (ts timestamp)""".format(table_name)

--- a/impala/tests/test_hive_dict_cursor.py
+++ b/impala/tests/test_hive_dict_cursor.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from pytest import yield_fixture
+from pytest import fixture
 
 
-@yield_fixture(scope='session')
+@fixture(scope='session')
 def cur2(con):
     cur = con.cursor(dictify=True)
     yield cur

--- a/impala/tests/test_http_connect.py
+++ b/impala/tests/test_http_connect.py
@@ -27,7 +27,7 @@ from impala.tests.util import ImpylaTestEnv
 
 ENV = ImpylaTestEnv()
 
-@pytest.yield_fixture
+@pytest.fixture
 def http_503_server():
   class RequestHandler503(SimpleHTTPServer.SimpleHTTPRequestHandler):
     """A custom http handler that checks for duplicate 'Host' headers from the most

--- a/impala/tests/test_impala.py
+++ b/impala/tests/test_impala.py
@@ -15,11 +15,11 @@ import sys
 
 import pytest
 from impala.compat import _xrange as xrange
-from pytest import yield_fixture
+from pytest import fixture
 
 BIGGER_TABLE_NUM_ROWS = 100
 
-@yield_fixture(scope='module')
+@fixture(scope='module')
 def bigger_table(cur):
     table_name = 'tmp_bigger_table'
     ddl = """CREATE TABLE {0} (s string)


### PR DESCRIPTION
- @yield_fixture was replaced with @fixture as yield_fixture is deprecated
- "connect" was added as py.test marking