### PR TITLE
Turn regex strings into raw strings

### DIFF
--- a/impala/interface.py
+++ b/impala/interface.py
@@ -270,7 +270,7 @@ def _bind_parameters_dict(operation, parameters):
             string_parameters[name] = str(value)
 
     # replace named parameters by their pyformat equivalents
-    operation = re.sub(":([^\d\W]\w*)", "%(\g<1>)s", operation)
+    operation = re.sub(r":([^\d\W]\w*)", r"%(\g<1>)s", operation)
 
     # replace pyformat parameters
     return operation % string_parameters

--- a/impala/sqlalchemy.py
+++ b/impala/sqlalchemy.py
@@ -225,7 +225,7 @@ class ImpalaDialect(DefaultDialect):
     def _get_server_version_info(self, connection):
         raw = connection.execute('select version()').scalar()
         v = raw.split()[2]
-        m = re.match('.*?(\d{1,3})\.(\d{1,3})\.(\d{1,3}).*', v)
+        m = re.match(r'.*?(\d{1,3})\.(\d{1,3})\.(\d{1,3}).*', v)
         return tuple([int(x) for x in m.group(1, 2, 3) if x is not None])
 
     def has_table(self, connection, table_name, schema=None):


### PR DESCRIPTION
I updated some minor versions of some dependencies in my own application and the following error popped up. I checked other strings that were used with the `re` module, and those were all raw strings, so I checked and if I manually (and locally) changed the string to a raw string, everything ran fine.

```
E     File "/home/david/workon/impala-39/lib/python3.9/site-packages/impala/sqlalchemy.py", line 227
E       m = re.match('.*?(\d{1,3})\.(\d{1,3})\.(\d{1,3}).*', v)
E                    ^
E   SyntaxError: invalid escape sequence \d
```

Not sure why updating dependencies broke this code specifically.
