### PR TITLE
Fallback to winkerberos if kerberos is not available (#504)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Optional:
 
 * `kerberos>=1.3.0` for Kerberos over HTTP support. This also requires Kerberos libraries
    to be installed on your system - see [System Kerberos](#system-kerberos)
+  * On Windows operating systems an alternative is 'winkerberos' which can be installed with pip
 
 * `pandas` for conversion to `DataFrame` objects; but see the [Ibis project][ibis] instead
 

--- a/impala/_thrift_api.py
+++ b/impala/_thrift_api.py
@@ -483,7 +483,15 @@ def get_http_transport(host, port, http_path, timeout=None, use_ssl=False,
     elif auth_mechanism == 'GSSAPI':
         # For GSSAPI over http we need to dynamically generate custom request headers.
         def get_custom_headers(cookie_header, has_auth_cookie):
-            import kerberos
+            # Try importing kerberos, then winkerberos as fallback. Report the original exception for kerberos.
+            try:
+                import kerberos
+            except ImportError as original_ex:
+                try:
+                    log.debug('importing kerberos failed, falling back to winkerberos')
+                    import winkerberos as kerberos
+                except ImportError:
+                    raise original_ex
             custom_headers = {}
             if cookie_header:
                 log.debug('add cookies to HTTP header')


### PR DESCRIPTION
Winkerberos is an alternative to kerberos package on Windows and has the same api, so can be used as a drop in replacement.

Based on another PR:
https://github.com/cloudera/impyla/pull/504

The difference is that the current patch prefers kerberos if both are available to avoid the breaking existing worklflows. setup.py is also not modified. To use winkerberos it has to be installed independently from impyla and impyla should be installed without [kerberos] extra.