### PR TITLE
IMPALA-14653: Handle STILL_EXECUTING_STATUS

### DIFF
--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -1041,10 +1041,16 @@ class CBatch(Batch):
                  convert_strings_to_unicode=True):
         self.expect_more_rows = expect_more_rows
         self.schema = schema
-        tcols = [_TTypeId_to_TColumnValue_getters[schema[i][1]](col)
-                 for (i, col) in enumerate(trowset.columns)]
-        num_cols = len(tcols)
-        num_rows = len(tcols[0].values)
+        if trowset:
+            tcols = [_TTypeId_to_TColumnValue_getters[schema[i][1]](col)
+                     for (i, col) in enumerate(trowset.columns)]
+            num_cols = len(tcols)
+            num_rows = len(tcols[0].values)
+        else:
+            # No results returned with STILL_EXECUTING_STATUS
+            tcols = []
+            num_cols = 0
+            num_rows = 0
         self.remaining_rows = num_rows
 
         log.debug('CBatch: input TRowSet num_cols=%s num_rows=%s tcols=%s',
@@ -1144,6 +1150,9 @@ class RBatch(Batch):
         self.expect_more_rows = expect_more_rows
         self.schema = schema
         self.rows = []
+        # Can be None with STILL_EXECUTING_STATUS
+        if not trowset:
+            return
         for trow in trowset.rows:
             row = []
             for (i, col_val) in enumerate(trow.colVals):


### PR DESCRIPTION
If FetchResults is called while the query is still executing, the TFetchResultsResp will not contain a TRowSet. This change allows the client to handle that case without throwing an exception.

Fixes #594.