### PR TITLE
Add import_dbapi() class method to ImpalaDialect

### DIFF
--- a/impala/sqlalchemy.py
+++ b/impala/sqlalchemy.py
@@ -203,8 +203,16 @@ class ImpalaDialect(DefaultDialect):
     type_compiler = ImpalaTypeCompiler
     execution_ctx_cls = ImpalaExecutionContext
 
+    # sqlalchemy dbapi() is deprecated in favor of import_dbapi().
+    # Keeping both to remain as compatible as possible.
     @classmethod
     def dbapi(cls):
+        # pylint: disable=method-hidden
+        import impala.dbapi
+        return impala.dbapi
+
+    @classmethod
+    def import_dbapi(cls):
         # pylint: disable=method-hidden
         import impala.dbapi
         return impala.dbapi


### PR DESCRIPTION
This fixes the following warning:
ADeprecationWarning: The dbapi() classmethod on dialect classes has been renamed to import_dbapi().

The issue was mentioned in #214