### PR TITLE
Fix IPv6 address handling in hs2-http2 (#570)

### DIFF
--- a/impala/_thrift_api.py
+++ b/impala/_thrift_api.py
@@ -418,6 +418,7 @@ def get_http_transport(host, port, http_path, timeout=None, use_ssl=False,
                        password=None, kerberos_host=None, kerberos_service_name=None,
                        http_cookie_names=None, jwt=None, user_agent=None,
                        get_user_custom_headers_func=None):
+    host_url = "[%s]" % host if ":" in host else host # add brackets for ipv6 address
     # TODO: support timeout
     if timeout is not None:
         log.error('get_http_transport does not support a timeout')
@@ -429,7 +430,7 @@ def get_http_transport(host, port, http_path, timeout=None, use_ssl=False,
           ssl_ctx.check_hostname = False  # Mandated by the SSL lib for CERT_NONE mode.
           ssl_ctx.verify_mode = ssl.CERT_NONE
 
-        url = 'https://%s:%s/%s' % (host, port, http_path)
+        url = 'https://%s:%s/%s' % (host_url, port, http_path)
         log.debug('get_http_transport url=%s', url)
         # TODO(#362): Add server authentication with thrift 0.12.
         transport = ImpalaHttpClient(
@@ -437,7 +438,7 @@ def get_http_transport(host, port, http_path, timeout=None, use_ssl=False,
             http_cookie_names=http_cookie_names,
             get_user_custom_headers_func=get_user_custom_headers_func)
     else:
-        url = 'http://%s:%s/%s' % (host, port, http_path)
+        url = 'http://%s:%s/%s' % (host_url, port, http_path)
         log.debug('get_http_transport url=%s', url)
         transport = ImpalaHttpClient(
             url, http_cookie_names=http_cookie_names,

--- a/impala/tests/test_hs2_fault_injection.py
+++ b/impala/tests/test_hs2_fault_injection.py
@@ -106,7 +106,8 @@ class TestHS2FaultInjection(object):
     """Class for testing the http fault injection in various rpcs used by Impyla"""
 
     def setup_method(self):
-        url = 'http://%s:%s/%s' % (ENV.host, ENV.http_port, "cliservice")
+        host = "[%s]" % ENV.host if ":" in ENV.host else ENV.host
+        url = 'http://%s:%s/%s' % (host, ENV.http_port, "cliservice")
         self.transport = FaultInjectingHttpClient(url)
         self.configuration = {'idle_session_timeout': '30'}
 

--- a/impala/tests/test_sqlalchemy.py
+++ b/impala/tests/test_sqlalchemy.py
@@ -54,7 +54,8 @@ def create_simple_test_table():
                )
 
 def create_test_engine(diealect):
-    return create_engine('{0}://{1}:{2}'.format(diealect, TEST_ENV.host, TEST_ENV.port))
+    host = "[%s]" % TEST_ENV.host if ":" in TEST_ENV.host else TEST_ENV.host
+    return create_engine('{0}://{1}:{2}'.format(diealect, host, TEST_ENV.port))
 
 def test_sqlalchemy_impala_compilation():
     engine = create_test_engine("impala")

--- a/impala/tests/util.py
+++ b/impala/tests/util.py
@@ -28,6 +28,17 @@ def get_env_var(name, coercer, default):
         sys.stderr.write("{0} not set; using {1!r}\n".format(name, default))
         return default
 
+def is_ipv6_only_host(host, port):
+    has_ipv6 = False
+    for addr in socket.getaddrinfo(host, port, socket.AF_UNSPEC,
+                                  socket.SOCK_STREAM, socket.IPPROTO_TCP):
+        (family, _, _, _, _) = addr
+        if family == socket.AF_INET:
+            return False # found ipv4
+        elif family == socket.AF_INET6:
+            has_ipv6 = True
+    return has_ipv6
+
 
 class ImpylaTestEnv(object):
 


### PR DESCRIPTION
- add brackets to ipv6 addresses in urls (e.g. https://[::1]:28000)
- fix tests to work with IMPYLA_TEST_HOST=::1

Tested with WIP patch for IPv6 support in Impala:
https://gerrit.cloudera.org/#/c/22527/