### PR TITLE
Always set ImpalaHttpClient.__preserve_all_cookies

### DIFF
--- a/impala/_thrift_api.py
+++ b/impala/_thrift_api.py
@@ -138,6 +138,7 @@ class ImpalaHttpClient(TTransportBase):
       self.__http_cookie_dict = dict()
       self.__auth_cookie_names = set()
     else:
+      self.__preserve_all_cookies = False
       if isinstance(http_cookie_names, six.string_types):
         http_cookie_names = [http_cookie_names]
       # Build a dictionary that maps cookie name to namedtuple.


### PR DESCRIPTION
The issue was introduced in #542.
Caught by Impala's LdapImpylaHttpTest.