### PR TITLE
Add Knox cookies in default cookies list

### DIFF
--- a/impala/dbapi.py
+++ b/impala/dbapi.py
@@ -191,8 +191,8 @@ def connect(host='localhost', port=21050, database=None, timeout=None,
         warn_deprecate('auth_cookie_names', 'http_cookie_names')
         http_cookie_names = auth_cookie_names
     elif http_cookie_names is None:
-        # Set default value as the list of HTTP cookie names used by Impala and Hive.
-        http_cookie_names = ['impala.auth', 'impala.session.id', 'hive.server2.auth']
+        # Set default value as the list of HTTP cookie names used by Impala, Hive and Knox.
+        http_cookie_names = ['impala.auth', 'impala.session.id', 'hive.server2.auth', 'KNOXSESSIONID', 'KNOX_BACKEND-HIVE', 'JSESSIONID']
 
     service = hs2.connect(host=host, port=port,
                           timeout=timeout, use_ssl=use_ssl,


### PR DESCRIPTION
Connecting over Knox backed with multiple HiveServer2 Instances and Load-balancing enabled leads to Invalid Session Handle error.
The root cause of this issue is because Knox uses different cookies than default ones i.e impala.auth, impala.session.id, hive.server2.auth

This can easily be fixed by adding below property in connection string.
`http_cookie_names = ["KNOXSESSIONID","KNOX_BACKEND-HIVE"]`

It would be good to have them added to default list and avoid inconvenience.