### PR TITLE
df.to_sql() support for impala + SQLAlchemy: has_table() got an unexpected argument 'info_cache'

### DIFF
--- a/impala/sqlalchemy.py
+++ b/impala/sqlalchemy.py
@@ -229,7 +229,7 @@ class ImpalaDialect(DefaultDialect):
         m = re.match(r'.*?(\d{1,3})\.(\d{1,3})\.(\d{1,3}).*', v)
         return tuple([int(x) for x in m.group(1, 2, 3) if x is not None])
 
-    def has_table(self, connection, table_name, schema=None):
+    def has_table(self, connection, table_name, schema=None, **kw):
         tables = self.get_table_names(connection, schema)
         if table_name in tables:
             return True

--- a/impala/tests/test_sqlalchemy.py
+++ b/impala/tests/test_sqlalchemy.py
@@ -114,10 +114,10 @@ def test_pandas_dataframe_to_sql():
     with engine.connect() as conn:
         try:
             df.to_sql('test_table', conn, if_exists='replace', index=False)
-            tables = pd.read_sql('SHOW TABLES', conn)
+            table = pd.read_sql('DESCRIBE test_table', conn)
             # The returned table names might contain the database name as prefix.
-            tables = [i.split(".")[-1].lower() for i in tables]
-            assert 'test_table' in tables
+            columns = table['name'].tolist()
+            assert ['a', 'b', 'c'] == columns
 
         finally:
-            conn.execute(text('DROP test_table'))
+            conn.execute(text('DROP TABLE test_table'))

--- a/impala/tests/test_sqlalchemy.py
+++ b/impala/tests/test_sqlalchemy.py
@@ -115,7 +115,6 @@ def test_pandas_dataframe_to_sql():
         try:
             df.to_sql('test_table', conn, if_exists='replace', index=False)
             table = pd.read_sql('DESCRIBE test_table', conn)
-            # The returned table names might contain the database name as prefix.
             columns = table['name'].tolist()
             assert ['a', 'b', 'c'] == columns
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps =
     pytest>=6,<7
     sqlalchemy>=2
     requests
+    pandas
 setenv =
     IMPYLA_TEST_HIVE_PORT = 11050
     IMPYLA_TEST_HIVE_USER = hive
@@ -20,3 +21,5 @@ commands =
 deps =
     pytest>=4,<5
     sqlalchemy>=1,<2
+    requests
+    pandas


### PR DESCRIPTION
Fixes #567 

Added arbitrary keyword arguments to `has_table()`.
This lets `has_table()` accept  `'info_cache'` (and other unknown kwargs that may be passed by SQLAlchemy to the dialect's `has_table()` in the future).