### PR TITLE
enable a way to pass custom user_agent when using HTTP transport

### DIFF
--- a/impala/dbapi.py
+++ b/impala/dbapi.py
@@ -44,7 +44,7 @@ def connect(host='localhost', port=21050, database=None, timeout=None,
             ldap_user=None, ldap_password=None, use_kerberos=None,
             protocol=None, krb_host=None, use_http_transport=False,
             http_path='', auth_cookie_names=None, http_cookie_names=None,
-            retries=3, jwt=None):
+            retries=3, jwt=None, user_agent=None):
     """Get a connection to HiveServer2 (HS2).
 
     These options are largely compatible with the impala-shell command line
@@ -101,6 +101,8 @@ def connect(host='localhost', port=21050, database=None, timeout=None,
         Currently cookie retention is supported for GSSAPI/LDAP/SASL/NOSASL/JWT over http.
     jwt: string containing a JSON Web Token
         This is used for auth_mechanism=JWT when using the HTTP transport.
+    user_agent: A user specified user agent when HTTP transport is used. If none is specified,
+        'Python/ImpylaHttpClient' is used
     use_ldap : bool, optional
         Specify `auth_mechanism='LDAP'` instead.
 
@@ -198,7 +200,7 @@ def connect(host='localhost', port=21050, database=None, timeout=None,
                           http_path=http_path,
                           http_cookie_names=http_cookie_names,
                           retries=retries,
-                          jwt=jwt)
+                          jwt=jwt, user_agent=user_agent)
     return hs2.HiveServer2Connection(service, default_db=database)
 
 

--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -828,7 +828,8 @@ def threaded(func):
 def connect(host, port, timeout=None, use_ssl=False, ca_cert=None,
             user=None, password=None, kerberos_service_name='impala',
             auth_mechanism=None, krb_host=None, use_http_transport=False,
-            http_path='', http_cookie_names=None, retries=3, jwt=None):
+            http_path='', http_cookie_names=None, retries=3, jwt=None,
+            user_agent=None):
     log.debug('Connecting to HiveServer2 %s:%s with %s authentication '
               'mechanism', host, port, auth_mechanism)
 
@@ -850,7 +851,7 @@ def connect(host, port, timeout=None, use_ssl=False, ca_cert=None,
                                        kerberos_host=kerberos_host,
                                        kerberos_service_name=kerberos_service_name,
                                        http_cookie_names=http_cookie_names,
-                                       jwt=jwt)
+                                       jwt=jwt, user_agent=user_agent)
     else:
         sock = get_socket(host, port, use_ssl, ca_cert)
 

--- a/impala/tests/test_dbapi_connect.py
+++ b/impala/tests/test_dbapi_connect.py
@@ -114,6 +114,17 @@ class ImpalaConnectionTests(unittest.TestCase):
                                   password="cloudera")
         self._execute_queries(self.connection)
 
+    def test_impala_ldap_connect_user_agent(self):
+        self.connection = connect(ENV.host, ENV.port, auth_mechanism="LDAP",
+                                  timeout=5,
+                                  user=ENV.hive_user,
+                                  password="cloudera",
+                                  http_path="http-path",
+                                  use_http_transport=True,
+                                  use_ssl=True,
+                                  user_agent="cloudera/impyla")
+        self._execute_queries(self.connection)
+
     @pytest.mark.skipif(DEFAULT_AUTH, reason=DEFAULT_AUTH_ERROR)
     def test_hive_nosasl_connect(self):
         self.connection = connect(ENV.host, ENV.hive_port, timeout=5)


### PR DESCRIPTION
When using HTTP transport currently the Impyla driver hard codes the user_agent string as 'Python/ImpalaHttpClient'
This PR is for a way to configure this as a parameter from dbapi.connect :
<pre>
custom_user_agent = 'dbt/impala'
handle = impala.dbapi.connect(
                    host=credentials.host,
                    port=credentials.port,
                    auth_mechanism='LDAP',
                    use_http_transport=credentials.use_http_transport,
                    user=credentials.username,
                    password=credentials.password,
                    use_ssl=credentials.use_ssl,
                    http_path=credentials.http_path,
                    retries=credentials.retries,
                    user_agent=custom_user_agent
                )
</pre>
To avoid confusion with impala_shell, the default user_agent string is changed to 'Python/ImpylaHttpClient'

Testcase:
 impala/tests/test_dbapi_connect.py

After editing the warehouse parameters, run using:
pytest impala/tests/test_dbapi_connect.py -k "ImpalaConnectionTests and test_impala_ldap_connect_user_agent"
==================================================================================== test session starts =====================================================================================
platform darwin -- Python 3.9.12, pytest-7.1.3, pluggy-1.0.0
rootdir: /Users/ganesh.venkateshwara/code/cloudera/impyla
collected 11 items / 10 deselected / 1 selected

impala/tests/test_dbapi_connect.py .                                                                                                                                                   [100%]
======================================================================== 1 passed, 10 deselected, 1 warning in 11.02s ========================================================================

The test case merely check if the user_agent is accepted when connecting to impyla using ldap.