### PR TITLE
Fix parameter substitution in execetutemany()

### DIFF
--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -368,7 +368,8 @@ class HiveServer2Cursor(Cursor):
         log.debug('Executing query %s', operation)
 
         paramstyle = None
-        if configuration:
+        if configuration and 'paramstyle' in configuration:
+            configuration = configuration.copy()
             paramstyle = configuration.pop('paramstyle', None)
 
         def op():

--- a/impala/tests/test_hive.py
+++ b/impala/tests/test_hive.py
@@ -43,6 +43,20 @@ def test_hive_queries(cur):
     assert len(results) == 1
     assert results[0][0] is None
 
+    # Test executemany() with parameter substitution. The %s should be ignored
+    # as paramstyle is "qmark".
+    cur.executemany("INSERT INTO tmp_hive VALUES (?, ?, ?)",
+                    [['a', 4, 1.0], ['%s', 5, None]],
+                    {'paramstyle': 'qmark'})
+
+    cur.execute("SELECT * from tmp_hive WHERE b = 4")
+    results = cur.fetchall()
+    assert results == [('a', 4, 1.0)]
+
+    cur.execute("SELECT * from tmp_hive WHERE b = 5")
+    results = cur.fetchall()
+    assert results == [('%s', 5, None)]
+
     cur.execute('DROP TABLE tmp_hive')
 
     cur.execute('SHOW TABLES')


### PR DESCRIPTION
Before this change the first execute_async called by executemany()
removed "paramstyle" from the configuration map, leading to applying
default (==all) substitution rules for subsequent parameters.

Testing:
- added a regression test (executemany() was totally untested)