### PR TITLE
Allow verifying server using default CA certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,16 @@ df = as_pandas(cur)
 # carry df through scikit-learn, for example
 ```
 
+For secure connection set use_ssl=True in connect(). Warning: this doesn't verify the server
+by default! To verify server set verify_cert or ca_cart perameter:
+
+```python
+# Verify server using system CA certificates:
+conn = connect(host='my.host.com', use_ssl=True, verify_cert=True)
+
+# Verify server using custom CA certificate:
+conn = connect(host='my.host.com', use_ssl=True, ca_cart="/tmp/my_cert.pem")
+```
 
 [pep249]: http://legacy.python.org/dev/peps/pep-0249/
 [pandas]: http://pandas.pydata.org/

--- a/impala/_thrift_api.py
+++ b/impala/_thrift_api.py
@@ -382,10 +382,10 @@ class ImpalaHttpClient(TTransportBase):
       raise HttpError(self.code, self.message, body, self.headers)
 
 
-def get_socket(host, port, use_ssl, ca_cert):
+def get_socket(host, port, use_ssl, ca_cert, verify_cert):
     # based on the Impala shell impl
-    log.debug('get_socket: host=%s port=%s use_ssl=%s ca_cert=%s',
-              host, port, use_ssl, ca_cert)
+    log.debug('get_socket: host=%s port=%s use_ssl=%s ca_cert=%s verify_cert=%s',
+              host, port, use_ssl, ca_cert, verify_cert)
 
     if use_ssl:
         from thrift.transport.TSSLSocket import TSSLSocket
@@ -397,10 +397,11 @@ def get_socket(host, port, use_ssl, ca_cert):
           def isOpen(self):
             return self.handle is not None
 
-        if ca_cert is None:
-            return ImpalaTSSLSocket(host, port, validate=False)
-        else:
+        if ca_cert:
             return ImpalaTSSLSocket(host, port, validate=True, ca_certs=ca_cert)
+        else:
+            return ImpalaTSSLSocket(host, port, validate=verify_cert)
+
     else:
         return TSocket(host, port)
 
@@ -409,14 +410,15 @@ def get_http_transport(host, port, http_path, timeout=None, use_ssl=False,
                        ca_cert=None, auth_mechanism='NOSASL', user=None,
                        password=None, kerberos_host=None, kerberos_service_name=None,
                        http_cookie_names=None, jwt=None, user_agent=None,
-                       get_user_custom_headers_func=None):
+                       get_user_custom_headers_func=None, verify_cert=False):
     host_url = "[%s]" % host if ":" in host else host # add brackets for ipv6 address
     # TODO: support timeout
     if timeout is not None:
         log.error('get_http_transport does not support a timeout')
     if use_ssl:
         ssl_ctx = ssl.create_default_context(cafile=ca_cert)
-        if ca_cert:
+        if ca_cert or verify_cert:
+          ssl_ctx.check_hostname = True
           ssl_ctx.verify_mode = ssl.CERT_REQUIRED
         else:
           ssl_ctx.check_hostname = False  # Mandated by the SSL lib for CERT_NONE mode.

--- a/impala/dbapi.py
+++ b/impala/dbapi.py
@@ -45,7 +45,7 @@ def connect(host='localhost', port=21050, database=None, timeout=None,
             protocol=None, krb_host=None, use_http_transport=False,
             http_path='', auth_cookie_names=None, http_cookie_names=None,
             retries=3, jwt=None, user_agent=None,
-            get_user_custom_headers_func=None):
+            get_user_custom_headers_func=None, verify_cert=False):
     """Get a connection to HiveServer2 (HS2).
 
     These options are largely compatible with the impala-shell command line
@@ -66,9 +66,9 @@ def connect(host='localhost', port=21050, database=None, timeout=None,
     use_ssl : bool, optional
         Enable SSL.
     ca_cert : str, optional
-        Local path to the the third-party CA certificate. If SSL is enabled but
-        the certificate is not specified, the server certificate will not be
-        validated.
+        Local path to the the third-party CA certificate. If set, the server certificate
+        will be verified using the provided CA cert. If SSL is enabled but
+        the certificate is not specified, see 'verify_cert' for behavior.
     auth_mechanism : {'NOSASL', 'PLAIN', 'GSSAPI', 'LDAP', 'JWT'}
         Specify the authentication mechanism. `'NOSASL'` for unsecured Impala.
         `'PLAIN'` for unsecured Hive (because Hive requires the SASL
@@ -110,6 +110,10 @@ def connect(host='localhost', port=21050, database=None, timeout=None,
         Used to add custom headers to the http messages when using hs2-http protocol.
         This is a function returning a list of tuples, each tuple contains a key-value
         pair. This allows duplicate headers to be set.
+    verify_cert : bool, optional
+        Whether to verify the server's TLS certificate when using SSL using the systems's
+        CA certificates. Ignored if 'ca_cert' is provided, in which case the certificate
+        will be verified using the provided CA cert.
 
         .. deprecated:: 0.18.0
     auth_cookie_names : list of str or str, optional
@@ -209,7 +213,8 @@ def connect(host='localhost', port=21050, database=None, timeout=None,
                           http_cookie_names=http_cookie_names,
                           retries=retries,
                           jwt=jwt, user_agent=user_agent,
-                          get_user_custom_headers_func=get_user_custom_headers_func)
+                          get_user_custom_headers_func=get_user_custom_headers_func,
+                          verify_cert=verify_cert)
     return hs2.HiveServer2Connection(service, default_db=database)
 
 

--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -918,7 +918,7 @@ def connect(host, port, timeout=None, use_ssl=False, ca_cert=None,
             user=None, password=None, kerberos_service_name='impala',
             auth_mechanism=None, krb_host=None, use_http_transport=False,
             http_path='', http_cookie_names=None, retries=3, jwt=None,
-            user_agent=None, get_user_custom_headers_func=None):
+            user_agent=None, get_user_custom_headers_func=None, verify_cert=False):
     log.debug('Connecting to HiveServer2 %s:%s with %s authentication '
               'mechanism', host, port, auth_mechanism)
 
@@ -937,9 +937,10 @@ def connect(host, port, timeout=None, use_ssl=False, ca_cert=None,
             kerberos_service_name=kerberos_service_name,
             http_cookie_names=http_cookie_names,
             jwt=jwt, user_agent=user_agent,
-            get_user_custom_headers_func=get_user_custom_headers_func)
+            get_user_custom_headers_func=get_user_custom_headers_func,
+            verify_cert=verify_cert)
     else:
-        sock = get_socket(host, port, use_ssl, ca_cert)
+        sock = get_socket(host, port, use_ssl, ca_cert, verify_cert)
 
         if timeout is not None:
             timeout = timeout * 1000.  # TSocket expects millis

--- a/impala/tests/test_dbapi_connect.py
+++ b/impala/tests/test_dbapi_connect.py
@@ -263,6 +263,20 @@ class ImpalaConnectionTests(unittest.TestCase):
             assert "Could not connect to any of" in str(e)
 
     @pytest.mark.skipif(SSL_DISABLED, reason=SSL_DISABLED_ERROR)
+    def test_ssl_connection_default_certs(self):
+        try:
+            # With verify_cert=True, the system's CA certificates will be used to verify
+            # the server certificate. Since the server certificate is self-signed and not
+            # in the system CA store, verification should fail.
+            # TODO: writing positive test would be nice but is more difficult
+            connect(
+                ENV.host, ENV.port, use_ssl=True, timeout=TIMEOUT_S, verify_cert=True)
+            assert False, "'connect' method should have thrown an exception but did not"
+        except TTransportException as e:
+            # The message is not too informative, verification error is swallowed by thrift.
+            assert "Could not connect to any of" in str(e)
+
+    @pytest.mark.skipif(SSL_DISABLED, reason=SSL_DISABLED_ERROR)
     def test_https_connection_nocert(self):
         self.connection = connect(ENV.host, ENV.http_port, use_http_transport=True,
                                   http_path="cliservice", use_ssl=True, timeout=TIMEOUT_S)
@@ -281,6 +295,22 @@ class ImpalaConnectionTests(unittest.TestCase):
             connection = connect(ENV.host, ENV.http_port, use_http_transport=True,
                                  http_path="cliservice", use_ssl=True, timeout=TIMEOUT_S,
                                  ca_cert=ENV.ssl_wrong_cert)
+            connection.cursor()
+            assert False, "'cursor' method should have thrown an exception but did not"
+        except Exception as e:
+            # TODO: replace with ssl.SSLCertVerificationError when dropping Python 2.7
+            assert "CERTIFICATE_VERIFY_FAILED" in str(e)
+
+    @pytest.mark.skipif(SSL_DISABLED, reason=SSL_DISABLED_ERROR)
+    def test_https_connection_default_certs(self):
+        try:
+            # With verify_cert=True, the system's CA certificates will be used to verify
+            # the server certificate. Since the server certificate is self-signed and not
+            # in the system CA store, verification should fail.
+            # TODO: writing positive test would be nice but is more difficult
+            connection = connect(ENV.host, ENV.http_port, use_http_transport=True,
+                                 http_path="cliservice", use_ssl=True, timeout=TIMEOUT_S,
+                                 verify_cert=True)
             connection.cursor()
             assert False, "'cursor' method should have thrown an exception but did not"
         except Exception as e:


### PR DESCRIPTION
Add verify_cert arg to connect() to verify the server when use_ssl=True but ca_cart is not. In this case if verify_cert=True then Python will validate the server using default CA certs.

For details of default CA handling in Python see:
https://docs.python.org/3/library/ssl.html

Testing:
- added negative tests for connecting to Impala with self signed cert
- no positive tests - these would need a proper certificate or forcing Python to accept a self-signed certificate