### PR TITLE
Skip test_impala_ldap_connect_user_agent in case of DEFAULT_AUTH

### DIFF
--- a/impala/tests/test_dbapi_connect.py
+++ b/impala/tests/test_dbapi_connect.py
@@ -114,6 +114,7 @@ class ImpalaConnectionTests(unittest.TestCase):
                                   password="cloudera")
         self._execute_queries(self.connection)
 
+    @pytest.mark.skipif(DEFAULT_AUTH, reason=DEFAULT_AUTH_ERROR)
     def test_impala_ldap_connect_user_agent(self):
         self.connection = connect(ENV.host, ENV.port, auth_mechanism="LDAP",
                                   timeout=5,


### PR DESCRIPTION
The test above was added in #498 and does not work with a default Impala cluster.

This is a test only change to make tests greens when using default authentication (=no authentication).