### PR TITLE
Fix proxy-authentication headers for Python 3.* and long basic credential encodings

### DIFF
--- a/impala/tests/test_http_connect.py
+++ b/impala/tests/test_http_connect.py
@@ -203,7 +203,6 @@ class TestHttpConnect(object):
     rows = cur.fetchall()
     assert rows == [(1,)]
 
-    print(http_proxy_server.get_headers())
     headers = http_proxy_server.get_headers()
     assert ('Authorization', "Basic dGhpc2lzYXJhdGhlcmxvbmd1c2VybmFtZTp2ZXJ5IWxvbmchcGFzc3dvcmR0aGF0Y3JlYXRlc2Fsb25nYmFzaWM2NGVuY29kaW5n") in headers
 

--- a/impala/tests/test_http_connect.py
+++ b/impala/tests/test_http_connect.py
@@ -205,7 +205,7 @@ class TestHttpConnect(object):
 
     print(http_proxy_server.get_headers())
     headers = http_proxy_server.get_headers()
-    assert ('Authorization', "Basic dGhpc2lzYXJhdGhlcmxvbmd1c2VybmFtZTp2ZXJ5IWxvbmchcGFzc3dvcmR0aGF0Y3JlYXRl2Fsb25nYmFzaWM2NGVuY29kaW5n") in headers
+    assert ('Authorization', "Basic dGhpc2lzYXJhdGhlcmxvbmd1c2VybmFtZTp2ZXJ5IWxvbmchcGFzc3dvcmR0aGF0Y3JlYXRlc2Fsb25nYmFzaWM2NGVuY29kaW5n") in headers
 
 def get_user_custom_headers_func():
   """Insert some custom http headers, including a duplicate."""

--- a/impala/tests/test_http_connect.py
+++ b/impala/tests/test_http_connect.py
@@ -188,6 +188,24 @@ class TestHttpConnect(object):
     assert count_tuples_with_key(headers, "key1") == 2
     assert count_tuples_with_key(headers, "key2") == 1
     assert count_tuples_with_key(headers, "key3") == 0
+    
+  def test_basic_auth_headers(self, http_proxy_server):
+    con = connect(
+      "localhost",
+      http_proxy_server.PORT,
+      use_http_transport=True,
+      user="thisisaratherlongusername",
+      password="very!long!passwordthatcreatesalongbasic64encoding",
+      auth_mechanism="PLAIN"
+    )
+    cur = con.cursor()
+    cur.execute('select 1')
+    rows = cur.fetchall()
+    assert rows == [(1,)]
+
+    print(http_proxy_server.get_headers())
+    headers = http_proxy_server.get_headers()
+    assert ('Authorization', "Basic dGhpc2lzYXJhdGhlcmxvbmd1c2VybmFtZTp2ZXJ5IWxvbmchcGFzc3dvcmR0aGF0Y3JlYXRl2Fsb25nYmFzaWM2NGVuY29kaW5n") in headers
 
 def get_user_custom_headers_func():
   """Insert some custom http headers, including a duplicate."""

--- a/impala/tests/test_thrift_api.py
+++ b/impala/tests/test_thrift_api.py
@@ -1,0 +1,24 @@
+import os
+
+import pytest
+
+from impala._thrift_api import ImpalaHttpClient
+
+
+@pytest.fixture()
+def proxy_env():
+    reset_value = os.environ.get("HTTPS_PROXY")
+    os.environ["HTTPS_PROXY"] = "https://foo:%3F%40%3D@localhost"
+    yield "proxy_env"
+    if reset_value is None:
+        del os.environ["HTTPS_PROXY"]
+    else:
+        os.environ["HTTPS_PROXY"] = reset_value
+
+
+class TestHttpTransport(object):
+    def test_proxy_auth_header(self, proxy_env):
+        client = ImpalaHttpClient(
+            uri_or_host="https://localhost:443/cliservice",
+        )
+        assert client.proxy_auth == "Basic Zm9vOj9APQ=="

--- a/impala/tests/test_util.py
+++ b/impala/tests/test_util.py
@@ -25,7 +25,7 @@ else:
 
 import pytest
 from impala.util import (cookie_matches_path, get_cookie_expiry, get_all_cookies,
-                         get_all_matching_cookies)
+                         get_all_matching_cookies, get_basic_credentials_for_request_headers)
 
 
 class ImpalaUtilTests(unittest.TestCase):
@@ -210,6 +210,20 @@ class ImpalaUtilTests(unittest.TestCase):
             headers)
         assert len(cookies) == 1
         assert cookies[0].key == 'c_cookie' and cookies[0].value == 'c_value'
+
+    def test_get_basic_credentials_for_request_headers(self):
+        assert get_basic_credentials_for_request_headers(
+            user="foo",
+            password="bar"
+        ) == "Zm9vOmJhcg=="
+        assert get_basic_credentials_for_request_headers(
+            user="thisisaratherlongusername",
+            password="withanotherverylongpasswordresultinginanencodinglongerthan76chars"
+        ) == "dGhpc2lzYXJhdGhlcmxvbmd1c2VybmFtZTp3aXRoYW5vdGhlcnZlcnlsb25ncGFzc3dvcmRyZXN1bHRpbmdpbmFuZW5jb2Rpbmdsb25nZXJ0aGFuNzZjaGFycw=="
+        assert get_basic_credentials_for_request_headers(
+            user="?",
+            password="?"
+        ) == "Pzo/"
 
 
 def make_cookie_headers(cookie_vals):

--- a/impala/util.py
+++ b/impala/util.py
@@ -14,6 +14,7 @@
 
 from __future__ import absolute_import
 
+import base64
 import sys
 import warnings
 import logging
@@ -252,3 +253,16 @@ def get_all_matching_cookies(cookie_names, path, resp_headers):
             if c and cookie_matches_path(c, path):
                 matching_cookies.append(c)
     return matching_cookies
+
+
+def get_basic_credentials_for_request_headers(user, password):
+    """Returns base64 encoded credentials for HTTP request headers
+
+    This function produces RFC 2617-compliant basic credentials:
+    - RFC 2045 encoding of username:password without limitations to 76 chars
+      per line (and without trailing newline)
+    - No translation of characters (+,/) for URL-safety
+    """
+    user_password = '%s:%s' % (user, password)
+    print(user_password)
+    return base64.b64encode(user_password.encode()).decode()

--- a/impala/util.py
+++ b/impala/util.py
@@ -264,5 +264,4 @@ def get_basic_credentials_for_request_headers(user, password):
     - No translation of characters (+,/) for URL-safety
     """
     user_password = '%s:%s' % (user, password)
-    print(user_password)
     return base64.b64encode(user_password.encode()).decode()


### PR DESCRIPTION
- Added tests that cover the descriptions of #540 and #517 
- Changed plain/ldap auth and proxy authentication to use the same utility function to encode credentials

Fixes #540
Fixes #517 

Note:
1. Tested with 2.7 and 3.7+
2. Tried to use module-local conventions (e.g. unittest/pytest)
3. I'm using impala quickstarter (4.4.1) for local test execution, no hive tests executed
4. `impala.tests.test_dbapi_connect.ImpalaConnectionTests.test_retry_dml` generally fails for me (and failed also before making any modifcations)