### PR TITLE
Unpin bitarray dependency on Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,11 @@ setup(
     packages=find_packages(),
     install_package_data=True,
     package_data={'impala.thrift': ['*.thrift']},
-    install_requires=['six', 'bitarray<3', 'thrift==0.16.0', 'thrift_sasl==0.4.3'],
+    install_requires=['six',
+                      'bitarray<3; python_version < "3"',
+                      'bitarray; python_version >= "3"',
+                      'thrift==0.16.0',
+                      'thrift_sasl==0.4.3'],
     extras_require={
         "kerberos": ['kerberos>=1.3.0'],
     },


### PR DESCRIPTION
Python 2.7 needs bitarray < 3, but on Python bitarray 3.* can be used. The bitarray functionality used in impyla is minimal and didn't change with the major version bump.