### PR TITLE
Fix py2.7 validation during build creation

### DIFF
--- a/io/manylinux/build.sh
+++ b/io/manylinux/build.sh
@@ -144,7 +144,10 @@ set_up_virt_env_py27() {
   source impyla_test_env/bin/activate
   set -eu
 
-  LD_LIBRARY_PATH="$py27lib" easy_install -U setuptools
+  # Upgrade to last pip that supports Python 2.7 and newer setuptool
+  # to handle Environment Markers in setup.py.
+  LD_LIBRARY_PATH="$py27lib" pip install pip==20.3
+  LD_LIBRARY_PATH="$py27lib" pip install -U setuptools
 }
 
 sanity_check() {


### PR DESCRIPTION
The validation tried to install impyla in an environment with very old setuptools (18.0.1) that didn't support the environment markers (e.g 'bitarray<3; python_version < "3"') added in #588. Installing fresh setuptools didn't work with with easy_install so moved to using pip in the py2.7 env too.