### PR TITLE
Avoid retrying non-idempotent RPCs in binary connections (#549)

### DIFF
--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -1167,12 +1167,7 @@ class ThriftRPC(object):
                 log.debug('Transport opened')
                 func = getattr(self.client, func_name)
                 return func(request)
-            except socket.error as e:
-                if open_finished and not safe_to_retry: raise e
-                msg = "RPC failed" if open_finished else "Failed to open transport"
-                log.exception('%s (tries_left=%s)', msg, tries_left)
-                last_exception = e
-            except TTransportException as e:
+            except (socket.error, TTransportException) as e:
                 if open_finished and not safe_to_retry: raise e
                 msg = "RPC failed" if open_finished else "Failed to open transport"
                 log.exception('%s (tries_left=%s)', msg, tries_left)
@@ -1210,7 +1205,7 @@ class ThriftRPC(object):
             open_finished = False
             tries_left -= 1
 
-        if last_exception is not None:
+        if last_exception:
             raise last_exception
         raise HiveServer2Error('Failed after retrying {0} times'
                                .format(self.retries))

--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -1144,41 +1144,45 @@ class ThriftRPC(object):
         self.client = client
         self.retries = retries
 
-    def _rpc(self, func_name, request, retry_on_http_error=False):
+    def _rpc(self, func_name, request, safe_to_retry=False):
         self._log_request(func_name, request)
-        response = self._execute(func_name, request, retry_on_http_error)
+        response = self._execute(func_name, request, safe_to_retry)
         self._log_response(func_name, response)
         err_if_rpc_not_ok(response)
         return response
 
-    def _execute(self, func_name, request, retry_on_http_error=False):
+    def _execute(self, func_name, request, safe_to_retry=False):
         # pylint: disable=protected-access
         # get the thrift transport
         transport = self.client._iprot.trans
         tries_left = self.retries
-        last_http_exception = None
+        last_exception = None
+        open_finished = False
         while tries_left > 0:
             try:
                 log.debug('Attempting to open transport (tries_left=%s)',
                           tries_left)
                 open_transport(transport)
+                open_finished = True
                 log.debug('Transport opened')
                 func = getattr(self.client, func_name)
                 return func(request)
-            except socket.error:
-                log.exception('Failed to open transport (tries_left=%s)',
-                              tries_left)
-                last_http_exception = None
-            except TTransportException:
-                log.exception('Failed to open transport (tries_left=%s)',
-                              tries_left)
-                last_http_exception = None
+            except socket.error as e:
+                if open_finished and not safe_to_retry: raise e
+                msg = "RPC failed" if open_finished else "Failed to open transport"
+                log.exception('%s (tries_left=%s)', msg, tries_left)
+                last_exception = e
+            except TTransportException as e:
+                if open_finished and not safe_to_retry: raise e
+                msg = "RPC failed" if open_finished else "Failed to open transport"
+                log.exception('%s (tries_left=%s)', msg, tries_left)
+                last_exception = e
             except HttpError as h:
-                if not retry_on_http_error:
+                if not safe_to_retry:
                     log.debug('Caught HttpError %s %s in %s which is not retryable',
                               h, str(h.body or ''), func_name)
                     raise
-                last_http_exception = h
+                last_exception = h
                 if tries_left > 1:
                     retry_secs = None
                     retry_after = h.http_headers.get('Retry-After', None)
@@ -1203,15 +1207,16 @@ class ThriftRPC(object):
                 raise
             log.debug('Closing transport (tries_left=%s)', tries_left)
             transport.close()
+            open_finished = False
             tries_left -= 1
 
-        if last_http_exception is not None:
-            raise last_http_exception
+        if last_exception is not None:
+            raise last_exception
         raise HiveServer2Error('Failed after retrying {0} times'
                                .format(self.retries))
 
-    def _operation(self, kind, request, retry_on_http_error=False):
-        resp = self._rpc(kind, request, retry_on_http_error)
+    def _operation(self, kind, request, safe_to_retry=False):
+        resp = self._rpc(kind, request, safe_to_retry)
         return self._get_operation(resp.operationHandle)
 
     def _log_request(self, kind, request):

--- a/impala/tests/test_dbapi_connect.py
+++ b/impala/tests/test_dbapi_connect.py
@@ -280,7 +280,7 @@ class ImpalaConnectionTests(unittest.TestCase):
                 cur.execute(insert)
                 successful_inserts += 1
             except:
-                con = connect(ENV.host, ENV.port, timeout=3)
+                con = connect(ENV.host, ENV.port, timeout=LOW_TIMEOUT_S)
                 cur = con.cursor()
                 pass
         # Use the reliable connection for result checking and cleanup.

--- a/impala/tests/test_dbapi_connect.py
+++ b/impala/tests/test_dbapi_connect.py
@@ -48,6 +48,8 @@ JWT_DISABLED_ERROR = "JWT authentication disabled"
 SSL_DISABLED = ENV.ssl_cert == ""
 SSL_DISABLED_ERROR = "No ssl certificate set."
 
+# Table loading / DDLs can take several seconds in Impala. Use a larger timeout to avoid flaky tests.
+TIMEOUT_S = 10
 
 class ImpalaConnectionTests(unittest.TestCase):
 
@@ -94,14 +96,14 @@ class ImpalaConnectionTests(unittest.TestCase):
         return username
 
     def test_impala_nosasl_connect(self):
-        self.connection = connect(ENV.host, ENV.port, timeout=5)
+        self.connection = connect(ENV.host, ENV.port, timeout=TIMEOUT_S)
         self._execute_queries(self.connection)
 
     @pytest.mark.skipif(ENV.skip_hive_tests, reason="Skipping hive tests")
     def test_hive_plain_connect(self):
         self.connection = connect(ENV.host, ENV.hive_port,
                                   auth_mechanism="PLAIN",
-                                  timeout=5,
+                                  timeout=TIMEOUT_S,
                                   user=ENV.hive_user,
                                   password="cloudera")
         self._execute_queries(self.connection)
@@ -109,7 +111,7 @@ class ImpalaConnectionTests(unittest.TestCase):
     @pytest.mark.skipif(DEFAULT_AUTH, reason=DEFAULT_AUTH_ERROR)
     def test_impala_plain_connect(self):
         self.connection = connect(ENV.host, ENV.port, auth_mechanism="PLAIN",
-                                  timeout=5,
+                                  timeout=TIMEOUT_S,
                                   user=ENV.hive_user,
                                   password="cloudera")
         self._execute_queries(self.connection)
@@ -117,7 +119,7 @@ class ImpalaConnectionTests(unittest.TestCase):
     @pytest.mark.skipif(DEFAULT_AUTH, reason=DEFAULT_AUTH_ERROR)
     def test_impala_ldap_connect_user_agent(self):
         self.connection = connect(ENV.host, ENV.port, auth_mechanism="LDAP",
-                                  timeout=5,
+                                  timeout=TIMEOUT_S,
                                   user=ENV.hive_user,
                                   password="cloudera",
                                   http_path="http-path",
@@ -128,7 +130,7 @@ class ImpalaConnectionTests(unittest.TestCase):
 
     @pytest.mark.skipif(DEFAULT_AUTH, reason=DEFAULT_AUTH_ERROR)
     def test_hive_nosasl_connect(self):
-        self.connection = connect(ENV.host, ENV.hive_port, timeout=5)
+        self.connection = connect(ENV.host, ENV.hive_port, timeout=TIMEOUT_S)
         self._execute_queries(self.connection)
 
     @pytest.mark.params_neg
@@ -160,7 +162,7 @@ class ImpalaConnectionTests(unittest.TestCase):
         jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwidXNlcm5hbWUiOiJpbXB5bGFqd3R0ZXN0IiwiaWF0IjoxNTE2MjM5MDIyfQ.Uvq2TZ9nRtM-JgFEd_fL2Z0kFcflx0Tr5cbJR4yySyc"
         self.connection = connect(ENV.host, ENV.http_port, use_http_transport=True,
                                   http_path="cliservice", auth_mechanism="JWT",
-                                  timeout=5, jwt=jwt)
+                                  timeout=TIMEOUT_S, jwt=jwt)
         username = self._execute_query_get_username(self.connection)
         assert(username == "impylajwttest")
         print("Username: {0}".format(username))
@@ -236,31 +238,33 @@ class ImpalaConnectionTests(unittest.TestCase):
 
     @pytest.mark.skipif(SSL_DISABLED, reason=SSL_DISABLED_ERROR)
     def test_ssl_connection_no_cert(self):
-        self.connection = connect(ENV.host, ENV.port, timeout=5, use_ssl=True)
+        self.connection = connect(ENV.host, ENV.port, timeout=TIMEOUT_S, use_ssl=True)
         self._execute_queries(self.connection)
 
 
     @pytest.mark.skipif(SSL_DISABLED, reason=SSL_DISABLED_ERROR)
     def test_ssl_connection_with_cert(self):
         self.connection = connect(
-            ENV.host, ENV.port, use_ssl=True, timeout=5, ca_cert=ENV.ssl_cert)
+            ENV.host, ENV.port, use_ssl=True, timeout=TIMEOUT_S, ca_cert=ENV.ssl_cert)
         self._execute_queries(self.connection)
 
     @pytest.mark.skipif(SSL_DISABLED, reason=SSL_DISABLED_ERROR)
     def test_https_connection(self):
         self.connection = connect(ENV.host, ENV.http_port, use_http_transport=True,
-                                  http_path="cliservice", use_ssl=True, timeout=5)
+                                  http_path="cliservice", use_ssl=True, timeout=TIMEOUT_S)
         self._execute_queries(self.connection)
 
     def test_retry_dml(self):
         """Regression test for #549."""
         # Connection with higher timeout to avoid errors.
