### PR TITLE
Bump Thrift to 0.23 + fix verify_cert with hs2 (#604)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Required:
 
 * `bitarray`
 
-* `thrift==0.16.0`
+* `thrift>=0.23.0`
 
 * `thrift_sasl==0.4.3`
 

--- a/impala/_thrift_api.py
+++ b/impala/_thrift_api.py
@@ -381,6 +381,16 @@ class ImpalaHttpClient(TTransportBase):
       raise HttpError(self.code, self.message, body, self.headers)
 
 
+def get_ssl_context(ca_cert, verify_cert):
+    ssl_ctx = ssl.create_default_context(cafile=ca_cert)
+    if ca_cert or verify_cert:
+        ssl_ctx.check_hostname = True
+        ssl_ctx.verify_mode = ssl.CERT_REQUIRED
+    else:
+        ssl_ctx.check_hostname = False  # Mandated by the SSL lib for CERT_NONE mode.
+        ssl_ctx.verify_mode = ssl.CERT_NONE
+    return ssl_ctx
+
 def get_socket(host, port, use_ssl, ca_cert, verify_cert):
     # based on the Impala shell impl
     log.debug('get_socket: host=%s port=%s use_ssl=%s ca_cert=%s verify_cert=%s',
@@ -388,19 +398,8 @@ def get_socket(host, port, use_ssl, ca_cert, verify_cert):
 
     if use_ssl:
         from thrift.transport.TSSLSocket import TSSLSocket
-
-        # This copies the solution in IMPALA-11343.
-        # TODO: remove once Thrit 0.17.0 is released
-        class ImpalaTSSLSocket(TSSLSocket):
-          # THRIFT-5595: override TSocket.isOpen because it's broken for TSSLSocket
-          def isOpen(self):
-            return self.handle is not None
-
-        if ca_cert:
-            return ImpalaTSSLSocket(host, port, validate=True, ca_certs=ca_cert)
-        else:
-            return ImpalaTSSLSocket(host, port, validate=verify_cert)
-
+        ssl_ctx = get_ssl_context(ca_cert, verify_cert)
+        return TSSLSocket(host, port, ssl_context=ssl_ctx)
     else:
         return TSocket(host, port)
 
@@ -415,13 +414,7 @@ def get_http_transport(host, port, http_path, timeout=None, use_ssl=False,
     if timeout is not None:
         log.error('get_http_transport does not support a timeout')
     if use_ssl:
-        ssl_ctx = ssl.create_default_context(cafile=ca_cert)
-        if ca_cert or verify_cert:
-          ssl_ctx.check_hostname = True
-          ssl_ctx.verify_mode = ssl.CERT_REQUIRED
-        else:
-          ssl_ctx.check_hostname = False  # Mandated by the SSL lib for CERT_NONE mode.
-          ssl_ctx.verify_mode = ssl.CERT_NONE
+        ssl_ctx = get_ssl_context(ca_cert, verify_cert)
 
         url = 'https://%s:%s/%s' % (host_url, port, http_path)
         log.debug('get_http_transport url=%s', url)

--- a/impala/tests/test_dbapi_connect.py
+++ b/impala/tests/test_dbapi_connect.py
@@ -62,19 +62,11 @@ class ImpalaConnectionTests(unittest.TestCase):
             self.connection.close()
 
     def _execute_queries(self, con):
-        ddl = """
-            CREATE TABLE {0} (
-              f1 INT,
-              f2 INT)
-        """.format(self.tablename)
-        try:
-            cur = con.cursor()
-            cur.execute(ddl)
-            con.commit()
-            cur.execute('DROP TABLE {0}'.format(self.tablename))
-            con.commit()
-        except:
-            raise
+        cur = con.cursor()
+        cur.execute("SELECT 1 + 1")
+        assert cur.fetchall() == [(2,)]
+        cur.execute("SELECT 2 + 2")
+        assert cur.fetchall() == [(4,)]
 
     def _execute_query_get_username(self, con):
         query = "select user()"
@@ -254,7 +246,7 @@ class ImpalaConnectionTests(unittest.TestCase):
             assert False, "'connect' method should have thrown an exception but did not"
         except TTransportException as e:
             # The message is not too informative, verification error is swallowed by thrift.
-            assert "Could not connect to any of" in str(e)
+            assert "CERTIFICATE_VERIFY_FAILED" in str(e.inner)
 
     @pytest.mark.skipif(SSL_DISABLED, reason=SSL_DISABLED_ERROR)
     def test_ssl_connection_default_certs(self):
@@ -268,7 +260,7 @@ class ImpalaConnectionTests(unittest.TestCase):
             assert False, "'connect' method should have thrown an exception but did not"
         except TTransportException as e:
             # The message is not too informative, verification error is swallowed by thrift.
-            assert "Could not connect to any of" in str(e)
+            assert "CERTIFICATE_VERIFY_FAILED" in str(e.inner)
 
     @pytest.mark.skipif(SSL_DISABLED, reason=SSL_DISABLED_ERROR)
     def test_https_connection_nocert(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 ]
 dependencies = [
     "bitarray",
-    "thrift==0.16.0",
+    "thrift>=0.23.0",
     "thrift_sasl==0.4.3",
     "pure-sasl>=0.6.2",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -13,5 +13,8 @@ deps =
 setenv =
     IMPYLA_TEST_HIVE_PORT = 11050
     IMPYLA_TEST_HIVE_USER = hive
+pass_env =
+    IMPYLA_SSL_CERT
+    IMPYLA_SSL_WRONG_CERT
 commands =
     pytest --connect impala/tests {posargs}


### PR DESCRIPTION
THRIFT-792 added inner exception to TSocket.open(). This revealed that test_ssl_connection_default_certs failed for a different reason than I assumed - instead of failing to verify it rejects to verify when ca_cert=None. To actually verify with default certs TSSLSocket's constructor needs to be called with ssl context.
Note that having positive tests would also have catched this earlier.

Thrift version is constrained to >= 0.23 instead of pinning it. Generated py files (created with Thrift 0.16) are not updated.

Also changed ImpalaConnectionTests's _execute_queries to do simple SELECT queries instead of CREATE+DROP table as some tests were flaky.