### PR TITLE
Use winkerberos on windows

### DIFF
--- a/impala/_thrift_api.py
+++ b/impala/_thrift_api.py
@@ -436,7 +436,11 @@ def get_http_transport(host, port, http_path, timeout=None, use_ssl=False,
     elif auth_mechanism == 'GSSAPI':
         # For GSSAPI over http we need to dynamically generate custom request headers.
         def get_custom_headers(cookie_header, has_auth_cookie):
-            import kerberos
+            try:
+                import winkerberos as kerberos
+            except ImportError:
+                import kerberos
+
             custom_headers = {}
             if cookie_header:
                 log.debug('add cookies to HTTP header')

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,10 @@ setup(
     package_data={'impala.thrift': ['*.thrift']},
     install_requires=['six', 'bitarray', 'thrift==0.16.0', 'thrift_sasl==0.4.3'],
     extras_require={
-        "kerberos": ['kerberos>=1.3.0'],
+        "kerberos": [
+            'kerberos>=1.3.0;platform_system!="Windows"',
+            'winkerberos;platform_system=="Windows"',
+        ],
     },
     keywords=('cloudera impala python hadoop sql hdfs mpp spark pydata '
               'pandas distributed db api pep 249 hive hiveserver2 hs2'),


### PR DESCRIPTION
This switches impyla to depend on `winkerberos` on windows rather than `kerberos`. The `winkerberos` package provides pre-built wheels for `windows` with the same python-facing API.

Fixes #466.