### PR TITLE
Change cur fixture to function level

### DIFF
--- a/impala/tests/conftest.py
+++ b/impala/tests/conftest.py
@@ -109,10 +109,19 @@ def con(host, port, auth_mech, tmp_db):
 
 
 @fixture(scope='session')
+def session_cur(con):
+    # session level cursor usable in session/module level fixtures
+    cur = con.cursor()
+    yield cur
+    cur.close()
+
+
+@fixture(scope='function')
 def cur(con):
     cur = con.cursor()
     yield cur
     cur.close()
+
 
 @fixture(scope='session')
 def cur_no_string_conv(con):

--- a/impala/tests/test_data_types.py
+++ b/impala/tests/test_data_types.py
@@ -20,17 +20,17 @@ from pytest import fixture
 from decimal import Decimal
 
 @fixture(scope='module')
-def decimal_table(cur):
+def decimal_table(session_cur):
     table_name = 'tmp_decimal_table'
     ddl = """CREATE TABLE {0} (
                  f1 decimal(10, 2),
                  f2 decimal(7, 5),
                  f3 decimal(38, 17))""".format(table_name)
-    cur.execute(ddl)
+    session_cur.execute(ddl)
     try:
         yield table_name
     finally:
-        cur.execute("DROP TABLE {0}".format(table_name))
+        session_cur.execute("DROP TABLE {0}".format(table_name))
 
 
 @pytest.mark.connect
@@ -53,11 +53,11 @@ def test_cursor_description_precision_scale(cur, decimal_table):
 
 
 @fixture(scope='module')
-def decimal_table2(cur):
+def decimal_table2(session_cur):
     table_name = 'tmp_decimal_table2'
     ddl = """CREATE TABLE {0} (val decimal(18, 9))""".format(table_name)
-    cur.execute(ddl)
-    cur.execute('''insert into {0}
+    session_cur.execute(ddl)
+    session_cur.execute('''insert into {0}
                    values (cast(123456789.123456789 as decimal(18, 9))),
                           (cast(-123456789.123456789 as decimal(18, 9))),
                           (cast(0.000000001 as decimal(18, 9))),
@@ -68,7 +68,7 @@ def decimal_table2(cur):
     try:
         yield table_name
     finally:
-        cur.execute("DROP TABLE {0}".format(table_name))
+        session_cur.execute("DROP TABLE {0}".format(table_name))
 
 
 def common_test_decimal(cur, decimal_table):
@@ -95,16 +95,16 @@ def test_decimal_no_string_conv(cur_no_string_conv, decimal_table2):
 
 
 @fixture(scope='module')
-def date_table(cur):
+def date_table(session_cur):
     table_name = 'tmp_date_table'
     ddl = """CREATE TABLE {0} (d date)""".format(table_name)
-    cur.execute(ddl)
-    cur.execute('''insert into {0}
+    session_cur.execute(ddl)
+    session_cur.execute('''insert into {0}
                    values (date "0001-01-01"), (date "1999-9-9")'''.format(table_name))
     try:
         yield table_name
     finally:
-        cur.execute("DROP TABLE {0}".format(table_name))
+        session_cur.execute("DROP TABLE {0}".format(table_name))
 
 
 def common_test_date(cur, date_table):
@@ -125,11 +125,11 @@ def test_date_no_string_conv(cur_no_string_conv, date_table):
 
 
 @fixture(scope='module')
-def timestamp_table(cur):
+def timestamp_table(session_cur):
     table_name = 'tmp_timestamp_table'
     ddl = """CREATE TABLE {0} (ts timestamp)""".format(table_name)
-    cur.execute(ddl)
-    cur.execute('''insert into {0}
+    session_cur.execute(ddl)
+    session_cur.execute('''insert into {0}
                    values (cast("1400-01-01 00:00:00" as timestamp)),
                           (cast("2014-06-23 13:30:51" as timestamp)),
                           (cast("2014-06-23 13:30:51.123" as timestamp)),
@@ -139,7 +139,7 @@ def timestamp_table(cur):
     try:
         yield table_name
     finally:
-        cur.execute("DROP TABLE {0}".format(table_name))
+        session_cur.execute("DROP TABLE {0}".format(table_name))
 
 
 def common_test_timestamp(cur, timestamp_table):

--- a/impala/tests/test_hive_dict_cursor.py
+++ b/impala/tests/test_hive_dict_cursor.py
@@ -15,7 +15,7 @@
 from pytest import fixture
 
 
-@fixture(scope='session')
+@fixture(scope='function')
 def cur2(con):
     cur = con.cursor(dictify=True)
     yield cur

--- a/impala/tests/test_impala.py
+++ b/impala/tests/test_impala.py
@@ -20,22 +20,22 @@ from pytest import fixture
 BIGGER_TABLE_NUM_ROWS = 100
 
 @fixture(scope='module')
-def bigger_table(cur):
+def bigger_table(session_cur):
     table_name = 'tmp_bigger_table'
     ddl = """CREATE TABLE {0} (s string)
              STORED AS PARQUET""".format(table_name)
-    cur.execute(ddl)
+    session_cur.execute(ddl)
     dml = """INSERT INTO {0}
              VALUES {1}""".format(table_name,
                  ",".join(["('row{0}')".format(i) for i in xrange(BIGGER_TABLE_NUM_ROWS)]))
     # Disable codegen and expr rewrites so query runs faster.
-    cur.execute("set disable_codegen=1")
-    cur.execute("set enable_expr_rewrites=0")
-    cur.execute(dml)
+    session_cur.execute("set disable_codegen=1")
+    session_cur.execute("set enable_expr_rewrites=0")
+    session_cur.execute(dml)
     try:
         yield table_name
     finally:
-        cur.execute("DROP TABLE {0}".format(table_name))
+        session_cur.execute("DROP TABLE {0}".format(table_name))
 
 
 def test_has_more_rows(cur, bigger_table):

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,13 @@ setenv =
 commands =
     pytest --connect impala/tests {posargs}
 
+[testenv:py3.7]
+deps =
+    pytest>=6,<7
+    sqlalchemy>=1,<2
+    requests
+    pandas
+
 [testenv:py27]
 deps =
     pytest>=4,<5


### PR DESCRIPTION
test_build_summary_table failed based on what other tests ran in the same session due to using the same session level cursor which could have altered query options from other tests. The patch switches to function level cursor to isolate tests and creates new fixture session_cur to use in session/module level fixtures that need a cursor.