### PR TITLE
Add get_view_name support to SQLAlchemy

### DIFF
--- a/impala/sqlalchemy.py
+++ b/impala/sqlalchemy.py
@@ -244,6 +244,11 @@ class ImpalaDialect(DefaultDialect):
             for tup in connection.execute(query).fetchall()
         ]
         return tables
+    
+    def get_view_names(self, connection, schema=None, **kw):
+        # Impala doesn't distinguish between tables and view when calling
+        # SHOW TABLES. So return a blank list.
+        return []
 
     def get_schema_names(self, connection, **kw):
         rp = connection.execute("SHOW SCHEMAS")


### PR DESCRIPTION
This fixes SQLAlchemy apps that expect `get_view_names` to be implemented.

Since `SHOW TABLES` doesn't distinguish between tables and views in Impala, this will always return an empty list.

Fixes apache/superset#23850