### PR TITLE
Add HTTP server verification (#362)

### DIFF
--- a/impala/_thrift_api.py
+++ b/impala/_thrift_api.py
@@ -191,14 +191,6 @@ class ImpalaHttpClient(TTransportBase):
       self.__http = http_client.HTTPConnection(self.host, self.port,
                                                timeout=self.__timeout)
     elif self.scheme == 'https':
-      # (#529) From python 3.12 http_client.HTTPSConnection no longer
-      # expects certfile and key_file. Certfile is included in context
-      # while key_file can be used in SSLContext.load_verify_locations.
-      # As Impyla doesn't support server authentication (#362) both
-      # certfile and key_file are expected to be None here.
-      if self.certfile or self.keyfile:
-        raise NotSupportedError("Server authentication is not supported " +
-                                "with HTTP endpoints")
       self.__http = http_client.HTTPSConnection(self.host, self.port,
                                                 timeout=self.__timeout,
                                                 context=self.context)

--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -928,11 +928,6 @@ def connect(host, port, timeout=None, use_ssl=False, ca_cert=None,
         kerberos_host = host
 
     if use_http_transport:
-        # TODO(#362): Add server authentication with thrift 0.12.
-        if ca_cert:
-            raise NotSupportedError("Server authentication is not supported " +
-                                    "with HTTP endpoints")
-
         transport = get_http_transport(
             host, port, http_path=http_path,
             use_ssl=use_ssl, ca_cert=ca_cert,

--- a/impala/tests/test_dbapi_connect.py
+++ b/impala/tests/test_dbapi_connect.py
@@ -14,6 +14,7 @@
 
 from __future__ import absolute_import, print_function
 
+import ssl
 import sys
 import time
 
@@ -47,6 +48,7 @@ JWT_DISABLED_ERROR = "JWT authentication disabled"
 # export IMPALA_SSL_ARGS="--ssl_client_ca_certificate=$IMPALA_SSL_CERT_DIR/server-cert.pem --ssl_server_certificate=$IMPALA_SSL_CERT_DIR/server-cert.pem --ssl_private_key=$IMPALA_SSL_CERT_DIR/server-key.pem --hostname=localhost"
 # bin/start-impala-cluster.py --impalad_args="$IMPALA_SSL_ARGS" --catalogd_args="$IMPALA_SSL_ARGS" --state_store_args="$IMPALA_SSL_ARGS"
 # export IMPYLA_SSL_CERT=$IMPALA_SSL_CERT_DIR/server-cert.pem
+# export IMPYLA_SSL_WRONG_CERT=$IMPALA_SSL_CERT_DIR/incorrect-commonname-cert.pem
 SSL_DISABLED = ENV.ssl_cert == ""
 SSL_DISABLED_ERROR = "No ssl certificate set."
 
@@ -251,10 +253,38 @@ class ImpalaConnectionTests(unittest.TestCase):
         self._execute_queries(self.connection)
 
     @pytest.mark.skipif(SSL_DISABLED, reason=SSL_DISABLED_ERROR)
-    def test_https_connection(self):
+    def test_ssl_connection_wrong_cert(self):
+        try:
+            connect(
+                ENV.host, ENV.port, use_ssl=True, timeout=TIMEOUT_S, ca_cert=ENV.ssl_wrong_cert)
+            assert False, "'connect' method should have thrown an exception but did not"
+        except TTransportException as e:
+            # The message is not too informative, verification error is swallowed by thrift.
+            assert "Could not connect to any of" in str(e)
+
+    @pytest.mark.skipif(SSL_DISABLED, reason=SSL_DISABLED_ERROR)
+    def test_https_connection_nocert(self):
         self.connection = connect(ENV.host, ENV.http_port, use_http_transport=True,
                                   http_path="cliservice", use_ssl=True, timeout=TIMEOUT_S)
         self._execute_queries(self.connection)
+
+    @pytest.mark.skipif(SSL_DISABLED, reason=SSL_DISABLED_ERROR)
+    def test_https_connection_with_cert(self):
+        self.connection = connect(ENV.host, ENV.http_port, use_http_transport=True,
+                                  http_path="cliservice", use_ssl=True, timeout=TIMEOUT_S,
+                                  ca_cert=ENV.ssl_cert)
+        self._execute_queries(self.connection)
+
+    @pytest.mark.skipif(SSL_DISABLED, reason=SSL_DISABLED_ERROR)
+    def test_https_connection_wrong_cert(self):
+        try:
+            connection = connect(ENV.host, ENV.http_port, use_http_transport=True,
+                                 http_path="cliservice", use_ssl=True, timeout=TIMEOUT_S,
+                                 ca_cert=ENV.ssl_wrong_cert)
+            connection.cursor()
+            assert False, "'cursor' method should have thrown an exception but did not"
+        except ssl.SSLCertVerificationError as e:
+            assert "CERTIFICATE_VERIFY_FAILED" in str(e)
 
     def test_retry_dml(self):
         """Regression test for #549.

--- a/impala/tests/util.py
+++ b/impala/tests/util.py
@@ -76,6 +76,7 @@ class ImpylaTestEnv(object):
                                          'NOSASL')
 
         self.ssl_cert = get_env_var('IMPYLA_SSL_CERT', identity, "")
+        self.ssl_wrong_cert = get_env_var('IMPYLA_SSL_WRONG_CERT', identity, "")
 
     def __repr__(self):
         kvs = ['{0}={1}'.format(k, v)


### PR DESCRIPTION
Simply removed the checks against passing ca_cart when using hs2-http.

Testing:
- added test_https_connection_with_cert
- manually tested that an incorrect certificate is verified and rejected (Impala's incorrect-commonname-cert.pem)
- tested with Python3.9 - 3.12