### PR TITLE
Issue #529: Fix https connection with Python 3.12

### DIFF
--- a/impala/_thrift_api.py
+++ b/impala/_thrift_api.py
@@ -171,9 +171,15 @@ class ImpalaHttpClient(TTransportBase):
       self.__http = http_client.HTTPConnection(self.host, self.port,
                                                timeout=self.__timeout)
     elif self.scheme == 'https':
+      # (#529) From python 3.12 http_client.HTTPSConnection no longer
+      # expects certfile and key_file. Certfile is included in context
+      # while key_file can be used in SSLContext.load_verify_locations.
+      # As Impyla doesn't support server authentication (#362) both
+      # certfile and key_file are expected to be None here.
+      if self.certfile or self.keyfile:
+        raise NotSupportedError("Server authentication is not supported " +
+                                "with HTTP endpoints")
       self.__http = http_client.HTTPSConnection(self.host, self.port,
-                                                key_file=self.keyfile,
-                                                cert_file=self.certfile,
                                                 timeout=self.__timeout,
                                                 context=self.context)
     if self.using_proxy():

--- a/impala/tests/test_dbapi_connect.py
+++ b/impala/tests/test_dbapi_connect.py
@@ -246,6 +246,12 @@ class ImpalaConnectionTests(unittest.TestCase):
             ENV.host, ENV.port, use_ssl=True, timeout=5, ca_cert=ENV.ssl_cert)
         self._execute_queries(self.connection)
 
+    @pytest.mark.skipif(SSL_DISABLED, reason=SSL_DISABLED_ERROR)
+    def test_https_connection(self):
+        self.connection = connect(ENV.host, ENV.http_port, use_http_transport=True,
+                                  http_path="cliservice", use_ssl=True, timeout=5)
+        self._execute_queries(self.connection)
+
 class ImpalaSocketTests(unittest.TestCase):
 
     def run_a_query(self):


### PR DESCRIPTION
Python 3.12 removed deprecated certfile and key_file arguments from http_client.HTTPSConnection. These should be always empty in Impyla as the server is never verified in https connections (see #362).