### PR TITLE
Add direct dependency to pure-sasl (#471)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "bitarray",
     "thrift==0.16.0",
     "thrift_sasl==0.4.3",
+    "pure-sasl>=0.6.2",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
impyla uses pure-sasl directly but it was not mentioned in setup.py. Installs still worked due to inderectly depending on it through thrift_sasl. Added the same dependency as the one in thrift_sasl.