### PR TITLE
Log "Closing operation" at debug level

### DIFF
--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -320,7 +320,7 @@ class HiveServer2Cursor(Cursor):
 
     def close_operation(self):
         if self._last_operation is not None:
-            log.info('Closing operation')
+            log.debug('Closing operation')
             self._reset_state()
 
     def _reset_state(self):


### PR DESCRIPTION
This function is called for every query during normal execution, making this info level too verbose.