### PR TITLE
Restrict bitarray varsion to 2.*

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     packages=find_packages(),
     install_package_data=True,
     package_data={'impala.thrift': ['*.thrift']},
-    install_requires=['six', 'bitarray', 'thrift==0.16.0', 'thrift_sasl==0.4.3'],
+    install_requires=['six', 'bitarray<3', 'thrift==0.16.0', 'thrift_sasl==0.4.3'],
     extras_require={
         "kerberos": ['kerberos>=1.3.0'],
     },


### PR DESCRIPTION
bitarray 3.0 removed Python 2.7 support, which led to failing to build sdist for Python 2.7. Besides Python 2.7 support several function were removed in 3.0, so it seems safer to use 2.* at the moment. Impala pins the dependency to 2.3 - I preferred to be more flexible in Impyla.