### PR TITLE
IMPALA-12149: Adds additional checks to ensure valid connection arguments

### DIFF
--- a/impala/dbapi.py
+++ b/impala/dbapi.py
@@ -25,7 +25,7 @@ from impala.error import (  # noqa
     OperationalError, ProgrammingError, IntegrityError, DataError,
     NotSupportedError)
 from impala.util import (
-    warn_deprecate, warn_protocol_param, warn_unused_jwt, warn_nontls_jwt)
+    warn_deprecate, warn_protocol_param, warn_nontls_jwt)
 import impala.hiveserver2 as hs2
 
 
@@ -163,10 +163,13 @@ def connect(host='localhost', port=21050, database=None, timeout=None,
             raise NotSupportedError('JWT authentication is only supported for HTTP transport')
         if not use_ssl:
             warn_nontls_jwt()
+        if user is not None or ldap_user is not None:
+            raise NotSupportedError("'user' argument cannot be specified with '{0}' authentication".format(auth_mechanism))
+        if password is not None or ldap_password is not None:
+            raise NotSupportedError("'password' argument cannot be specified with '{0}' authentication".format(auth_mechanism))
     else:
         if jwt is not None:
-            warn_unused_jwt()
-
+            raise NotSupportedError("'jwt' argument cannot be specified with '{0}' authentication".format(auth_mechanism))
 
     if ldap_user is not None:
         warn_deprecate('ldap_user', 'user')

--- a/impala/tests/conftest.py
+++ b/impala/tests/conftest.py
@@ -47,6 +47,7 @@ def pytest_configure(config):
         root_logger.setLevel(logging.INFO)
         root_logger.addHandler(logging.StreamHandler())
     config.addinivalue_line("markers", "connect")
+    config.addinivalue_line("markers", "params_neg: marks tests that verify invalid parameters are not allowed")
 
 def pytest_runtest_setup(item):
     if (getattr(item.obj, 'connect', None) and

--- a/impala/util.py
+++ b/impala/util.py
@@ -167,12 +167,6 @@ def warn_deprecate(functionality='This', alternative=None):
     warnings.warn(msg, Warning)
 
 
-def warn_unused_jwt():
-    msg = ("The JWT argument is ignored as auth_mechanism is not 'JWT'. "
-           "Specify auth_mechanism='JWT' to make use of JWT authentication.")
-    warnings.warn(msg, Warning)
-
-
 def warn_nontls_jwt():
     msg = ("JWT authentication is running without SSL/TLS. This is not a secure "
            "configuration unless other layers are providing transport security.")


### PR DESCRIPTION
IMPALA-12149: Adds additional checks to ensure connection arguments that are applicable to username/password auth and JWT auth are not mixed together on the same call to the connect method.

These additional checks prevent confusion about which authentication method is actually used for the connection.

New tests were added to cover the new checks.