### PR TITLE
Set supports_statement_cache=False in sqlalchemy (#503)

### DIFF
--- a/impala/sqlalchemy.py
+++ b/impala/sqlalchemy.py
@@ -202,6 +202,9 @@ class ImpalaDialect(DefaultDialect):
     ddl_compiler = ImpalaDDLCompiler
     type_compiler = ImpalaTypeCompiler
     execution_ctx_cls = ImpalaExecutionContext
+    # disable supports_statement_cache explicitly to avoid warning in sqlalchemy.
+    # TODO: it is not clear whether it would be safe to enable, needs more research
+    supports_statement_cache = False
 
     @classmethod
     def dbapi(cls):


### PR DESCRIPTION
This avoids a warning in sqlalchemy. It is not clear to me whether it could be enabled, it would need a deeper dive into sqlalchemy. Other dialects I checked also set it to False.