-        self.connection = connect(ENV.host, ENV.port, timeout=10)
+
+        self.connection = connect(ENV.host, ENV.port, timeout=TIMEOUT_S)
         # Connect with low timeout to trigger failed RPCs.
         # TODO: This reproduces the issue in the default Impala dev env (no local catalog),
         #       but may fail to reproduce it in the future if Impala will get faster.
         #       Ideally the error would be injected in a more stable way.
-        low_timeout_connection = connect(ENV.host, ENV.port, timeout=3)
+        LOW_TIMEOUT_S = 3
+        low_timeout_connection = connect(ENV.host, ENV.port, timeout=LOW_TIMEOUT_S)
         create = "CREATE TABLE {0} (f1 INT)".format(self.tablename)
         insert = "INSERT INTO TABLE {0} SELECT 1".format(self.tablename)
         invalidate = "INVALIDATE METADATA {0}".format(self.tablename)
@@ -283,7 +287,7 @@ class ImpalaConnectionTests(unittest.TestCase):
         cur = self.connection.cursor()
         cur.execute(select)
         result = cur.fetchall()
-        # It is unknown whether unsuccesful INSERTs actually inserted rows.
+        # It is unknown whether unsuccessful INSERTs actually inserted rows.
         assert len(result) <= NUM_INSERTS
         assert len(result) >= successful_inserts
         cur.execute(drop)


### PR DESCRIPTION
See the #549 for the detailed analyses of the issue.

The fix works similarly to the existing solution for http connections:
- each RPC knows whether it is idempotent
- if the error comes from establishing the connection, then retry
- if the error comes from executing the RPC, only retry if the RPC is idempotent

A test is added that relies on slow metadata handling in the Impala cluster to trigger timouts. It would be nice to add wider and more reliable tests in the future similarly to the http tests in test_hs2_fault_injection.py