### PR TITLE
Prepare release 0.22a1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+0.22a1
+------
+* **Improvements**
+  - Fallback to winkerberos if kerberos is not available (#587)
+  - Update build_summary_table function to match impala-shell (#578)
+  - Unpin bitarray dependency on Python 3 (#588)
+
+* **Bug Fixes**
+  - sqlalchemy 2 related fixes #580, #582
+
 0.21
 ------
 * **Improvements**

--- a/impala/__init__.py
+++ b/impala/__init__.py
@@ -14,4 +14,4 @@
 
 from __future__ import absolute_import
 # setup.py also contains the version - the two should have the same value!
-__version__ = u'v0.21.0'
+__version__ = u'v0.22a1'

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def readme():
 setup(
     name='impyla',
     # impala/__init__.py also contains the version - the two should have the same value!
-    version='v0.21.0',
+    version='v0.22a1',
     description='Python client for the Impala distributed query engine',
     long_description_content_type='text/markdown',
     long_description=readme(),
@@ -54,7 +54,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',


### PR DESCRIPTION
Also removed Python 3.6 (EOL since 2021) from the supported versions. It is still likely to work but testing it is a nuisance.